### PR TITLE
game: Add pawn promotion when piece reaches last row.

### DIFF
--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -353,6 +353,65 @@
         .clock.white .label { color: #ddd; }
         .clock.black .label { color: #aaa; }
 
+        /* ================= PROMOTION MODAL ================= */
+
+        .promo-overlay {
+            display: none;
+            position: fixed;
+            inset: 0;
+            background: rgba(0, 0, 0, 0.7);
+            z-index: 100;
+            justify-content: center;
+            align-items: center;
+        }
+        .promo-overlay.active { display: flex; }
+
+        .promo-dialog {
+            background: #1a1a30;
+            border: 2px solid #f0c040;
+            border-radius: 12px;
+            padding: 24px 28px;
+            text-align: center;
+            box-shadow: 0 12px 48px rgba(0, 0, 0, 0.8);
+        }
+
+        .promo-title {
+            font-size: 1rem;
+            font-weight: 700;
+            color: #f0c040;
+            margin-bottom: 16px;
+            letter-spacing: 1px;
+            text-transform: uppercase;
+        }
+
+        .promo-pieces {
+            display: flex;
+            gap: 12px;
+            justify-content: center;
+        }
+
+        .promo-btn {
+            width: 64px;
+            height: 64px;
+            border: 2px solid #333;
+            border-radius: 8px;
+            background: #252545;
+            cursor: pointer;
+            padding: 6px;
+            transition: all 0.2s ease;
+        }
+        .promo-btn:hover {
+            border-color: #f0c040;
+            background: #2a2a55;
+            transform: scale(1.08);
+            box-shadow: 0 0 12px rgba(240, 192, 64, 0.3);
+        }
+        .promo-btn img {
+            width: 100%;
+            height: 100%;
+            pointer-events: none;
+        }
+
     </style>
 </head>
 <body>
@@ -423,6 +482,14 @@
 
     </div>
 
+    <!-- ========== PROMOTION MODAL ========== -->
+    <div class="promo-overlay" id="promoOverlay">
+        <div class="promo-dialog">
+            <div class="promo-title">Promote Pawn</div>
+            <div class="promo-pieces" id="promoChoices"></div>
+        </div>
+    </div>
+
     <!-- ========================================================
          JAVASCRIPT
          ======================================================== -->
@@ -453,6 +520,7 @@
         let whiteTime = 0;
         let blackTime = 0;
         let timerInterval = null;
+        let pendingPromo = null;  // { fr, fc, tr, tc } awaiting promotion choice
 
         /* ==============================================================
            DOM references
@@ -464,6 +532,8 @@
         const wCapEl    = document.getElementById('whiteCaptured');
         const bCapEl    = document.getElementById('blackCaptured');
         const newGameEl = document.getElementById('newGameBtn');
+        const promoOverlay = document.getElementById('promoOverlay');
+        const promoChoices = document.getElementById('promoChoices');
 
         /* ==============================================================
            CSRF
@@ -607,15 +677,71 @@
         }
 
         /* ==============================================================
+           Promotion modal helpers
+           ============================================================== */
+        function isPromotionMove(fr, fc, tr) {
+            const p = board[fr][fc];
+            if (!p) return false;
+            return (p === 'P' && tr === 0) || (p === 'p' && tr === 7);
+        }
+
+        function showPromoModal(color) {
+            const prefix = color === 'white' ? 'w' : 'b';
+            const pieces = [
+                { key: 'q', label: 'Queen' },
+                { key: 'r', label: 'Rook' },
+                { key: 'b', label: 'Bishop' },
+                { key: 'n', label: 'Knight' },
+            ];
+            promoChoices.innerHTML = '';
+            pieces.forEach(({ key }) => {
+                const btn = document.createElement('button');
+                btn.className = 'promo-btn';
+                const img = document.createElement('img');
+                img.src = PIECE_IMG[prefix + key];
+                btn.appendChild(img);
+                btn.addEventListener('click', () => onPromoChoice(key));
+                promoChoices.appendChild(btn);
+            });
+            promoOverlay.classList.add('active');
+        }
+
+        function hidePromoModal() {
+            promoOverlay.classList.remove('active');
+            pendingPromo = null;
+        }
+
+        async function onPromoChoice(choice) {
+            if (!pendingPromo) return;
+            const { fr, fc, tr, tc } = pendingPromo;
+            hidePromoModal();
+            await executeMove(fr, fc, tr, tc, choice);
+        }
+
+        /* ==============================================================
            Move execution
            ============================================================== */
         async function tryMove(fr, fc, tr, tc) {
             clearStatus();
+            if (isPromotionMove(fr, fc, tr)) {
+                pendingPromo = { fr, fc, tr, tc };
+                const color = pColor(board[fr][fc]);
+                showPromoModal(color);
+                return;
+            }
+            await executeMove(fr, fc, tr, tc, null);
+        }
+
+        async function executeMove(fr, fc, tr, tc, promotionPiece) {
+            clearStatus();
             try {
-                const data = await post('/api/move/', {
+                const body = {
                     from_row: fr, from_col: fc,
                     to_row: tr, to_col: tc,
-                });
+                };
+                if (promotionPiece) body.promotion_piece = promotionPiece;
+
+                const data = await post('/api/move/', body);
                 if (data.valid) {
                     board = data.board;
                     turn  = data.current_turn;

--- a/game/urls.py
+++ b/game/urls.py
@@ -6,5 +6,6 @@ urlpatterns = [
     path('api/move/', views.make_move, name='make_move'),
     path('api/valid-moves/', views.valid_moves, name='valid_moves'),
     path('api/new-game/', views.new_game, name='new_game'),
+    path('api/check-promotion/', views.check_promotion, name='check_promotion'),
     path('api/state/', views.get_state, name='get_state'),
 ]

--- a/game/views.py
+++ b/game/views.py
@@ -28,6 +28,7 @@ def make_move(request):
         from_col = int(data['from_col'])
         to_row = int(data['to_row'])
         to_col = int(data['to_col'])
+        promotion_piece = data.get('promotion_piece', None)
     except (json.JSONDecodeError, KeyError, ValueError, TypeError):
         return JsonResponse(
             {'valid': False, 'message': 'Invalid request data.'},
@@ -38,7 +39,7 @@ def make_move(request):
     game = ChessGame.from_dict(game_data) if game_data else ChessGame()
 
     success, message, captured = game.make_move(
-        from_row, from_col, to_row, to_col,
+        from_row, from_col, to_row, to_col, promotion_piece,
     )
 
     if success:
@@ -88,6 +89,26 @@ def new_game(request):
         'move_history': [],
         'captured_pieces': {'white': [], 'black': []},
     })
+
+@require_GET
+def check_promotion(request):
+    """Return whether a planned move triggers pawn promotion."""
+    try:
+        from_row = int(request.GET['from_row'])
+        from_col = int(request.GET['from_col'])
+        to_row = int(request.GET['to_row'])
+    except (KeyError, ValueError, TypeError):
+        return JsonResponse({'is_promotion': False})
+
+    game_data = request.session.get('game')
+    if not game_data:
+        return JsonResponse({'is_promotion': False})
+
+    is_promo = ChessGame.is_promotion_move(
+        game_data['board'], from_row, from_col, to_row,
+    )
+    return JsonResponse({'is_promotion': is_promo})
+
 
 @require_GET
 def get_state(request):


### PR DESCRIPTION
## Description

Add pawn promotion logic so that when a pawn reaches the opponent's back rank, the player is prompted to choose a promotion piece (Queen, Rook, Bishop, or Knight).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #22 

## Changes

### C++ Engine (`game/engine/main.cpp`)
- Add `isPromotionMove()` to detect pawn reaching promotion rank
- Add `resolvePromotion()` to resolve chosen piece with color preservation
- Add `serializeBoard()` to return board state as 64-char string
- Extend `MOVES` protocol to include `is_promotion` flag (4 fields per move)
- Add `PROMOTE` command: validates move, verifies promotion square, applies promotion, returns new board

### Python Engine (`game/engine.py`)
- Update `make_move()` to call C++ `PROMOTE` command with Python fallback
- Update `_get_engine_moves()` to parse new 4-field `MOVES` output
- Add `_call_engine_promote()` and `_parse_board64()` helpers
- Add `_is_promotion()`, `_promote()`, and `is_promotion_move()` static methods

### Views & Routes (`game/views.py`, `game/urls.py`)
- Accept `promotion_piece` parameter in `make_move` view
- Add `/api/check-promotion/` endpoint

### Frontend (`game/templates/game/board.html`)
- Add promotion modal overlay with Queen, Rook, Bishop, Knight selection
- Detect promotion moves client-side before sending to API
- Send `promotion_piece` in move request payload

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Testing

Verified C++ engine manually: