### PR TITLE
feat: implement load_from_fen and add FENLoaderTest 

### DIFF
--- a/game/engine.py
+++ b/game/engine.py
@@ -214,6 +214,31 @@ class ChessGame:
                 return True, "Valid move."
         return False, "Illegal move."
 
+    def load_from_fen(self, fen):
+        """Sets the board state and turn from a FEN string."""
+        try:
+            parts = fen.split(' ')
+            rows = parts[0].split('/')
+            
+            new_board = []
+            for row in rows:
+                board_row = []
+                for char in row:
+                    if char.isdigit():
+                        board_row.extend([None] * int(char))
+                    else:
+                        board_row.append(char)
+                new_board.append(board_row)
+            
+            self.board = new_board
+            if len(parts) > 1:
+                self.current_turn = 'white' if parts[1] == 'w' else 'black'
+            
+            self.valid_moves_cache = {}
+            return True
+        except Exception:
+            return False
+
     def make_move(self, fr, fc, tr, tc, promotion_piece=None):
         """Execute move and invalidate cache to ensure fresh calculations."""
         piece = self.board[fr][fc]

--- a/game/tests.py
+++ b/game/tests.py
@@ -533,3 +533,32 @@ class OpeningBookTest(SimpleTestCase):
         self.assertEqual(move['from_row'], 6)
         self.assertEqual(move['to_row'], 4)
         ChessGame._opening_book = None
+
+class FENLoaderTest(SimpleTestCase):
+    """Verify that the engine can load states from FEN strings correctly."""
+
+    def test_load_starting_position(self):
+        """Should correctly set up the board and turn for the start of a game."""
+        game = ChessGame()
+        # We manually change the turn to black first to make sure 
+        # the loader actually changes it back to white.
+        game.current_turn = 'black'
+        
+        start_fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq'
+        success = game.load_from_fen(start_fen)
+        
+        self.assertTrue(success)
+        self.assertEqual(game.current_turn, 'white')
+        self.assertEqual(game.board[0][0], 'r')  # Black rook at top-left
+        self.assertEqual(game.board[7][4], 'K')  # White king at bottom-middle
+
+    def test_load_mid_game_position(self):
+        """Should correctly set up a mid-game state."""
+        game = ChessGame()
+        # A FEN where it's black's turn
+        mid_fen = 'rnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR b KQkq'
+        success = game.load_from_fen(mid_fen)
+        
+        self.assertTrue(success)
+        self.assertEqual(game.current_turn, 'black')
+        self.assertEqual(game.board[3][2], 'p')  # The 'c5' pawn


### PR DESCRIPTION
## Description

This PR implements the load_from_fen method in engine.py. This allows the game state (board pieces and current turn) to be initialized from a standard FEN string.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)


## Related Issue

Fixes #203 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

Screenshots to demonstrate visual changes.
<img width="1022" height="362" alt="test" src="https://github.com/user-attachments/assets/10ba6582-f1f2-4d54-91e0-274f85af5e72" />
<img width="1029" height="441" alt="test-" src="https://github.com/user-attachments/assets/8f366efd-46ff-4d33-b1d7-24ce04765a49" />


## Additional Notes

The implementation currently handles piece placement and active color (turn). It serves as the foundation for future enhancements like castling rights and en passant parsing.
