### PR TITLE
docs: update minimum Python version to 3.12 in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ Welcome to GSSoC! Here's how the contribution flow works for this project:
 
 | Tool | Version |
 |------|---------|
-| Python | ≥ 3.10 |
+| Python | ≥ 3.12 |
 | g++ | ≥ 11 (for C++ engine) |
 | pip | latest |
 


### PR DESCRIPTION
## Description

There was a version conflict where CONTRIBUTING.md stated Python ≥ 3.10 was required, while requirements.txt specified django>=6.0,<7.0, which strictly requires Python ≥ 3.12.

This PR updates the documentation to accurately reflect the codebase's true minimum requirement of Python 3.12, ensuring that fresh setups succeed without dependency resolution errors.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Related Issue

Fixes #157 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

N/A - Documentation only.

## Additional Notes

I verified locally that a fresh virtual environment using Python 3.12 successfully installs all dependencies via pip install -r requirements.txt without throwing the previous Django version error.
