### PR TITLE
 fix: ensure resume button is visible for AI game sessions

### DIFF
--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -440,8 +440,10 @@
 
                 if (modeBadge) modeBadge.textContent = gameMode === 'ai' ? 'VS AI' : 'PVP';
 
-                // Show Resume button if move history exists
-                if (data.move_history && data.move_history.length > 0) {
+                // Show Resume button if we have an ongoing game
+                const hasMoves = data.move_history && data.move_history.length > 0;
+                const isAI = data.mode === 'ai';
+                if (hasMoves || isAI) {
                     if (welcomeResumeBtn) welcomeResumeBtn.style.display = 'block';
                 } else {
                     if (welcomeResumeBtn) welcomeResumeBtn.style.display = 'none';


### PR DESCRIPTION
## Description

Ensures the "Resume Game" button is visible for AI game sessions even when no moves have been made.

Previously, the visibility logic relied solely on `move_history.length > 0`, which prevented users from resuming valid AI sessions if the page was refreshed early in the game.

---

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

---

## Related Issue

Fixes #223

---

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] I have commented my code where necessary
* [ ] I have updated the documentation if needed
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix/feature works
* [x] New and existing tests pass locally

---

## Screenshots (if applicable)

Attached in the issue thread showing:

<img width="1325" height="930" alt="image" src="https://github.com/user-attachments/assets/2bd3a1da-ea97-480e-8028-88871c6991aa" />
<img width="501" height="739" alt="image" src="https://github.com/user-attachments/assets/e2797c72-57fe-48ea-9eb4-e8dbac078ef0" />
<img width="1496" height="901" alt="image" src="https://github.com/user-attachments/assets/3b4ec178-84e5-428e-afca-12752c3ddc95" />

---

## Additional Notes

* Updated the condition controlling `welcomeResumeBtn` visibility
* Now checks for active game session (including AI mode) instead of relying only on move history

This ensures consistent session recovery behavior across all game states.
