### PR TITLE
fix: resolve resign button crash due to missing #resignModal element …

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -665,62 +665,24 @@
         loadGame();
     }
 
-    window.showResignModal = function() {
-        document.getElementById('resignModal').style.display = 'flex';
-    };
-
-    window.closeResignModal = function() {
-        document.getElementById('resignModal').style.display = 'none';
-    };
-
-    window.confirmResign = async function() {
-        closeResignModal();
-        try {
-            const response = await post('/api/resign/');
-            if (response.valid) {
-                gameOver = true;
-                paused = true;
-        
-                clearInterval(timerInterval);
-
-                const wName = document.getElementById('whiteNameLabel').textContent;
-                const bName = document.getElementById('blackNameLabel').textContent;
-                const loserName = (turn === 'white' ? wName : bName);
-                const winnerName = (turn === 'white' ? bName : wName);
-                
-                const statusEl = document.getElementById('statusBar');
-                if (statusEl) {
-                    statusEl.textContent = `${loserName} resigned. ${winnerName} wins!`;
-                    statusEl.style.color = "#f0c040";
+    function resignGame() {
+        if (gameOver || paused) return;
+        showConfirm("Resign?", "Are you sure you want to resign?", async () => {
+            try {
+                const response = await post('/api/resign/');
+                if (response.valid) {
+                    handleGameOver('resign', turn);
                 }
-
-                document.getElementById('gameOverTitle').textContent = "Game Over";
-                document.getElementById('gameOverMessage').textContent = `${loserName} resigned. ${winnerName} wins!`;
-                document.getElementById('gameOverOverlay').style.display = 'flex';
-
-                document.getElementById('resignBtn').style.display = 'none';
-                document.getElementById('pauseBtn').style.display = 'none';
-                
-                document.getElementById('gameOverPvPBtn').onclick = async () => { 
-                    document.getElementById('gameOverOverlay').style.display = 'none';
-                    gameOver = false; 
-                    paused = false; 
-                    await startNewGame('pvp'); 
-                };
-
-                document.getElementById('gameOverAIBtn').onclick = async () => { 
-                    document.getElementById('gameOverOverlay').style.display = 'none';
-                    gameOver = false; 
-                    paused = false; 
-                    await startNewGame('ai'); 
-                };
-
-                await loadGame();
+            } catch (e) {
+                showStatus('Resign failed.', true);
             }
-        } catch (error) {
-            console.error("Resign failed:", error);
-        }
-    };
+        }, '#ff6b6b');
+    }
+
+    const resignBtnBoard = document.getElementById('resignBtnBoard');
+    const resignBtnPanel = document.getElementById('resignBtnPanel');
+    if (resignBtnBoard) resignBtnBoard.onclick = resignGame;
+    if (resignBtnPanel) resignBtnPanel.onclick = resignGame;
     function generateFEN() {
     let fenRows = [];
     for (let r = 0; r < 8; r++) {

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -114,7 +114,7 @@
             </div>
 
             <button id="pauseBtn" class="btn btn-gold">Pause</button>
-            <button id="resignBtn" class="btn btn-danger" onclick="showResignModal()">Resign</button>
+            <button id="resignBtnBoard" class="btn btn-danger">Resign</button>
 
             <div class="board-outer">
                 <div class="board-row">
@@ -158,7 +158,7 @@
                     <button class="btn btn-gold" id="newAIBtn">Play vs AI</button>
                     <button class="btn btn-gold" id="copyFenBtn">Copy FEN</button>
                     <button class="btn btn-gold" id="drawBtn" style="display: none;">Offer Draw</button>
-                    <button class="btn" id="resignBtn" style="background: #333; color: #fff;">Resign</button>
+                    <button class="btn" id="resignBtnPanel" style="background: #333; color: #fff;">Resign</button>
                 </div>
             </div>
             <div class="card">
@@ -286,7 +286,8 @@
             const gameOverPvPBtn = document.getElementById('gameOverPvPBtn');
             const gameOverAIBtn = document.getElementById('gameOverAIBtn');
 
-            const resignBtn = document.getElementById('resignBtn');
+            const resignBtnBoard = document.getElementById('resignBtnBoard');
+            const resignBtnPanel = document.getElementById('resignBtnPanel');
             const drawBtn = document.getElementById('drawBtn');
             const drawOverlay = document.getElementById('drawOverlay');
             const drawMessage = document.getElementById('drawMessage');
@@ -825,11 +826,21 @@
 
             if (pauseBtn) pauseBtn.onclick = () => paused ? resumeGame() : pauseGame();
 
-            if (resignBtn) resignBtn.onclick = () => {
-                if (!gameOver && !paused) {
-                    showConfirm("Resign?", "Are you sure you want to resign?", () => endGame('resign', turn));
-                }
-            };
+            function resignGame() {
+                if (gameOver || paused) return;
+                showConfirm("Resign?", "Are you sure you want to resign?", async () => {
+                    try {
+                        const response = await post('/api/resign/');
+                        if (response.valid) {
+                            endGame('resign', turn);
+                        }
+                    } catch (e) {
+                        showStatus('Resign failed.', true);
+                    }
+                }, '#ff6b6b');
+            }
+            if (resignBtnBoard) resignBtnBoard.onclick = resignGame;
+            if (resignBtnPanel) resignBtnPanel.onclick = resignGame;
 
             if (drawBtn) drawBtn.onclick = offerDraw;
             if (drawAcceptBtn) drawAcceptBtn.onclick = async () => {


### PR DESCRIPTION
…(#178)

- Remove reference to non-existent #resignModal DOM element

- Fix duplicate id='resignBtn' by renaming to resignBtnBoard and resignBtnPanel

- Replace orphaned showResignModal/closeResignModal/confirmResign functions

- Wire both resign buttons to use existing showConfirm() pattern with /api/resign/ call

- Add error handling for failed resign API calls

## Description

Brief description of the changes in this PR.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Related Issue

Fixes #178 


