### PR TITLE
Fix: Board state not restored on browser back navigation

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -753,4 +753,7 @@
     const copyFenBtn = document.getElementById('copyFenBtn');
     if (copyFenBtn) copyFenBtn.onclick = copyFEN;
     loadGame();
+    window.addEventListener('pageshow', (event) => {
+    loadGame();
+});
 })();


### PR DESCRIPTION
## Description

Fixes an issue where the chessboard UI resets to the default position when navigating back using the browser Back button, while the backend session still holds the correct mid-game state.

This PR ensures the frontend always rehydrates the game state from the backend.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update

## Related Issue

Fixes #76

## Changes Made

* Added `pageshow` event listener to handle browser back/forward navigation
* Ensured `loadGame()` is triggered to fetch latest state from `/api/state/`
* Synced board position, turn, and timers with backend session
* Preserved existing auto-pause behavior on tab switch

## Testing

* Back navigation after multiple moves
* Page reload
* Tab switch (auto pause still works correctly)
* Verified no UI/backend desynchronization

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [ ] I have added tests (not applicable for this fix)
* [x] My changes generate no new warnings

## Additional Notes

This fix specifically addresses browser back/forward cache (bfcache) behavior to ensure consistent state restoration.
