### PR TITLE
Add .env.example and read SECRET_KEY, DEBUG from environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+SECRET_KEY=your-secret-key-here
+DEBUG=True
+DATABASE_URL=

--- a/README.md
+++ b/README.md
@@ -45,8 +45,19 @@ source venv/bin/activate     # macOS / Linux
 
 # 3. Install dependencies
 pip install -r requirements.txt
+
 # 4. Set up environment variables
+
+# Copy example env file
+
+# Windows (PowerShell)
+copy .env.example .env
+
+# macOS / Linux
 cp .env.example .env
+
+# Open `.env` and set SECRET_KEY if needed
+
 # 5. Run migrations and start the server
 python manage.py migrate
 python manage.py runserver

--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ source venv/bin/activate     # macOS / Linux
 
 # 3. Install dependencies
 pip install -r requirements.txt
-
-# 4. Run migrations and start the server
+# 4. Set up environment variables
+cp .env.example .env
+# 5. Run migrations and start the server
 python manage.py migrate
 python manage.py runserver
 ```

--- a/core/settings.py
+++ b/core/settings.py
@@ -12,7 +12,7 @@ https://docs.djangoproject.com/en/6.0/ref/settings/
 
 from pathlib import Path
 from dotenv import load_dotenv
-
+import os
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -24,10 +24,10 @@ load_dotenv(BASE_DIR / '.env')
 # See https://docs.djangoproject.com/en/6.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-xxp%6a$wd+upx#21yr%xz=o_o^@spzf%ozsp1i-lr!^bj%f6)4'
+SECRET_KEY = os.environ.get('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get('DEBUG', 'True') == 'True'
 
 ALLOWED_HOSTS = ['.vercel.app', '*']
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/6.0/ref/settings/
 from pathlib import Path
 from dotenv import load_dotenv
 import os
+import dj_database_url
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -76,7 +77,7 @@ WSGI_APPLICATION = 'core.wsgi.application'
 
 # Database
 # https://docs.djangoproject.com/en/6.0/ref/settings/#databases
-import dj_database_url
+ 
 
 DATABASES = {
     'default': dj_database_url.config(

--- a/core/settings.py
+++ b/core/settings.py
@@ -24,10 +24,10 @@ load_dotenv(BASE_DIR / '.env')
 # See https://docs.djangoproject.com/en/6.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
- SECRET_KEY = os.environ.get('SECRET_KEY', 'django-insecure-dev-key-for-local-testing')
+SECRET_KEY = os.environ.get('SECRET_KEY', 'django-insecure-dev-key-for-local-testing')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get('DEBUG', 'True') == 'True'
+DEBUG = os.environ.get('DEBUG', 'True').lower() == 'true'
 
 ALLOWED_HOSTS = ['.vercel.app', '*']
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -24,7 +24,7 @@ load_dotenv(BASE_DIR / '.env')
 # See https://docs.djangoproject.com/en/6.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get('SECRET_KEY')
+ SECRET_KEY = os.environ.get('SECRET_KEY', 'django-insecure-dev-key-for-local-testing')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get('DEBUG', 'True') == 'True'


### PR DESCRIPTION
Fixes #131

Apologies for raising this without being formally assigned — I opened 
this issue 6 hours ago and had the fix ready since then but the traffic 
on the issue concerned me so I wanted to make sure my work was visible.

Changes made:
-  Added import os to settings.py
- SECRET_KEY now reads from environment variable
-  DEBUG now reads from environment variable
- Added .env.example at project root
 - Verified .env is already gitignored
 - Tested locally, server runs fine

Happy to make any changes the maintainer suggests.