### PR TITLE
Feat/opening book impl

### DIFF
--- a/game/engine.py
+++ b/game/engine.py
@@ -1,12 +1,23 @@
 """Checkora Game Manager.
 
 Manages chess game state and coordinates with the C++ engine for move
-validation. Includes a persistent DP table (valid_moves_cache) that 
+validation. Includes a persistent DP table (valid_moves_cache) that
 updates on-demand to avoid redundant brute-force calculations while
 ensuring 100% accuracy.
+
+Opening Book
+------------
+During the first few moves the AI consults a pre-built opening book
+(``game/engine/opening_book.json``) instead of running the expensive
+minimax search.  Keys are minimal FEN strings (board layout + side to
+move + castling rights, **no** en-passant / half-move / full-move
+counters) and values are lists of ``[from_row, from_col, to_row,
+to_col]`` move coordinates.  When multiple book moves are available one
+is chosen at random to add variety.
 """
 
 import os
+import random
 import subprocess
 import json
 import sys
@@ -34,6 +45,12 @@ class ChessGame:
         ]
     )
     FILES = 'abcdefgh'
+
+    # Path to the JSON opening book
+    OPENING_BOOK_PATH = os.path.join(ENGINE_DIR, 'opening_book.json')
+
+    # Class-level cache so the file is read only once per process
+    _opening_book: dict | None = None
 
     INITIAL_BOARD = [
         ['r', 'n', 'b', 'q', 'k', 'b', 'n', 'r'],
@@ -412,6 +429,83 @@ class ChessGame:
         return 'ok'
 
     # ------------------------------------------------------------------
+    #  AI -- Opening Book
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def _load_opening_book(cls) -> dict:
+        """Load the opening book JSON from disk (cached after first load)."""
+        if cls._opening_book is None:
+            try:
+                with open(cls.OPENING_BOOK_PATH, encoding='utf-8') as fh:
+                    cls._opening_book = json.load(fh)
+            except (OSError, json.JSONDecodeError):
+                cls._opening_book = {}  # Graceful fallback: no book
+        return cls._opening_book
+
+    def generate_fen_key(self) -> str:
+        """Build a minimal FEN key (board + side + castling, no counters).
+
+        This matches the key format used in ``opening_book.json``.
+        """
+        # Piece-placement section
+        fen_rows = []
+        for row in self.board:
+            empty = 0
+            row_str = ''
+            for piece in row:
+                if piece is None:
+                    empty += 1
+                else:
+                    if empty:
+                        row_str += str(empty)
+                        empty = 0
+                    row_str += piece
+            if empty:
+                row_str += str(empty)
+            fen_rows.append(row_str)
+        placement = '/'.join(fen_rows)
+
+        # Side to move
+        side = 'w' if self.current_turn == 'white' else 'b'
+
+        # Castling rights
+        castling = self.serialize_castling_rights()  # already returns '-' if none
+
+        return f"{placement} {side} {castling}"
+
+    def get_opening_book_move(self) -> dict | None:
+        """Return a random book move for the current position, or ``None``.
+
+        The move is validated against the engine before being returned so
+        the AI never plays an illegal book move.
+        """
+        book = self._load_opening_book()
+        fen_key = self.generate_fen_key()
+        candidates = book.get(fen_key)
+        if not candidates:
+            return None
+
+        # Shuffle so variety is uniform across the candidate list
+        candidates = list(candidates)  # copy – do not mutate the book
+        random.shuffle(candidates)
+
+        for move in candidates:
+            if len(move) != 4:
+                continue
+            fr, fc, tr, tc = move
+            is_valid, _ = self.validate_move(fr, fc, tr, tc)
+            if is_valid:
+                return {
+                    'from_row': fr,
+                    'from_col': fc,
+                    'to_row': tr,
+                    'to_col': tc,
+                }
+
+        return None  # No valid book move found
+
+    # ------------------------------------------------------------------
     #  AI -- Minimax via C++ engine
     # ------------------------------------------------------------------
 
@@ -419,11 +513,21 @@ class ChessGame:
     AI_SEARCH_DEPTH_PYTHON = 3  # Python engine needs conservative depth
 
     def get_ai_move(self):
-        """Ask the C++ engine to compute the best move using minimax.
+        """Return the best move for the current position.
+
+        Checks the opening book first for an instant theory response.
+        Falls back to the C++ minimax engine when the position is not
+        in the book or the book move fails validation.
 
         Returns a dict with from/to coordinates, or None when no
         legal move exists (checkmate / stalemate).
         """
+        # 1. Opening-book lookup (fast path)
+        book_move = self.get_opening_book_move()
+        if book_move:
+            return book_move
+
+        # 2. Minimax search (slow path)
         board_str = self.serialize_board()
         rights_str = self.serialize_castling_rights()
         depth = self._get_ai_search_depth()

--- a/game/engine.py
+++ b/game/engine.py
@@ -491,7 +491,14 @@ class ChessGame:
         random.shuffle(candidates)
 
         for move in candidates:
-            if len(move) != 4:
+            # Sanity-check: must be a 4-item sequence of ints, all in 0..7.
+            # This prevents IndexError inside validate_move if the JSON ever
+            # contains malformed entries like [9, 9, 9, 9].
+            if (
+                not isinstance(move, (list, tuple))
+                or len(move) != 4
+                or not all(isinstance(c, int) and 0 <= c <= 7 for c in move)
+            ):
                 continue
             fr, fc, tr, tc = move
             is_valid, _ = self.validate_move(fr, fc, tr, tc)

--- a/game/engine/opening_book.json
+++ b/game/engine/opening_book.json
@@ -1,0 +1,204 @@
+{
+  "_comment": "Opening book: keys are FEN positions (no move count), values are lists of [from_row, from_col, to_row, to_col].",
+
+  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq": [
+    [6, 4, 4, 4],
+    [6, 3, 4, 3],
+    [7, 6, 5, 5]
+  ],
+
+  "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq": [
+    [1, 2, 3, 2],
+    [1, 4, 3, 4],
+    [1, 3, 3, 3],
+    [0, 6, 2, 5]
+  ],
+
+  "rnbqkbnr/pppppppp/8/8/3P4/8/PPP1PPPP/RNBQKBNR b KQkq": [
+    [1, 3, 3, 3],
+    [1, 4, 3, 4],
+    [0, 6, 2, 5]
+  ],
+
+  "rnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w KQkq": [
+    [7, 6, 5, 5],
+    [7, 1, 5, 2],
+    [6, 3, 4, 3]
+  ],
+
+  "rnbqkbnr/pp1ppppp/8/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq": [
+    [0, 6, 2, 5],
+    [1, 6, 2, 6],
+    [1, 3, 2, 3]
+  ],
+
+  "r1bqkbnr/pp1ppppp/2n5/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq": [
+    [5, 5, 4, 4],
+    [6, 3, 4, 3]
+  ],
+
+  "r1bqkbnr/pp1ppppp/2n5/2p5/4P3/2N2N2/PPPP1PPP/R1BQKB1R b KQkq": [
+    [1, 4, 2, 4],
+    [1, 6, 2, 6]
+  ],
+
+  "rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq": [
+    [7, 6, 5, 5],
+    [7, 1, 5, 2],
+    [6, 3, 4, 3]
+  ],
+
+  "rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq": [
+    [0, 1, 2, 2],
+    [0, 6, 2, 5],
+    [1, 3, 2, 3]
+  ],
+
+  "r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq": [
+    [5, 3, 3, 1],
+    [6, 1, 4, 1]
+  ],
+
+  "r1bqkbnr/pppp1ppp/2n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R b KQkq": [
+    [1, 0, 2, 0],
+    [0, 6, 2, 5],
+    [1, 3, 2, 3]
+  ],
+
+  "r1bqkbnr/1ppp1ppp/p1n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq": [
+    [5, 1, 4, 2],
+    [4, 4, 3, 4]
+  ],
+
+  "r1bqkbnr/1ppp1ppp/p1n5/4p3/B3P3/5N2/PPPP1PPP/RNBQK2R b KQkq": [
+    [0, 6, 2, 5],
+    [1, 3, 2, 3]
+  ],
+
+  "r1bqkb1r/1ppp1ppp/p1n2n2/4p3/B3P3/5N2/PPPP1PPP/RNBQK2R w KQkq": [
+    [7, 4, 7, 6],
+    [4, 4, 3, 4]
+  ],
+
+  "r1bqkb1r/1ppp1ppp/p1n2n2/4p3/B3P3/5N2/PPPP1PPP/RNBQ1RK1 b kq": [
+    [1, 1, 3, 1],
+    [2, 2, 3, 2]
+  ],
+
+  "rnbqkbnr/ppp1pppp/8/3p4/3P4/8/PPP1PPPP/RNBQKBNR w KQkq": [
+    [6, 2, 4, 2],
+    [7, 1, 5, 2],
+    [7, 6, 5, 5]
+  ],
+
+  "rnbqkbnr/ppp1pppp/8/3p4/2PP4/8/PP2PPPP/RNBQKBNR b KQkq": [
+    [1, 4, 2, 4],
+    [1, 1, 2, 1],
+    [0, 6, 2, 5]
+  ],
+
+  "rnbqkbnr/ppp2ppp/4p3/3p4/2PP4/8/PP2PPPP/RNBQKBNR w KQkq": [
+    [7, 1, 5, 2],
+    [6, 2, 4, 2]
+  ],
+
+  "rnbqkbnr/ppp2ppp/4p3/3p4/2PP4/2N5/PP2PPPP/R1BQKBNR b KQkq": [
+    [0, 6, 2, 5],
+    [0, 1, 2, 2],
+    [1, 1, 2, 1]
+  ],
+
+  "rnbqkb1r/ppp2ppp/4pn2/3p4/2PP4/2N5/PP2PPPP/R1BQKBNR w KQkq": [
+    [5, 2, 4, 1],
+    [7, 6, 5, 5]
+  ],
+
+  "rnbqkb1r/ppp2ppp/4pn2/3p4/2PP4/2N2N2/PP2PPPP/R1BQKB1R b KQkq": [
+    [1, 1, 2, 1],
+    [0, 1, 2, 2]
+  ],
+
+  "rnbqkb1r/ppp2ppp/4pn2/3p4/2PP4/4PN2/PP3PPP/RNBQKB1R b KQkq": [
+    [0, 1, 2, 2],
+    [1, 2, 3, 2]
+  ],
+
+  "rnbqkb1r/pp3ppp/4pn2/2pp4/2PP4/4PN2/PP3PPP/RNBQKB1R w KQkq": [
+    [5, 3, 4, 2],
+    [7, 6, 5, 5]
+  ],
+
+  "rnbqkbnr/ppp1pppp/8/3p4/3PP3/8/PPP2PPP/RNBQKBNR b KQkq": [
+    [1, 4, 3, 4],
+    [3, 3, 4, 4],
+    [0, 6, 2, 5]
+  ],
+
+  "rnbqkbnr/ppp2ppp/8/3pp3/3PP3/8/PPP2PPP/RNBQKBNR w KQkq": [
+    [7, 6, 5, 5],
+    [7, 1, 5, 2]
+  ],
+
+  "rnbqkb1r/pppp1ppp/5n2/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq": [
+    [5, 5, 4, 4],
+    [6, 3, 4, 3],
+    [5, 1, 4, 2]
+  ],
+
+  "rnbqkb1r/pppp1ppp/5n2/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R b KQkq": [
+    [0, 3, 2, 3],
+    [1, 2, 2, 2],
+    [2, 5, 4, 4]
+  ],
+
+  "rnbqkb1r/pppp1ppp/5n2/4p3/4PP2/5N2/PPPP2PP/RNBQKB1R b KQkq": [
+    [2, 5, 3, 5],
+    [1, 3, 3, 3]
+  ],
+
+  "rnbqkb1r/ppp2ppp/3p1n2/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq": [
+    [4, 2, 3, 3],
+    [7, 4, 7, 6],
+    [6, 2, 4, 2]
+  ],
+
+  "r1bqkbnr/pppp1ppp/2n5/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R b KQkq": [
+    [1, 5, 3, 5],
+    [0, 5, 2, 3]
+  ],
+
+  "rnbqk2r/pppp1ppp/5n2/2b1p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq": [
+    [5, 5, 3, 4],
+    [7, 4, 7, 6]
+  ],
+
+  "rnbqkbnr/pp1ppppp/2p5/8/4P3/8/PPPP1PPP/RNBQKBNR w KQkq": [
+    [7, 6, 5, 5],
+    [6, 3, 4, 3],
+    [7, 1, 5, 2]
+  ],
+
+  "rnbqkbnr/pp1ppppp/2p5/8/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq": [
+    [1, 3, 2, 3],
+    [1, 6, 2, 6],
+    [0, 6, 2, 5]
+  ],
+
+  "rnbqkbnr/pp1p1ppp/2p5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq": [
+    [5, 3, 3, 2],
+    [6, 1, 4, 1],
+    [7, 1, 5, 2]
+  ],
+
+  "rnbqkbnr/pp2pppp/2p5/3p4/3PP3/8/PPP2PPP/RNBQKBNR w KQkq": [
+    [6, 2, 4, 2],
+    [4, 4, 3, 3],
+    [7, 1, 5, 2]
+  ],
+
+  "rnbqkbnr/pp2pppp/2p5/3p4/2PPP3/8/PP3PPP/RNBQKBNR b KQkq": [
+    [3, 3, 4, 4],
+    [1, 4, 3, 4],
+    [0, 6, 2, 5]
+  ]
+}

--- a/game/tests.py
+++ b/game/tests.py
@@ -484,7 +484,6 @@ class OpeningBookTest(SimpleTestCase):
         )
         ChessGame._opening_book = None
 
-
     def test_book_moves_show_variety(self):
         """With multiple candidates different moves should be chosen over many calls."""
         game = ChessGame()

--- a/game/tests.py
+++ b/game/tests.py
@@ -448,12 +448,27 @@ class OpeningBookTest(SimpleTestCase):
         self.assertIsNone(move)
         ChessGame._opening_book = None
 
-    def test_first_legal_candidate_returned_when_first_is_illegal(self):
-        """The first *legal* candidate is returned even if earlier ones fail."""
+    def test_out_of_range_coords_skipped_without_calling_validate(self):
+        """Out-of-range entries must be rejected by the bounds check alone.
+
+        validate_move is NOT mocked here — if the bounds check were missing,
+        board[9][9] would raise IndexError and the test would fail.
+        """
+        game = ChessGame()
+        ChessGame._opening_book = {
+            game.generate_fen_key(): [[9, 9, 9, 9]],  # out-of-range only
+        }
+        # No mock — real validate_move would IndexError without the guard
+        move = game.get_opening_book_move()
+        self.assertIsNone(move)
+        ChessGame._opening_book = None
+
+    def test_first_legal_candidate_returned_when_first_is_malformed(self):
+        """A valid second candidate is returned after a malformed first entry."""
         game = ChessGame()
         fen = game.generate_fen_key()
         ChessGame._opening_book = {
-            fen: [[9, 9, 9, 9], [6, 4, 4, 4]],  # first entry invalid coords
+            fen: [[9, 9, 9, 9], [6, 4, 4, 4]],  # first entry out-of-range
         }
 
         def fake_validate(fr, fc, tr, tc):
@@ -463,9 +478,12 @@ class OpeningBookTest(SimpleTestCase):
             move = game.get_opening_book_move()
 
         self.assertIsNotNone(move)
-        self.assertEqual([move['from_row'], move['from_col'], move['to_row'], move['to_col']],
-                         [6, 4, 4, 4])
+        self.assertEqual(
+            [move['from_row'], move['from_col'], move['to_row'], move['to_col']],
+            [6, 4, 4, 4],
+        )
         ChessGame._opening_book = None
+
 
     def test_book_moves_show_variety(self):
         """With multiple candidates different moves should be chosen over many calls."""

--- a/game/tests.py
+++ b/game/tests.py
@@ -334,5 +334,186 @@ class AIMoveTest(TestCase):
         data = r.json()
         self.assertTrue(data['valid'])
         self.assertEqual(data['current_turn'], 'black')
-        self.assertEqual(data['ai_move']['from_row'], 6)
-        self.assertEqual(data['ai_move']['to_row'], 4)
+        # The opening book (or engine) picks the move; just verify coordinates are present
+        self.assertIn('from_row', data['ai_move'])
+        self.assertIn('from_col', data['ai_move'])
+        self.assertIn('to_row', data['ai_move'])
+        self.assertIn('to_col', data['ai_move'])
+
+
+
+class OpeningBookTest(SimpleTestCase):
+    """Unit tests for the opening-book integration in ChessGame."""
+
+    # ------------------------------------------------------------------
+    # FEN key generation
+    # ------------------------------------------------------------------
+
+    def test_fen_key_starting_position(self):
+        """Starting position must produce the correct standard FEN key."""
+        game = ChessGame()
+        key = game.generate_fen_key()
+        self.assertEqual(
+            key,
+            'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq',
+        )
+
+    def test_fen_key_side_switches_after_move(self):
+        """After white moves the key should show 'b' as the active side."""
+        game = ChessGame()
+        game.current_turn = 'black'
+        key = game.generate_fen_key()
+        self.assertIn(' b ', key)
+
+    def test_fen_key_reflects_castling_rights_loss(self):
+        """Losing castling rights must be reflected in the FEN key."""
+        game = ChessGame()
+        game.castling_rights = {'w_k': False, 'w_q': False, 'b_k': False, 'b_q': False}
+        key = game.generate_fen_key()
+        self.assertTrue(key.endswith(' -'))
+
+    def test_fen_key_empty_board_row_uses_digit(self):
+        """An entirely empty rank must produce '8' not eight dots."""
+        game = ChessGame()
+        key = game.generate_fen_key()
+        # Ranks 3-6 (0-indexed 2-5) are empty at start → four '8' segments
+        self.assertIn('/8/', key)
+
+    # ------------------------------------------------------------------
+    # Book loading
+    # ------------------------------------------------------------------
+
+    def test_book_loads_from_json_file(self):
+        """The book file must be loadable and return a non-empty dict."""
+        # Reset the class-level cache so the real file is read
+        ChessGame._opening_book = None
+        book = ChessGame._load_opening_book()
+        self.assertIsInstance(book, dict)
+        self.assertGreater(len(book), 0)
+
+    def test_book_caches_after_first_load(self):
+        """Subsequent calls must return the same object (no re-read)."""
+        ChessGame._opening_book = None
+        book1 = ChessGame._load_opening_book()
+        book2 = ChessGame._load_opening_book()
+        self.assertIs(book1, book2)
+
+    def test_book_falls_back_gracefully_on_missing_file(self):
+        """A missing book file should produce an empty dict, not a crash."""
+        ChessGame._opening_book = None
+        with mock.patch.object(ChessGame, 'OPENING_BOOK_PATH', '/nonexistent/path.json'):
+            book = ChessGame._load_opening_book()
+        self.assertEqual(book, {})
+        # Restore so other tests use the real book
+        ChessGame._opening_book = None
+
+    # ------------------------------------------------------------------
+    # get_opening_book_move
+    # ------------------------------------------------------------------
+
+    def test_starting_position_returns_book_move(self):
+        """At the start of the game a valid book move should be returned."""
+        game = ChessGame()
+        ChessGame._opening_book = None
+
+        with mock.patch.object(ChessGame, 'validate_move', return_value=(True, 'ok')):
+            move = game.get_opening_book_move()
+
+        self.assertIsNotNone(move, 'Expected a book move for the starting position')
+        self.assertIn('from_row', move)
+        self.assertIn('from_col', move)
+        self.assertIn('to_row', move)
+        self.assertIn('to_col', move)
+
+    def test_unknown_position_returns_none(self):
+        """An out-of-book position must return None (fall through to engine)."""
+        game = ChessGame()
+        # Force a book with no matching key
+        ChessGame._opening_book = {}
+
+        move = game.get_opening_book_move()
+        self.assertIsNone(move)
+        # Restore
+        ChessGame._opening_book = None
+
+    def test_illegal_book_moves_are_skipped(self):
+        """If validate_move rejects all candidates the result is None."""
+        game = ChessGame()
+        ChessGame._opening_book = {
+            game.generate_fen_key(): [[6, 4, 4, 4]],
+        }
+
+        with mock.patch.object(ChessGame, 'validate_move', return_value=(False, 'illegal')):
+            move = game.get_opening_book_move()
+
+        self.assertIsNone(move)
+        ChessGame._opening_book = None
+
+    def test_first_legal_candidate_returned_when_first_is_illegal(self):
+        """The first *legal* candidate is returned even if earlier ones fail."""
+        game = ChessGame()
+        fen = game.generate_fen_key()
+        ChessGame._opening_book = {
+            fen: [[9, 9, 9, 9], [6, 4, 4, 4]],  # first entry invalid coords
+        }
+
+        def fake_validate(fr, fc, tr, tc):
+            return (True, 'ok') if [fr, fc, tr, tc] == [6, 4, 4, 4] else (False, 'bad')
+
+        with mock.patch.object(ChessGame, 'validate_move', side_effect=fake_validate):
+            move = game.get_opening_book_move()
+
+        self.assertIsNotNone(move)
+        self.assertEqual([move['from_row'], move['from_col'], move['to_row'], move['to_col']],
+                         [6, 4, 4, 4])
+        ChessGame._opening_book = None
+
+    def test_book_moves_show_variety(self):
+        """With multiple candidates different moves should be chosen over many calls."""
+        game = ChessGame()
+        fen = game.generate_fen_key()
+        ChessGame._opening_book = {
+            fen: [[6, 4, 4, 4], [6, 3, 4, 3], [7, 6, 5, 5]],
+        }
+        seen = set()
+        with mock.patch.object(ChessGame, 'validate_move', return_value=(True, 'ok')):
+            for _ in range(60):
+                m = game.get_opening_book_move()
+                if m:
+                    seen.add((m['from_row'], m['from_col'], m['to_row'], m['to_col']))
+
+        self.assertGreater(len(seen), 1, 'Book should produce variety across 60 calls')
+        ChessGame._opening_book = None
+
+    # ------------------------------------------------------------------
+    # Integration: get_ai_move uses book on first move
+    # ------------------------------------------------------------------
+
+    def test_get_ai_move_uses_book_before_engine(self):
+        """get_ai_move() must return the book move without calling the engine."""
+        game = ChessGame()
+        ChessGame._opening_book = None
+
+        with (
+            mock.patch.object(ChessGame, 'validate_move', return_value=(True, 'ok')),
+            mock.patch.object(ChessGame, '_call_engine') as mock_engine,
+        ):
+            move = game.get_ai_move()
+
+        mock_engine.assert_not_called()
+        self.assertIsNotNone(move)
+        ChessGame._opening_book = None
+
+    def test_get_ai_move_falls_back_to_engine_when_book_empty(self):
+        """When the book has no entry the engine must be consulted."""
+        game = ChessGame()
+        ChessGame._opening_book = {}  # empty book
+
+        with mock.patch.object(ChessGame, '_call_engine', return_value='BESTMOVE 6 4 4 4') as mock_engine:
+            move = game.get_ai_move()
+
+        mock_engine.assert_called_once()
+        self.assertIsNotNone(move)
+        self.assertEqual(move['from_row'], 6)
+        self.assertEqual(move['to_row'], 4)
+        ChessGame._opening_book = None

--- a/game/tests.py
+++ b/game/tests.py
@@ -341,7 +341,6 @@ class AIMoveTest(TestCase):
         self.assertIn('to_col', data['ai_move'])
 
 
-
 class OpeningBookTest(SimpleTestCase):
     """Unit tests for the opening-book integration in ChessGame."""
 


### PR DESCRIPTION
## Description

Integrates a chess opening book into the AI so it plays standard theory moves instantly during the first 4–5 moves, instead of running the expensive minimax search from move one. The book covers Ruy Lopez, Sicilian Defense, and Queen's Gambit. When multiple book moves are available, one is picked randomly for variety. If the position is not in the book, the AI falls back to the C++ minimax engine exactly as before.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #79 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

N/A — backend only change

## Additional Notes

- **Book format:** `game/engine/opening_book.json` — keys are minimal FEN strings (`board + side to move + castling rights`), values are lists of `[from_row, from_col, to_row, to_col]` moves.
- **36 positions / 93 moves** covering Ruy Lopez, Sicilian Defense, and Queen's Gambit (4–5 moves deep).
- Book is loaded once and cached at the class level — no repeated disk reads.
- Every book move is validated by the engine before being played — illegal book entries are automatically skipped.
- **14 new tests** added in `OpeningBookTest` covering FEN generation, book loading/caching, missing-file fallback, illegal-move filtering, move variety, and the fast/slow path in `get_ai_move()`.
- All 42 tests pass locally.


this change is additive