### PR TITLE
feat: Add FEN string support for new game

### DIFF
--- a/game/engine.py
+++ b/game/engine.py
@@ -104,6 +104,45 @@ class ChessGame:
         }
 
     @classmethod
+    def from_fen(cls, fen_string: str):
+        """Load a game state from a custom FEN string."""
+        game = cls()
+        
+        parts = fen_string.strip().split()
+        if len(parts) < 3:
+            raise ValueError("Invalid FEN string")
+            
+        placement, side, castling = parts[0], parts[1], parts[2]
+        
+        rows = placement.split('/')
+        if len(rows) != 8:
+            raise ValueError("Invalid FEN: must have 8 rows")
+            
+        board = []
+        for row in rows:
+            board_row = []
+            for char in row:
+                if char.isdigit():
+                    board_row.extend([None] * int(char))
+                else:
+                    board_row.append(char)
+            if len(board_row) != 8:
+                raise ValueError("Invalid FEN: row length must be 8")
+            board.append(board_row)
+            
+        game.board = board
+        game.current_turn = 'white' if side.lower() == 'w' else 'black'
+        
+        game.castling_rights = {
+            'w_k': 'K' in castling,
+            'w_q': 'Q' in castling,
+            'b_k': 'k' in castling,
+            'b_q': 'q' in castling
+        }
+        
+        return game
+
+    @classmethod
     def from_dict(cls, data):
         """Restore a game from a session dictionary."""
         game = cls.__new__(cls)

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -49,6 +49,8 @@
                     style="padding: 10px; border-radius: 5px; border: 1px solid #444; background: #1a1a2e; color: #fff;">
                 <input type="text" id="blackNameInput" placeholder="Black Player Name" 
                     style="padding: 10px; border-radius: 5px; border: 1px solid #444; background: #1a1a2e; color: #fff;">
+                <input type="text" id="fenInput" placeholder="Optional FEN string" 
+                    style="padding: 10px; border-radius: 5px; border: 1px solid #444; background: #1a1a2e; color: #fff;">
             </div>
 
             <div style="display: flex; flex-direction: column; gap: 14px;">
@@ -786,7 +788,19 @@
             }
 
             async function startNewGame(mode) {
-                const d = await post('/api/new-game/', { mode: mode });
+                const wName = document.getElementById('whiteNameInput')?.value || 'White';
+                const bName = document.getElementById('blackNameInput')?.value || 'Black';
+                const fen = document.getElementById('fenInput')?.value?.trim() || '';
+
+                const body = { mode: mode, white_name: wName, black_name: bName };
+                if (fen) body.fen = fen;
+
+                const d = await post('/api/new-game/', body);
+                if (!d.board) {
+                    showStatus(d.message || "Failed to start new game", true);
+                    return;
+                }
+
                 board = d.board;
                 turn = d.current_turn;
                 paused = false;

--- a/game/views.py
+++ b/game/views.py
@@ -104,7 +104,15 @@ def new_game(request):
     request.session['white_name'] = data.get('white_name', 'White')
     request.session['black_name'] = data.get('black_name', 'Black')
 
-    game = ChessGame()
+    fen = data.get('fen', '').strip()
+    if fen:
+        try:
+            game = ChessGame.from_fen(fen)
+        except ValueError:
+            return JsonResponse({'valid': False, 'message': 'Invalid FEN string.'}, status=400)
+    else:
+        game = ChessGame()
+
     game.mode = mode
 
     request.session['game'] = game.to_dict()


### PR DESCRIPTION
#  Add FEN-Based Game Initialization Support

##  Overview

This PR introduces support for initializing chess games using **FEN (Forsyth–Edwards Notation)** strings. It allows users to start a game from custom board positions instead of the default starting setup.

---

##  Changes Made

### 1. FEN Parsing Logic (`game/engine.py`)

- Added a new class method:

Closes #84 

```python
ChessGame.from_fen(fen_string)
