### PR TITLE
ci: add Vercel deployment check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,21 +268,7 @@ jobs:
         continue-on-error: false
 
 # ───────────────────────────────────────────────────────────────────
-# JOB 6 — Vercel Deploy Check
+# NOTE: Deployment is handled natively by Vercel's GitHub integration.
+# Vercel auto-deploys on every push to main and creates preview
+# deployments for every PR — no separate deploy job needed here.
 # ───────────────────────────────────────────────────────────────────
-  vercel-deploy-check:
-    name: 🌐 Vercel Deploy Check
-    runs-on: ubuntu-latest
-    needs: [test, migrate-check, security]
-    
-    steps:
-      - name: ⏳ Wait for Vercel Preview/Production Deployment
-        uses: patrickedqvist/wait-for-vercel-preview@06c79330064b0e6ef7a2574603b62d3c98789125 # v1.3.2
-        id: waitForVercel
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          max_timeout: 300
-      
-      - name: 🌐 Display Vercel URL
-        run: |
-          echo "Vercel Deployment is ready: ${{ steps.waitForVercel.outputs.url }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write   # allows posting CI summary comments on PRs
+  deployments: read      # required for Vercel preview polling
 
 env:
   DJANGO_SETTINGS_MODULE: core.settings
@@ -276,7 +277,7 @@ jobs:
     
     steps:
       - name: ⏳ Wait for Vercel Preview/Production Deployment
-        uses: patrickedqvist/wait-for-vercel-preview@v1.3.2
+        uses: patrickedqvist/wait-for-vercel-preview@06c79330064b0e6ef7a2574603b62d3c98789125 # v1.3.2
         id: waitForVercel
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,21 @@ jobs:
         continue-on-error: false
 
 # ───────────────────────────────────────────────────────────────────
-# NOTE: Deployment is handled natively by Vercel's GitHub integration.
-# Vercel auto-deploys on every push to main and creates preview
-# deployments for every PR — no separate deploy job needed here.
+# JOB 6 — Vercel Deploy Check
 # ───────────────────────────────────────────────────────────────────
+  vercel-deploy-check:
+    name: 🌐 Vercel Deploy Check
+    runs-on: ubuntu-latest
+    needs: [test, migrate-check, security]
+    
+    steps:
+      - name: ⏳ Wait for Vercel Preview/Production Deployment
+        uses: patrickedqvist/wait-for-vercel-preview@v1.3.2
+        id: waitForVercel
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          max_timeout: 300
+      
+      - name: 🌐 Display Vercel URL
+        run: |
+          echo "Vercel Deployment is ready: ${{ steps.waitForVercel.outputs.url }}"


### PR DESCRIPTION
## Description

Added a dedicated `vercel-deploy-check` job to the CI/CD workflow (`ci.yml`). This job waits for the native Vercel preview/production deployment to complete successfully before marking the CI pipeline as fully passed, and outputs the deployed Vercel URL for easy access.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

*(No visual UI changes. This applies to the CI/CD pipeline on GitHub Actions.)*

## Additional Notes

This job requires the standard `GITHUB_TOKEN` to check the commit statuses posted by Vercel. It has a timeout of 5 minutes (`300` seconds) to prevent the CI from hanging indefinitely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow now waits for preview/production deployments to become ready before proceeding and prints the resolved deployment URL for visibility.
  * Added permissions to allow the workflow to poll deployment status, improving reliability of deployment checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->