### PR TITLE
Auto-label issues with GitHub Script

### DIFF
--- a/.github/workflows/label-gssoc.yml
+++ b/.github/workflows/label-gssoc.yml
@@ -34,13 +34,19 @@ jobs:
               });
             } catch (err) {
               if (err.status === 404) {
-                await github.rest.issues.createLabel({
-                  owner,
-                  repo,
-                  name: label,
-                  color,
-                  description
-                });
+                try {
+                  await github.rest.issues.createLabel({
+                    owner,
+                    repo,
+                    name: label,
+                    color,
+                    description
+                  });
+                } catch (createErr) {
+                  if (createErr.status !== 422) {
+                    throw createErr;
+                  }
+                }
               } else {
                 throw err;
               }

--- a/.github/workflows/label-gssoc.yml
+++ b/.github/workflows/label-gssoc.yml
@@ -19,7 +19,7 @@ jobs:
             const repo = context.repo.repo;
             const issue_number = context.payload.issue.number;
             const label = 'GSSoC';
-            const color = '#D97706';
+            const color = '#FD873D';
             const description = 'Under GirlScript Summer of Code';
 
             try {

--- a/.github/workflows/label-gssoc.yml
+++ b/.github/workflows/label-gssoc.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Ensure label and add to issue
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const owner = context.repo.owner;

--- a/.github/workflows/label-gssoc.yml
+++ b/.github/workflows/label-gssoc.yml
@@ -19,8 +19,8 @@ jobs:
             const repo = context.repo.repo;
             const issue_number = context.payload.issue.number;
             const label = 'GSSoC';
-            const color = 'FF7A00';
-            const description = 'GirlScript Summer of Code';
+            const color = '#D97706';
+            const description = 'Under GirlScript Summer of Code';
 
             try {
               await github.rest.issues.getLabel({ owner, repo, name: label });

--- a/.github/workflows/label-gssoc.yml
+++ b/.github/workflows/label-gssoc.yml
@@ -18,18 +18,37 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const issue_number = context.payload.issue.number;
+            
             const label = 'GSSoC';
-            const color = '#FD873D';
+            const color = 'FD873D'; 
             const description = 'Under GirlScript Summer of Code';
-
+            
             try {
-              await github.rest.issues.getLabel({ owner, repo, name: label });
+              await github.rest.issues.updateLabel({
+                owner,
+                repo,
+                name: label,
+                new_name: label,
+                color,
+                description
+              });
             } catch (err) {
               if (err.status === 404) {
-                await github.rest.issues.createLabel({ owner, repo, name: label, color, description });
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name: label,
+                  color,
+                  description
+                });
               } else {
                 throw err;
               }
             }
-
-            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [label] });
+            
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number,
+              labels: [label]
+            });

--- a/.github/workflows/label-gssoc.yml
+++ b/.github/workflows/label-gssoc.yml
@@ -9,18 +9,27 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      contents: write
 
     steps:
-      - name: Ensure GSSoC label exists
-        uses: peter-evans/create-or-update-label@v1
+      - name: Ensure label and add to issue
+        uses: actions/github-script@v6
         with:
-          name: GSSoC
-          color: FF7A00
-          description: "GirlScript Summer of Code"
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.issue.number;
+            const label = 'GSSoC';
+            const color = 'FF7A00';
+            const description = 'GirlScript Summer of Code';
 
-      - name: Add GSSoC label to the new issue
-        uses: actions-ecosystem/action-add-labels@v4
-        with:
-          labels: GSSoC
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name: label });
+            } catch (err) {
+              if (err.status === 404) {
+                await github.rest.issues.createLabel({ owner, repo, name: label, color, description });
+              } else {
+                throw err;
+              }
+            }
+
+            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [label] });

--- a/.github/workflows/label-gssoc.yml
+++ b/.github/workflows/label-gssoc.yml
@@ -20,7 +20,7 @@ jobs:
           description: "GirlScript Summer of Code"
 
       - name: Add GSSoC label to the new issue
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions-ecosystem/action-add-labels@v4
         with:
           labels: GSSoC
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
Replaces third-party labeling actions with `actions/github-script` to avoid marketplace restrictions and ensure the label is created + applied in one workflow step.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issue
Fixes #118 

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings