### PR TITLE
docs: Add GitHub community standards and templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug Report
+about: Report a bug to help us improve
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Description
+
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## Expected Behavior
+
+A clear description of what you expected to happen.
+
+## Actual Behavior
+
+A clear description of what actually happened.
+
+## Screenshots
+
+If applicable, add screenshots to help explain your problem.
+
+## Environment
+
+- OS: [e.g., Windows 11, macOS 14, Ubuntu 22.04]
+- Browser: [e.g., Chrome 120, Firefox 121]
+- Python Version: [e.g., 3.11]
+
+## Additional Context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## Problem Statement
+
+A clear and concise description of the problem or limitation you're experiencing.
+
+## Proposed Solution
+
+Describe the solution you'd like to see implemented.
+
+## Alternatives Considered
+
+Describe any alternative solutions or features you've considered.
+
+## Additional Context
+
+Add any other context, mockups, or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+## Description
+
+Brief description of the changes in this PR.
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update
+
+## Related Issue
+
+Fixes #(issue number)
+
+## Checklist
+
+- [ ] My code follows the project's style guidelines
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code where necessary
+- [ ] I have updated the documentation if needed
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix/feature works
+- [ ] New and existing tests pass locally
+
+## Screenshots (if applicable)
+
+Add screenshots to demonstrate visual changes.
+
+## Additional Notes
+
+Any additional information reviewers should know.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,108 @@
+# Contributing to Checkora
+
+Thank you for considering contributing to Checkora! We welcome contributions from the community.
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork locally
+3. Set up the development environment
+4. Create a new branch for your changes
+
+## Development Setup
+
+```bash
+# Clone the repository
+git clone https://github.com/your-username/checkora.git
+cd checkora
+
+# Create a virtual environment
+python -m venv venv
+source venv/bin/activate  # On Windows: venv\Scripts\activate
+
+# Install dependencies
+pip install -r requirements.txt
+
+# Run migrations
+python manage.py migrate
+
+# Start the development server
+python manage.py runserver
+```
+
+## Branch Naming Convention
+
+Use the following prefixes for your branches:
+
+- `feat/` - New features
+- `fix/` - Bug fixes
+- `docs/` - Documentation changes
+- `refactor/` - Code refactoring
+- `test/` - Adding or updating tests
+- `chore/` - Maintenance tasks
+
+Example: `feat/add-user-authentication`
+
+## Commit Message Format
+
+```
+<scope>: <short clear action in present tense>.
+```
+
+### Rules
+
+- **Scope** should be a module or feature name (e.g., `game`, `api`, `ui`, `templates`, `core`)
+- Use concise but descriptive language
+- Start action with a capital letter (Fix, Add, Rename, Update, Remove, Highlight, Forbid, Focus, Improve)
+- No emojis
+- No extra explanation
+- One sentence only
+- End with a period
+- Keep it under 80 characters
+
+### Examples
+
+```
+game: Add move validation for checkers pieces.
+api: Fix permissions querying for game sessions.
+templates: Update board layout for better responsiveness.
+core: Remove deprecated settings configuration.
+```
+
+## Pull Request Guidelines
+
+1. **One PR = One Purpose**
+   - Fix one bug, OR
+   - Add one feature, OR
+   - Improve documentation
+
+2. Keep PRs focused and small
+3. Update documentation if needed
+4. Add tests for new features
+5. Ensure all tests pass before submitting
+
+## Code Style
+
+- Follow PEP 8 for Python code
+- Use meaningful variable and function names
+- Add docstrings to functions and classes
+- Keep functions focused and concise
+
+## Reporting Issues
+
+When reporting issues, please include:
+
+- A clear description of the problem
+- Steps to reproduce
+- Expected vs actual behavior
+- Your environment (OS, Python version, etc.)
+
+## Code of Conduct
+
+Please be respectful and considerate in all interactions. We are committed to providing a welcoming and inclusive environment for everyone.
+
+## Questions?
+
+If you have questions, feel free to open an issue for discussion.
+
+Thank you for contributing! 🎮

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Checkora
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Description

Adds essential GitHub community standards files to make the project more contributor-friendly.

## Type of Change

- [x] Documentation update

## Changes

- Add MIT License
- Add CONTRIBUTING.md with guidelines for:
  - Development setup
  - Branch naming conventions
  - Commit message format
  - Pull request guidelines
- Add GitHub issue templates:
  - Bug report template
  - Feature request template
- Add Pull Request template