### PR TITLE
ui: Fix pawn promotion modal being overridden by duplicate function.

### DIFF
--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -680,6 +680,7 @@
         function isPromotionMove(fr, fc, tr) {
             const p = board[fr][fc];
             if (!p) return false;
+            // White pawn ('P') rank 0 par, ya Black pawn ('p') rank 7 par
             return (p === 'P' && tr === 0) || (p === 'p' && tr === 7);
         }
 
@@ -698,7 +699,10 @@
                 const img = document.createElement('img');
                 img.src = PIECE_IMG[prefix + key];
                 btn.appendChild(img);
-                btn.addEventListener('click', () => onPromoChoice(key));
+                
+                // Click karne par promotion choice bhejo
+                btn.onclick = () => onPromoChoice(key);
+                
                 promoChoices.appendChild(btn);
             });
             promoOverlay.classList.add('active');
@@ -775,38 +779,7 @@
                 statusEl.className = 'status-bar error';
             }
         }
-        async function tryMove(fr,fc,tr,tc) {
-            if (paused) return;
-            
-            const piece = board[fr][fc];
-            if (!piece || pColor(piece) !== turn) {
-                return;
-            }
-
-            const data = await post('/api/move/', {
-                from_row: fr, from_col: fc,
-                to_row: tr, to_col: tc
-            });
-
-            if (!data.valid) {
-                showStatus(data.message, true);
-                deselect();
-                return;
-            }
-
-            board = data.board;
-            turn = data.current_turn;
-            lastMove = {from:[fr,fc], to:[tr,tc]};
-
-            selected = null;
-            hints = []
-
-            syncPieces();
-            updateTurn();
-            updateMoves(data.move_history);
-            updateCaptured(data.captured_pieces);
-            startTimer();
-        }
+        
 
         /* ==========================================================
         EVENTS


### PR DESCRIPTION
## Description

Fixed a critical bug in the frontend where the pawn promotion modal was not triggering. A duplicate `tryMove` function was overriding the correct logic and auto-promoting pawns to Queens without user input. Removed the duplicate code, restored the modal popup, and ensured the timer syncs correctly after a promotion move is executed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings