### PR TITLE
feat: add selectable time controls (1/3/10/30 min) and timeout endgame

### DIFF
--- a/game/engine.py
+++ b/game/engine.py
@@ -67,15 +67,15 @@ class ChessGame:
     #  Construction / serialization
     # ------------------------------------------------------------------
 
-    def __init__(self):
+    def __init__(self, time_seconds=600):
         self.board = [row[:] for row in self.INITIAL_BOARD]
         self.current_turn = 'white'
         self.move_history = []
         self.captured = {'white': [], 'black': []}
         # DP Table: {(row, col): [list of moves]}
         self.valid_moves_cache = {}
-        self.white_time = 10 * 60  # 10 minutes
-        self.black_time = 10 * 60
+        self.white_time = time_seconds
+        self.black_time = time_seconds
         self.last_ts = time.time()
         self.paused = False
         self.mode = 'pvp'

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -51,6 +51,17 @@
                     style="padding: 10px; border-radius: 5px; border: 1px solid #444; background: #1a1a2e; color: #fff;">
             </div>
 
+            <div style="margin-bottom: 20px;">
+                <label style="color: #ccc; display: block; margin-bottom: 5px; font-size: 0.9rem; text-align: center;">Time Control</label>
+                <select id="welcomeTimeControl"
+                    style="width: 100%; padding: 10px; border-radius: 5px; border: 1px solid #444; background: #1a1a2e; color: #fff;">
+                    <option value="60">1 min (Bullet)</option>
+                    <option value="180">3 min (Blitz)</option>
+                    <option value="600" selected>10 min (Rapid)</option>
+                    <option value="1800">30 min (Classical)</option>
+                </select>
+            </div>
+
             <div id="modeSelection" style="display: flex; flex-direction: column; gap: 14px;">
                 <button class="btn btn-gold" id="welcomePvPBtn" style="padding: 12px; font-size: 1.05rem;">Pass & Play
                     (PvP)</button>
@@ -864,6 +875,11 @@
                     const winner = color === 'white' ? 'Black' : 'White';
                     title = 'Resignation';
                     message = `${color.charAt(0).toUpperCase() + color.slice(1)} resigned. ${winner} wins!`;
+                } else if (reason === 'timeout') {
+                    const loser = color === 'white' ? 'White' : 'Black';
+                    const winner = color === 'white' ? 'Black' : 'White';
+                    title = 'Time Up!';
+                    message = `${loser} is out of time. ${winner} wins!`;
                 }
 
                 gameOverTitle.textContent = title;
@@ -903,9 +919,14 @@
             function startTimer() {
                 clearInterval(timerInterval);
                 timerInterval = setInterval(() => {
-                    if (paused) return;
-                    if (turn === 'white' && whiteTime > 0) whiteTime--;
-                    if (turn === 'black' && blackTime > 0) blackTime--;
+                    if (paused || gameOver) return;
+                    if (turn === 'white') {
+                        if (whiteTime > 0) whiteTime--;
+                        if (whiteTime <= 0) endGame('timeout', 'white');
+                    } else {
+                        if (blackTime > 0) blackTime--;
+                        if (blackTime <= 0) endGame('timeout', 'black');
+                    }
                     renderClocks();
                 }, 1000);
             }
@@ -989,12 +1010,15 @@
                 const wName = document.getElementById('whiteNameInput')?.value || 'White';
                 const bName = document.getElementById('blackNameInput')?.value || 'Black';
 
+                const timeControl = parseInt(document.getElementById('welcomeTimeControl')?.value || '600');
+
                 const d = await post('/api/new-game/', {
                     mode: mode,
                     player_color: pColor,
                     white_name: wName,
                     black_name: bName,
-                    difficulty: difficulty
+                    difficulty: difficulty,
+                    time_control: timeControl
                 });
 
                 board = d.board;

--- a/game/views.py
+++ b/game/views.py
@@ -110,7 +110,9 @@ def new_game(request):
     request.session['difficulty'] = difficulty
     request.session['player_color'] = player_color
 
-    game = ChessGame()
+    time_control = int(data.get('time_control', 600))
+
+    game = ChessGame(time_seconds=time_control)
     game.mode = mode
     game.player_color = player_color
     game.paused = False


### PR DESCRIPTION
## Description

Adds selectable time controls and implements timeout-based game termination.

Previously, the game used a fixed 10-minute timer with no flexibility and no handling when a player's time expired.

---

## What’s Changed

### Backend

* `ChessGame` now accepts dynamic `time_seconds` instead of a hardcoded value
* `new_game` reads `time_control` from request and initializes accordingly

### Frontend

* Added time control dropdown (1, 3, 10, 30 minutes) in welcome modal
* Updated `startNewGame()` to send selected time to backend
* Timer now detects when time reaches zero and triggers `endGame('timeout', color)`

### UI

* Added "Time Up!" overlay displaying winner and loser

---

## Testing

* Verified all time options (1/3/10/30 min) initialize correctly
* Verified timer countdown works for both players
* Verified game ends immediately on timeout
* Verified correct winner/loser display

---
<img width="427" height="586" alt="image" src="https://github.com/user-attachments/assets/4f13cd9d-e268-4539-9138-22bbef330fea" />


<img width="413" height="576" alt="image" src="https://github.com/user-attachments/assets/0046839f-0c6e-4c0b-87d3-d019c0684767" />

<img width="1310" height="915" alt="image" src="https://github.com/user-attachments/assets/17a9bd72-5eef-4c17-b643-3e50e91ca3c4" />


## Related Issue
