### PR TITLE
Add fifty-move and threefold draw rules

### DIFF
--- a/game/engine.py
+++ b/game/engine.py
@@ -86,7 +86,8 @@ class ChessGame:
         }
         self.en_passant_target = None  # (row, col) of the square a pawn can capture en passant
         self.halfmove_clock = 0
-        self.repetition_counts = {self.generate_position_key(): 1}
+        self.repetition_history = [self.generate_position_key()]
+        self.repetition_counts = {self.repetition_history[0]: 1}
 
     def serialize_board(self):
         """Flatten the 2-D board into a 64-char string for the C++ engine."""
@@ -108,7 +109,7 @@ class ChessGame:
             'en_passant_target': self.en_passant_target,
             'player_color': self.player_color,
             'halfmove_clock': self.halfmove_clock,
-            'repetition_counts': self.repetition_counts,
+            'repetition_history': self.repetition_history,
         }
 
     @classmethod
@@ -129,11 +130,13 @@ class ChessGame:
         game.en_passant_target = data.get('en_passant_target', None)
         game.halfmove_clock = data.get('halfmove_clock', 0)
 
-        repetition_counts = data.get('repetition_counts')
-        if isinstance(repetition_counts, dict) and repetition_counts:
-            game.repetition_counts = repetition_counts
+        repetition_history = data.get('repetition_history')
+        if isinstance(repetition_history, list) and repetition_history:
+            game.repetition_history = repetition_history
         else:
-            game.repetition_counts = {game.generate_position_key(): 1}
+            game.repetition_history = [game.generate_position_key()]
+
+        game._rebuild_repetition_counts()
 
         game.valid_moves_cache = {}
         return game
@@ -215,9 +218,28 @@ class ChessGame:
 
     def _en_passant_key(self):
         """Return a compact en-passant key for repetition tracking."""
-        if not self.en_passant_target:
+        if not self._has_legal_en_passant_capture():
             return '-'
         return f"{self.en_passant_target[0]},{self.en_passant_target[1]}"
+
+    def _has_legal_en_passant_capture(self):
+        """Return True when the side to move can legally capture en passant."""
+        if not self.en_passant_target:
+            return False
+
+        target_row, target_col = self.en_passant_target
+        pawn_row = target_row + 1 if self.current_turn == 'white' else target_row - 1
+        pawn_piece = 'P' if self.current_turn == 'white' else 'p'
+
+        if not (0 <= pawn_row < 8):
+            return False
+
+        for delta_col in (-1, 1):
+            pawn_col = target_col + delta_col
+            if 0 <= pawn_col < 8 and self.board[pawn_row][pawn_col] == pawn_piece:
+                return True
+
+        return False
 
     def generate_position_key(self):
         """Build the full repetition key for the current board state."""
@@ -226,8 +248,16 @@ class ChessGame:
     def _update_repetition(self):
         """Increment and return the repetition count for the current position."""
         key = self.generate_position_key()
-        self.repetition_counts[key] = self.repetition_counts.get(key, 0) + 1
+        self.repetition_history.append(key)
+        self._rebuild_repetition_counts()
         return self.repetition_counts[key]
+
+    def _rebuild_repetition_counts(self):
+        """Rebuild the repetition counter from the stored history list."""
+        counts = {}
+        for key in self.repetition_history:
+            counts[key] = counts.get(key, 0) + 1
+        self.repetition_counts = counts
 
     # ------------------------------------------------------------------
     #  Public API
@@ -351,11 +381,24 @@ class ChessGame:
 
         self.last_ts = time.time()
 
-        repetition_count = self._update_repetition()
+        current_rights = self.serialize_castling_rights()
+        is_irreversible = is_pawn_move or bool(captured) or current_rights != rights_before
+        if is_irreversible:
+            self.repetition_history = [self.generate_position_key()]
+            self._rebuild_repetition_counts()
+        else:
+            repetition_count = self._update_repetition()
 
         # Check for checkmate / stalemate / check
         game_status = self.check_game_status()
-        
+
+        if game_status == 'checkmate':
+            return True, notation, captured, game_status
+
+        if game_status == 'stalemate':
+            return True, notation, captured, game_status
+
+        repetition_count = self.repetition_counts.get(self.generate_position_key(), 1)
         if self.halfmove_clock >= 100 or repetition_count >= 3:
             return True, notation, captured, 'draw'
 

--- a/game/engine.py
+++ b/game/engine.py
@@ -85,6 +85,8 @@ class ChessGame:
             'b_k': True, 'b_q': True
         }
         self.en_passant_target = None  # (row, col) of the square a pawn can capture en passant
+        self.halfmove_clock = 0
+        self.repetition_counts = {self.generate_position_key(): 1}
 
     def serialize_board(self):
         """Flatten the 2-D board into a 64-char string for the C++ engine."""
@@ -105,6 +107,8 @@ class ChessGame:
             'castling_rights': self.castling_rights,
             'en_passant_target': self.en_passant_target,
             'player_color': self.player_color,
+            'halfmove_clock': self.halfmove_clock,
+            'repetition_counts': self.repetition_counts,
         }
 
     @classmethod
@@ -123,6 +127,13 @@ class ChessGame:
         game.player_color = data.get('player_color', 'white')
         game.castling_rights = data.get('castling_rights', {'w_k': True, 'w_q': True, 'b_k': True, 'b_q': True})
         game.en_passant_target = data.get('en_passant_target', None)
+        game.halfmove_clock = data.get('halfmove_clock', 0)
+
+        repetition_counts = data.get('repetition_counts')
+        if isinstance(repetition_counts, dict) and repetition_counts:
+            game.repetition_counts = repetition_counts
+        else:
+            game.repetition_counts = {game.generate_position_key(): 1}
 
         game.valid_moves_cache = {}
         return game
@@ -202,6 +213,22 @@ class ChessGame:
             return "-1 -1"
         return f"{self.en_passant_target[0]} {self.en_passant_target[1]}"
 
+    def _en_passant_key(self):
+        """Return a compact en-passant key for repetition tracking."""
+        if not self.en_passant_target:
+            return '-'
+        return f"{self.en_passant_target[0]},{self.en_passant_target[1]}"
+
+    def generate_position_key(self):
+        """Build the full repetition key for the current board state."""
+        return f"{self.generate_fen_key()} {self._en_passant_key()}"
+
+    def _update_repetition(self):
+        """Increment and return the repetition count for the current position."""
+        key = self.generate_position_key()
+        self.repetition_counts[key] = self.repetition_counts.get(key, 0) + 1
+        return self.repetition_counts[key]
+
     # ------------------------------------------------------------------
     #  Public API
     # ------------------------------------------------------------------
@@ -232,6 +259,7 @@ class ChessGame:
             return False, "Black ran out of time", None, 'timeout'
 
         captured = self.board[tr][tc]
+        is_pawn_move = piece.lower() == 'p'
         board_before = self.serialize_board()
         rights_before = self.serialize_castling_rights()
         ep_before = self._serialize_ep()
@@ -297,6 +325,11 @@ class ChessGame:
         if captured:
             self.captured[self.current_turn].append(captured)
 
+        if is_pawn_move or captured:
+            self.halfmove_clock = 0
+        else:
+            self.halfmove_clock += 1
+
         notation = self._notation(fr, fc, tr, tc, piece, captured, board_before, rights_before, ep_before)
         if promoted and '=' not in notation:
             notation += '=' + (self.board[tr][tc] or 'Q').upper()
@@ -318,9 +351,14 @@ class ChessGame:
 
         self.last_ts = time.time()
 
+        repetition_count = self._update_repetition()
+
         # Check for checkmate / stalemate / check
         game_status = self.check_game_status()
         
+        if self.halfmove_clock >= 100 or repetition_count >= 3:
+            return True, notation, captured, 'draw'
+
         return True, notation, captured, game_status
 
     def get_valid_moves(self, row, col):

--- a/game/tests.py
+++ b/game/tests.py
@@ -317,6 +317,24 @@ class DrawRuleTest(SimpleTestCase):
         self.assertEqual(status, 'draw')
         self.assertEqual(game.halfmove_clock, 100)
 
+    def test_checkmate_beats_fifty_move_draw(self):
+        game = ChessGame()
+        game.halfmove_clock = 99
+
+        with mock.patch.object(ChessGame, '_call_engine') as mock_engine:
+            def fake_engine(cmd):
+                if cmd.startswith('NOTATION'):
+                    return 'NOTATION Nf3'
+                if cmd.startswith('STATUS'):
+                    return 'STATUS checkmate'
+                return None
+
+            mock_engine.side_effect = fake_engine
+            success, _, _, status = game.make_move(7, 6, 5, 5)
+
+        self.assertTrue(success)
+        self.assertEqual(status, 'checkmate')
+
     def test_threefold_repetition_triggers_draw(self):
         game = ChessGame()
 
@@ -337,6 +355,28 @@ class DrawRuleTest(SimpleTestCase):
             self.assertTrue(success)
 
         self.assertEqual(status, 'draw')
+
+    def test_session_round_trip_preserves_draw_state(self):
+        game = ChessGame()
+        game.halfmove_clock = 42
+        game.repetition_history.append('test-position')
+        game._rebuild_repetition_counts()
+
+        restored = ChessGame.from_dict(game.to_dict())
+
+        self.assertEqual(restored.halfmove_clock, 42)
+        self.assertEqual(restored.repetition_history, game.repetition_history)
+        self.assertEqual(restored.repetition_counts, game.repetition_counts)
+
+    def test_position_key_ignores_unusable_en_passant_square(self):
+        game = ChessGame()
+        game.make_move(6, 4, 4, 4)
+
+        with_ep = game.generate_position_key()
+        game.en_passant_target = None
+        without_ep = game.generate_position_key()
+
+        self.assertEqual(with_ep, without_ep)
 
 
 class AIMoveTest(TestCase):

--- a/game/tests.py
+++ b/game/tests.py
@@ -297,6 +297,48 @@ class PauseTest(TestCase):
         self.assertFalse(r2.json()['paused'])
 
 
+class DrawRuleTest(SimpleTestCase):
+    """Test rule-based draw detection in the engine."""
+
+    def setUp(self):
+        self.validate_patcher = mock.patch.object(ChessGame, 'validate_move', return_value=(True, 'ok'))
+        self.validate_patcher.start()
+
+    def tearDown(self):
+        self.validate_patcher.stop()
+
+    def test_fifty_move_rule_triggers_draw(self):
+        game = ChessGame()
+        game.halfmove_clock = 99
+
+        success, _, _, status = game.make_move(7, 6, 5, 5)
+
+        self.assertTrue(success)
+        self.assertEqual(status, 'draw')
+        self.assertEqual(game.halfmove_clock, 100)
+
+    def test_threefold_repetition_triggers_draw(self):
+        game = ChessGame()
+
+        sequence = [
+            (7, 6, 5, 5),
+            (0, 6, 2, 5),
+            (5, 5, 7, 6),
+            (2, 5, 0, 6),
+            (7, 6, 5, 5),
+            (0, 6, 2, 5),
+            (5, 5, 7, 6),
+            (2, 5, 0, 6),
+        ]
+
+        status = 'active'
+        for fr, fc, tr, tc in sequence:
+            success, _, _, status = game.make_move(fr, fc, tr, tc)
+            self.assertTrue(success)
+
+        self.assertEqual(status, 'draw')
+
+
 class AIMoveTest(TestCase):
     """Test the /api/ai-move/ endpoint."""
 


### PR DESCRIPTION
## Description

Adds backend support for rule-based draws in chess games. This PR implements the 50-move rule using a halfmove clock and detects threefold repetition using a position repetition map stored in session state. The logic now returns `draw` consistently when either rule is triggered, and unit tests cover both cases.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #125 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

N/A

## Additional Notes

Implemented on branch `feat/50move-threefold-draw`.  Full `game` test suite passes locally.