### PR TITLE
ui: Add welcome screen and refactor game mode selection.

### DIFF
--- a/game/engine.py
+++ b/game/engine.py
@@ -46,6 +46,7 @@ class ChessGame:
         self.black_time = 10 * 60
         self.last_ts = time.time()
         self.paused = False
+        self.mode = 'pvp'  # NAYA: Default mode 'pvp' (Player vs Player) hai
 
     def serialize_board(self):
         """Flatten the 2-D board into a 64-char string for the C++ engine."""
@@ -63,7 +64,8 @@ class ChessGame:
             'white_time': self.white_time,
             'black_time': self.black_time,
             'last_ts': self.last_ts,
-            'paused': self.paused
+            'paused': self.paused,
+            'mode': self.mode  # NAYA
         }
 
     @classmethod
@@ -78,6 +80,7 @@ class ChessGame:
         game.white_time = data['white_time']
         game.black_time = data['black_time']
         game.last_ts = data['last_ts']
+        game.mode = data.get('mode', 'pvp')  # NAYA
 
         cache_data = data.get('valid_moves_cache', {})
         game.valid_moves_cache = {}

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -416,9 +416,24 @@
 </head>
 <body>
 
+    <!-- ========== WELCOME MESSAGE ========== -->
+
+    <div class="promo-overlay active" id="welcomeOverlay" style="background: #0f0f1a; z-index: 9999;">
+        <div class="promo-dialog" style="min-width: 320px; padding: 35px;">
+            <div class="promo-title" style="font-size: 1.6rem; color: #fff; margin-bottom: 10px;">Checkora</div>
+            <p style="color: #aaa; margin-bottom: 30px; font-size: 0.95rem;">Select a game mode to start playing.</p>
+            
+            <div style="display: flex; flex-direction: column; gap: 14px;">
+                <button class="btn btn-gold" id="welcomePvPBtn" style="padding: 12px; font-size: 1.05rem;">Pass & Play (PvP)</button>
+                <button class="btn btn-gold" id="welcomeAIBtn" style="padding: 12px; font-size: 1.05rem;">Play vs AI</button>
+                <button class="btn" id="welcomeResumeBtn" style="padding: 12px; font-size: 1.05rem; background: #333; color: #fff; display: none;">Resume Game</button>
+            </div>
+        </div>
+    </div>
+
     <!-- ========== HEADER ========== -->
     <div class="header">
-        <h1>Checkora <span class="badge">BETA</span></h1>
+        <h1>Checkora <span class="badge" id="modeBadge">PVP</span></h1>
     </div>
 
     <!-- ========== GAME ========== -->
@@ -474,14 +489,33 @@
         <!-- Right Panel -->
         <div class="panel">
             <div class="card">
+                <div class="card-title">Game Controls</div>
+                <div style="display: flex; flex-direction: column; gap: 8px;">
+                    <button class="btn btn-gold" id="newPvPBtn">Pass & Play (PvP)</button>
+                    <button class="btn btn-gold" id="newAIBtn">Play vs AI</button>
+                </div>
+            </div>
+            <div class="card">
                 <div class="card-title">Move History</div>
                 <div class="moves-list" id="movesList">
                     <span class="placeholder">No moves yet</span>
                 </div>
             </div>
-            <button class="btn btn-gold" id="newGameBtn">New Game</button>
         </div>
 
+    </div>
+
+    <div class="promo-overlay" id="confirmOverlay">
+        <div class="promo-dialog">
+            <div class="promo-title" style="color: #ff6b6b;">Abandon Game?</div>
+            <p style="color: #aaa; margin-bottom: 20px; font-size: 0.9rem; letter-spacing: 0.5px;">
+                Your current progress will be lost.<br>Are you sure you want to start a new game?
+            </p>
+            <div style="display: flex; gap: 12px; justify-content: center;">
+                <button class="btn btn-gold" id="confirmYesBtn" style="width: 90px;">Yes</button>
+                <button class="btn" id="confirmNoBtn" style="width: 90px; background: #333; color: #fff;">Cancel</button>
+            </div>
+        </div>
     </div>
 
     <!-- ========== PROMOTION MODAL ========== -->
@@ -500,17 +534,13 @@
         'use strict';
 
         /* ==========================================================
-        CONSTANTS
+        CONSTANTS & STATE
         ========================================================== */
         const PIECE_IMG = {};
         for (const c of ['w','b'])
             for (const t of ['k','q','r','b','n','p'])
-                PIECE_IMG[c+t] =
-                    `https://images.chesscomfiles.com/chess-themes/pieces/neo/150/${c}${t}.png`;
+                PIECE_IMG[c+t] = `https://images.chesscomfiles.com/chess-themes/pieces/neo/150/${c}${t}.png`;
 
-        /* ==========================================================
-        STATE
-        ========================================================== */
         let board = [];
         let turn = 'white';
         let selected = null;
@@ -524,10 +554,12 @@
         let blackTime = 0;
         let paused = false;
         let timerInterval = null;
-        let pendingPromo = null;  // { fr, fc, tr, tc } awaiting promotion choice
+        let pendingPromo = null;  
+
+        let gameMode = 'pvp';  
 
         /* ==========================================================
-        DOM REFERENCES
+        DOM REFERENCES (Sab ek jagah)
         ========================================================== */
         const boardEl   = document.getElementById('board');
         const turnEl    = document.getElementById('turnBadge');
@@ -536,21 +568,29 @@
         const wCapEl    = document.getElementById('whiteCaptured');
         const bCapEl    = document.getElementById('blackCaptured');
         const pauseBtn  = document.getElementById('pauseBtn');
-        const newGameEl = document.getElementById('newGameBtn');
         const promoOverlay = document.getElementById('promoOverlay');
         const promoChoices = document.getElementById('promoChoices');
+        const modeBadge = document.getElementById('modeBadge'); 
+
+        // Naye Welcome aur Confirm Screen ke Variables
+        const welcomeOverlay = document.getElementById('welcomeOverlay');
+        const welcomeResumeBtn = document.getElementById('welcomeResumeBtn');
+        const welcomePvPBtn = document.getElementById('welcomePvPBtn');
+        const welcomeAIBtn = document.getElementById('welcomeAIBtn');
+        const confirmOverlay = document.getElementById('confirmOverlay');
+        const confirmYesBtn = document.getElementById('confirmYesBtn');
+        const confirmNoBtn = document.getElementById('confirmNoBtn');
+        const newPvPBtn = document.getElementById('newPvPBtn');
+        const newAIBtn = document.getElementById('newAIBtn');
 
         /* ==========================================================
-        CSRF
+        CSRF & API HELPERS
         ========================================================== */
         function csrf() {
             const m = document.cookie.match(/csrftoken=([^;]+)/);
             return m ? decodeURIComponent(m[1]) : '';
         }
 
-        /* ==========================================================
-        API HELPERS
-        ========================================================== */
         async function get(url) {
             return (await fetch(url)).json();
         }
@@ -566,9 +606,6 @@
             })).json();
         }
 
-        /* ==========================================================
-        UTILITIES
-        ========================================================== */
         const pKey   = p => p ? ((p === p.toUpperCase() ? 'w' : 'b') + p.toLowerCase()) : null;
         const pColor = p => p ? (p === p.toUpperCase() ? 'white' : 'black') : null;
         const sq     = (r,c) => boardEl.children[r*8 + c];
@@ -585,6 +622,16 @@
             blackTime = data.black_time;
             paused = data.paused;
 
+            gameMode = data.mode || 'pvp';
+            if (modeBadge) modeBadge.textContent = gameMode === 'ai' ? 'VS AI' : 'PVP';
+
+            // Agar history hai toh Resume button dikhao warna chhupao
+            if (data.move_history && data.move_history.length > 0) {
+                if (welcomeResumeBtn) welcomeResumeBtn.style.display = 'block';
+            } else {
+                if (welcomeResumeBtn) welcomeResumeBtn.style.display = 'none';
+            }
+
             updateTurn();
             updateMoves(data.move_history);
             updateCaptured(data.captured_pieces);
@@ -600,7 +647,6 @@
         ========================================================== */
         function buildBoard() {
             boardEl.innerHTML = '';
-
             for (let r=0; r<8; r++) {
                 for (let c=0; c<8; c++) {
                     const d = document.createElement('div');
@@ -645,7 +691,6 @@
 
             if (selected) {
                 sq(selected.r, selected.c).classList.add('selected');
-
                 hints.forEach(h => {
                     const el = sq(h.row, h.col);
                     const d = document.createElement('div');
@@ -661,6 +706,12 @@
         async function selectPiece(r,c) {
             const p = board[r][c];
             if (!p || pColor(p) !== turn || paused) return;
+
+            // NAYA AI LOCK: Agar AI mode hai aur Black ki turn hai, toh click ignore karo
+            if (gameMode === 'ai' && turn === 'black') {
+                showStatus("Waiting for AI to move...", false);
+                return;
+            }
 
             selected = {r,c};
             const data = await get(`/api/valid-moves/?row=${r}&col=${c}`);
@@ -680,7 +731,6 @@
         function isPromotionMove(fr, fc, tr) {
             const p = board[fr][fc];
             if (!p) return false;
-            // White pawn ('P') rank 0 par, ya Black pawn ('p') rank 7 par
             return (p === 'P' && tr === 0) || (p === 'p' && tr === 7);
         }
 
@@ -699,10 +749,7 @@
                 const img = document.createElement('img');
                 img.src = PIECE_IMG[prefix + key];
                 btn.appendChild(img);
-                
-                // Click karne par promotion choice bhejo
                 btn.onclick = () => onPromoChoice(key);
-                
                 promoChoices.appendChild(btn);
             });
             promoOverlay.classList.add('active');
@@ -738,7 +785,6 @@
         }
 
         async function executeMove(fr, fc, tr, tc, promotionPiece) {
-            // clearStatus function definition if not globally available can be ignored or added here.
             try {
                 const body = {
                     from_row: fr, from_col: fc,
@@ -752,7 +798,6 @@
                     turn  = data.current_turn;
                     lastMove = { from: [fr, fc], to: [tr, tc] };
                     
-                    // FIX: Har move ke baad backend se exact time sync karo
                     whiteTime = data.white_time;
                     blackTime = data.black_time;
                     
@@ -762,38 +807,27 @@
                     updateMoves(data.move_history);
                     updateCaptured(data.captured_pieces);
                     syncPieces();
-                    
-                    // FIX: UI timers ko turant update karo
                     renderClocks(); 
-                    
                     startTimer();
                 } else {
-                    const statusEl  = document.getElementById('statusBar');
-                    statusEl.textContent = data.message;
-                    statusEl.className = 'status-bar error';
+                    showStatus(data.message, true);
                     deselect();
                 }
             } catch (e) {
-                const statusEl  = document.getElementById('statusBar');
-                statusEl.textContent = 'Connection error.';
-                statusEl.className = 'status-bar error';
+                showStatus('Connection error.', true);
             }
         }
-        
 
         /* ==========================================================
         EVENTS
         ========================================================== */
         async function onClick(r,c) {
             if (dragging) return;
-
             if (selected) {
                 if (hints.some(h => h.row===r && h.col===c))
                     return tryMove(selected.r,selected.c,r,c);
-
                 if (board[r][c] && pColor(board[r][c])===turn)
                     return selectPiece(r,c);
-
                 return deselect();
             }
             selectPiece(r,c);
@@ -801,6 +835,7 @@
 
         function onDragStart(e,r,c) {
             if (paused || pColor(board[r][c])!==turn) return e.preventDefault();
+            if (gameMode === 'ai' && turn === 'black') return e.preventDefault(); // AI Lock
             dragging = true;
             dragSrc = {r,c};
             selectPiece(r,c);
@@ -818,8 +853,6 @@
         function updateTurn() {
             turnEl.textContent = turn === 'white' ? "White's Turn" : "Black's Turn";
             turnEl.className = 'turn-badge ' + turn;
-
-            // Active clock class ko player turn ke hisaab se switch karo
             document.getElementById('whiteClock').classList.toggle('active', turn === 'white');
             document.getElementById('blackClock').classList.toggle('active', turn === 'black');
         }
@@ -879,7 +912,6 @@
 
         async function pauseGame() {
             if (paused) return;
-            // Ab hum current UI timer bhi bhej rahe hain
             const d = await post('/api/pause/', {
                 pause: true,
                 white_time: whiteTime,
@@ -894,7 +926,6 @@
 
         async function resumeGame() {
             if (!paused) return;
-            // Resume karte waqt time bhejne ki zarurat nahi, backend wahi se continue karega
             const d = await post('/api/pause/', { pause: false });
             paused = d.paused;
             whiteTime = d.white_time;
@@ -912,7 +943,6 @@
 
         window.addEventListener('beforeunload', () => {
             if (!paused) {
-                // Tab band karte waqt bhi exact time save karwao
                 navigator.sendBeacon('/api/pause/', JSON.stringify({
                     pause: true,
                     white_time: whiteTime,
@@ -922,18 +952,52 @@
         });
 
         /* ==========================================================
-        NEW GAME
+        WELCOME & CONFIRMATION LOGIC
         ========================================================== */
-        newGameEl.onclick = async () => {
-            const d = await post('/api/new-game/', {});
+        let pendingMode = null;
+
+        // Welcome screen logic
+        if (welcomePvPBtn) welcomePvPBtn.onclick = () => { welcomeOverlay.classList.remove('active'); startNewGame('pvp'); };
+        if (welcomeAIBtn) welcomeAIBtn.onclick = () => { welcomeOverlay.classList.remove('active'); startNewGame('ai'); };
+        if (welcomeResumeBtn) welcomeResumeBtn.onclick = () => { 
+            welcomeOverlay.classList.remove('active'); 
+            if (paused) resumeGame();
+        };
+
+        function requestNewGame(mode) {
+            pendingMode = mode;
+            confirmOverlay.classList.add('active');
+        }
+
+        if (confirmYesBtn) confirmYesBtn.onclick = () => {
+            confirmOverlay.classList.remove('active');
+            if (pendingMode) startNewGame(pendingMode);
+        };
+
+        if (confirmNoBtn) confirmNoBtn.onclick = () => {
+            confirmOverlay.classList.remove('active');
+            pendingMode = null;
+        };
+
+        if (newPvPBtn) newPvPBtn.onclick = () => requestNewGame('pvp');
+        if (newAIBtn) newAIBtn.onclick = () => requestNewGame('ai');
+
+        async function startNewGame(mode) {
+            const d = await post('/api/new-game/', { mode: mode });
             board = d.board;
             turn = d.current_turn;
             paused = false;
+            gameMode = d.mode;
+            
+            if (modeBadge) modeBadge.textContent = gameMode === 'ai' ? 'VS AI' : 'PVP';
+            movesEl.innerHTML = '<span class="placeholder">No moves yet</span>';
+            wCapEl.innerHTML = bCapEl.innerHTML = '';
+            
             loadGame();
-        };
+        }
 
         /* ==========================================================
-        INIT
+        INIT (Game yahan se shuru hota hai)
         ========================================================== */
         loadGame();
     })();

--- a/game/views.py
+++ b/game/views.py
@@ -80,15 +80,22 @@ def valid_moves(request):
 
 @require_POST
 def new_game(request):
-    """Reset the game to the initial position."""
+    """Reset the game to the initial position with selected mode."""
+    data = json.loads(request.body or '{}')
+    mode = data.get('mode', 'pvp')  # Frontend se mode aayega
+    
     game = ChessGame()
+    game.mode = mode
+    
     request.session['game'] = game.to_dict()
     request.session.modified = True
+    
     return JsonResponse({
         'board': game.board,
         'current_turn': game.current_turn,
         'move_history': [],
         'captured_pieces': {'white': [], 'black': []},
+        'mode': game.mode
     })
 
 @require_GET
@@ -142,6 +149,7 @@ def get_state(request):
         'paused': game.paused,
         'move_history': game.move_history,
         'captured_pieces': game.captured,
+        'mode': game.mode if 'game' in locals() else game_data.get('mode', 'pvp'),
     })
 
 @csrf_exempt


### PR DESCRIPTION
## Description

- Added a dedicated Welcome/Main Menu screen for users to select between "Pass & Play (PvP)" and "Play vs AI" modes before the board is displayed.
- Added a "Resume Game" feature that only appears if there is an active game session with move history.
- Cleaned up `board.html` by centralizing DOM references, removing duplicate functions, and optimizing the event listener logic.
- Implemented an AI lock to prevent users from interacting with black pieces during the computer's turn.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings