### PR TITLE
feat: Add Copy FEN button to copy board position (#83)

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -719,6 +719,36 @@
             console.error("Resign failed:", error);
         }
     };
+    function generateFEN() {
+    let fenRows = [];
+    for (let r = 0; r < 8; r++) {
+        let row = '';
+        let empty = 0;
+        for (let c = 0; c < 8; c++) {
+            const p = board[r][c];
+            if (!p) { empty++; }
+            else {
+                if (empty > 0) { row += empty; empty = 0; }
+                row += p;
+            }
+        }
+        if (empty > 0) row += empty;
+        fenRows.push(row);
+    }
+        const activeColor = turn === 'white' ? 'w' : 'b';
+        const movesList = movesEl.querySelectorAll('.move-row');
+        const fullMove = movesList.length + 1;
+        return `${fenRows.join('/')} ${activeColor} KQkq - 0 ${fullMove}`;
+    }
 
+    async function copyFEN() {
+        const fen = generateFEN();
+        await navigator.clipboard.writeText(fen);
+        showStatus('FEN copied to clipboard!', false);
+        setTimeout(() => showStatus('', false), 2000);
+    }
+
+    const copyFenBtn = document.getElementById('copyFenBtn');
+    if (copyFenBtn) copyFenBtn.onclick = copyFEN;
     loadGame();
 })();

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -680,6 +680,8 @@
             if (response.valid) {
                 gameOver = true;
                 paused = true;
+        
+                clearInterval(timerInterval);
 
                 const wName = document.getElementById('whiteNameLabel').textContent;
                 const bName = document.getElementById('blackNameLabel').textContent;

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -123,6 +123,7 @@
                 <div style="display: flex; flex-direction: column; gap: 8px;">
                     <button class="btn btn-gold" id="newPvPBtn">Pass & Play (PvP)</button>
                     <button class="btn btn-gold" id="newAIBtn">Play vs AI</button>
+                    <button class="btn btn-gold" id="copyFenBtn">Copy FEN</button>
                     <button class="btn btn-gold" id="drawBtn" style="display: none;">Offer Draw</button>
                 </div>
             </div>


### PR DESCRIPTION
---

## Description
Adds a "Copy FEN" button to the right panel that generates the current board position as a FEN string and copies it to the clipboard. A brief "FEN copied to clipboard!" message confirms the action.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Breaking change

## Related Issue
Fixes #83

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

## Screenshots (if applicable)
N/A

## Additional Notes
- Synced with upstream main after major refactor (CSS/JS now separated into static files)
- FEN generated from existing `board` JS array in `board.js`
- Active color derived from `turn` variable
- Castling set to `KQkq` as default for first version
- En passant hardcoded to `-` as per issue scope
- "Copy FEN" button added to right panel in `board.html`

---

