### PR TITLE
feat: update document.title to show turn and game over status

### DIFF
--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -950,6 +950,10 @@
             turnEl.className = 'turn-badge ' + turn;
             document.getElementById('whiteClock').classList.toggle('active', turn === 'white');
             document.getElementById('blackClock').classList.toggle('active', turn === 'black');
+            // Update browser tab title to reflect whose turn it is
+            if (!gameOver) {
+                document.title = (turn === 'white' ? 'White to Move - Checkora' : 'Black to Move - Checkora');
+            }
         }
 
         function updateMoves(history) {
@@ -1001,6 +1005,8 @@
             gameOverMessage.textContent = message;
             gameOverOverlay.classList.add('active');
             showStatus(title + ' ' + message, false);
+            // Update browser tab title to indicate game over
+            document.title = 'Game Over - Checkora';
         }
 
         /* ==========================================================


### PR DESCRIPTION
## Description

Updates the browser tab title dynamically to improve UX:

"White to Move - Checkora" when it's White's turn
"Black to Move - Checkora" when it's Black's turn
"Game Over - Checkora" when the game ends

This change updates document.title in updateTurn() and sets it on game over in handleGameOver().

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #95 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browser tab title now dynamically updates to display whose turn it is during active gameplay
  * Browser tab title displays "Game Over - Checkora" when a game concludes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->