### PR TITLE
Fix mobile responsiveness: improve layout scaling and remove horizontal scroll

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -350,6 +350,12 @@ body {
 }
 
 @media (max-width: 768px) {
+    :root {
+        --board-border-width: 3px;
+        --mobile-board-size: min(calc(100vw - 52px), 480px);
+        --mobile-square-size: calc((var(--mobile-board-size) - (var(--board-border-width) * 2)) / 8);
+    }
+
     .header {
         padding: 16px 0 10px;
     }
@@ -384,10 +390,11 @@ body {
     }
 
     .chessboard {
-        width: min(calc(100vw - 52px), 480px);
-        height: min(calc(100vw - 52px), 480px);
-        grid-template-columns: repeat(8, 1fr);
-        grid-template-rows: repeat(8, 1fr);
+        width: var(--mobile-board-size);
+        height: var(--mobile-board-size);
+        border-width: var(--board-border-width);
+        grid-template-columns: repeat(8, var(--mobile-square-size));
+        grid-template-rows: repeat(8, var(--mobile-square-size));
     }
 
     .square {
@@ -396,7 +403,7 @@ body {
     }
 
     .ranks span {
-        height: calc(min(calc(100vw - 52px), 480px) / 8);
+        height: var(--mobile-square-size);
     }
 
     .files {
@@ -404,7 +411,7 @@ body {
     }
 
     .files span {
-        width: calc(min(calc(100vw - 52px), 480px) / 8);
+        width: var(--mobile-square-size);
     }
 
     .piece,

--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -349,6 +349,101 @@ body {
     .panel .card { flex: 1; min-width: 200px; }
 }
 
+@media (max-width: 768px) {
+    .header {
+        padding: 16px 0 10px;
+    }
+
+    .header h1 {
+        font-size: 1.5rem;
+    }
+
+    .game-layout {
+        width: 100%;
+        gap: 16px;
+        padding: 10px 12px 24px;
+    }
+
+    .panel,
+    .board-container {
+        width: 100%;
+        max-width: 100%;
+    }
+
+    .panel {
+        flex-direction: column;
+    }
+
+    .panel .card {
+        min-width: 0;
+    }
+
+    .board-outer {
+        width: 100%;
+        max-width: calc(100vw - 24px);
+    }
+
+    .chessboard {
+        width: min(calc(100vw - 52px), 480px);
+        height: min(calc(100vw - 52px), 480px);
+        grid-template-columns: repeat(8, 1fr);
+        grid-template-rows: repeat(8, 1fr);
+    }
+
+    .square {
+        width: 100%;
+        height: 100%;
+    }
+
+    .ranks span {
+        height: calc(min(calc(100vw - 52px), 480px) / 8);
+    }
+
+    .files {
+        padding-left: 24px;
+    }
+
+    .files span {
+        width: calc(min(calc(100vw - 52px), 480px) / 8);
+    }
+
+    .piece,
+    .capture-ring {
+        width: 90%;
+        height: 90%;
+    }
+
+    .move-dot {
+        width: 28%;
+        height: 28%;
+    }
+
+    .capture-ring {
+        border-width: max(3px, 0.08rem);
+    }
+
+    .clocks {
+        width: 100%;
+    }
+
+    .clock {
+        padding: 12px;
+    }
+
+    .clock .time {
+        font-size: 1rem;
+    }
+
+    .btn {
+        min-height: 44px;
+    }
+
+    .turn-badge,
+    #pauseBtn {
+        width: 100%;
+    }
+}
+
 /* ================= CLOCKS ================= */
 
 .clocks {


### PR DESCRIPTION

## Description
Improved the mobile responsiveness of the chessboard layout.
The board now scales better on smaller screens, side panels stack more cleanly, and horizontal scrolling is reduced.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #72 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

## Screenshots :
Mobile responsive preview showing:
- scaled chessboard
- stacked side panels
- no horizontal scrolling


## Screenshots

Mobile responsive preview showing:
- scaled chessboard
- stacked side panels
- no horizontal scrolling

Attached screenshots:

<img width="1095" height="900" alt="image" src="https://github.com/user-attachments/assets/85e2d9a1-331c-49b9-822a-aadd5103d8fe" />
<img width="1064" height="928" alt="image" src="https://github.com/user-attachments/assets/af0cc460-7c0f-4dc1-8322-325f54253f88" />
<img width="1081" height="924" alt="image" src="https://github.com/user-attachments/assets/e37919ab-7748-4ea9-81e7-7d8fef60abb5" />

## Additional Notes

Changes are limited to mobile layout responsiveness in `game/templates/game/board.html`.