### PR TITLE
fix: disable AI timer in PvE mode (fixes #158)

### DIFF
--- a/game/engine.py
+++ b/game/engine.py
@@ -404,7 +404,8 @@ class ChessGame:
         if elapsed > 0:
             if self.current_turn == 'white':
                 self.white_time = max(0, self.white_time - elapsed)
-            else:
+            elif self.mode != 'ai':
+                # In AI mode, don't deduct time from the AI's clock
                 self.black_time = max(0, self.black_time - elapsed)
 
         self.last_ts = now

--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -401,6 +401,23 @@ body {
     opacity: 0.4;
 }
 
+/* AI clock disabled in PvE mode */
+.clock.ai-disabled {
+    opacity: 0.35;
+    border-style: dashed;
+    border-color: #333;
+    background: #111122;
+}
+.clock.ai-disabled .time {
+    color: #5a5a7a;
+    font-size: 1.3rem;
+}
+.clock.ai-disabled .label::after {
+    content: ' (AI)';
+    font-size: 0.55rem;
+    opacity: 0.6;
+}
+
 /* Color hints */
 .clock.white .label { color: #ddd; }
 .clock.black .label { color: #aaa; }

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -419,7 +419,12 @@
 
         turnEl.className = 'turn-badge ' + turn;
         document.getElementById('whiteClock').classList.toggle('active', turn === 'white');
-        document.getElementById('blackClock').classList.toggle('active', turn === 'black');
+        // In AI mode, never highlight the AI clock as active
+        if (gameMode === 'ai') {
+            document.getElementById('blackClock').classList.remove('active');
+        } else {
+            document.getElementById('blackClock').classList.toggle('active', turn === 'black');
+        }
         
         markPlayable();
 
@@ -494,7 +499,14 @@
 
     function renderClocks() {
         document.querySelector('#whiteClock .time').textContent = fmt(whiteTime);
-        document.querySelector('#blackClock .time').textContent = fmt(blackTime);
+        const blackClockEl = document.getElementById('blackClock');
+        if (gameMode === 'ai') {
+            document.querySelector('#blackClock .time').textContent = '∞';
+            blackClockEl.classList.add('ai-disabled');
+        } else {
+            document.querySelector('#blackClock .time').textContent = fmt(blackTime);
+            blackClockEl.classList.remove('ai-disabled');
+        }
     }
 
     function updatePauseUI() {
@@ -506,7 +518,8 @@
         timerInterval = setInterval(() => {
             if (paused) return;
             if (turn==='white' && whiteTime>0) whiteTime--;
-            if (turn==='black' && blackTime>0) blackTime--;
+            // In AI mode, don't tick down the AI's clock
+            if (turn==='black' && blackTime>0 && gameMode !== 'ai') blackTime--;
             renderClocks();
         },1000);
     }

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -629,7 +629,12 @@
                 turnEl.textContent = turn === 'white' ? "White's Turn" : "Black's Turn";
                 turnEl.className = 'turn-badge ' + turn;
                 document.getElementById('whiteClock').classList.toggle('active', turn === 'white');
-                document.getElementById('blackClock').classList.toggle('active', turn === 'black');
+                // In AI mode, never highlight the AI clock as active
+                if (gameMode === 'ai') {
+                    document.getElementById('blackClock').classList.remove('active');
+                } else {
+                    document.getElementById('blackClock').classList.toggle('active', turn === 'black');
+                }
                 markPlayable();
                 if (!gameOver) {
                     document.title = (turn === 'white' ? 'White to Move - Checkora' : 'Black to Move - Checkora');
@@ -703,7 +708,14 @@
 
             function renderClocks() {
                 document.querySelector('#whiteClock .time').textContent = fmt(whiteTime);
-                document.querySelector('#blackClock .time').textContent = fmt(blackTime);
+                const blackClockEl = document.getElementById('blackClock');
+                if (gameMode === 'ai') {
+                    document.querySelector('#blackClock .time').textContent = '∞';
+                    blackClockEl.classList.add('ai-disabled');
+                } else {
+                    document.querySelector('#blackClock .time').textContent = fmt(blackTime);
+                    blackClockEl.classList.remove('ai-disabled');
+                }
             }
 
             function updatePauseUI() {
@@ -715,7 +727,8 @@
                 timerInterval = setInterval(() => {
                     if (paused) return;
                     if (turn === 'white' && whiteTime > 0) whiteTime--;
-                    if (turn === 'black' && blackTime > 0) blackTime--;
+                    // In AI mode, don't tick down the AI's clock
+                    if (turn === 'black' && blackTime > 0 && gameMode !== 'ai') blackTime--;
                     renderClocks();
                 }, 1000);
             }


### PR DESCRIPTION
## What this PR fixes

In PvE mode, the AI moves instantly, so its clock almost never decreases. After a few moves, the player ends up losing a noticeable amount of time while the AI still has almost its full clock. This makes the timer feel unfair and not very meaningful in this mode.

## What I changed

Instead of trying to artificially slow down the AI, I disabled the AI timer in PvE:

- The AI clock now shows ∞ instead of counting down  
- It’s visually dimmed and labeled as "(AI)" so it's clear it's inactive  
- Timer logic skips the AI’s clock when the game is in PvE mode  
- The same logic is applied on the backend to keep things consistent  

PvP mode is unchanged — both clocks still work normally there.

## Why this approach

Since the AI doesn’t actually “think” in real time, keeping a timer for it doesn’t add value. Adding delays would just be a workaround. Disabling the AI timer felt like a simpler and more honest solution.

## Testing

I tested this locally:

- In PvE: the player’s clock runs normally, and the AI clock stays at ∞  
- In PvP: both clocks behave exactly as before  

Everything seems to work as expected.