### PR TITLE
fix: resolve AI move calculation stall on initialization and refresh

### DIFF
--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -457,6 +457,10 @@
                 renderClocks();
                 updatePauseUI();
                 startTimer();
+
+                if (gameMode === 'ai' && turn !== playerColor && !gameOver) {
+                    requestAIMove();
+                }
             }
 
             /* ==========================================================
@@ -933,6 +937,10 @@
                 updatePauseUI();
                 renderClocks();
                 startTimer();
+
+                if (gameMode === 'ai' && turn !== playerColor && !gameOver) {
+                    requestAIMove();
+                }
             }
 
             /* ==========================================================


### PR DESCRIPTION
## Description

Fixes an issue where the AI fails to trigger its move calculation during initial game load (when AI moves first) and after page refresh during the AI’s turn.

Previously, the UI displayed "AI is thinking..." but the backend move trigger (`requestAIMove`) was never invoked, leaving the game in a stalled state.

---

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

---

## Related Issue

Fixes #224

---

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] I have commented my code where necessary
* [ ] I have updated the documentation if needed
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix/feature works
* [x] New and existing tests pass locally

---


## Additional Notes

* Added a conditional check during game initialization and resume flow
* Ensures `requestAIMove()` is called when:

  * `gameMode === 'ai'`
  * Current turn does not match player color

This guarantees the AI move is triggered consistently on both initial load and restored sessions.
