### PR TITLE
views: use secrets module for OTP generation instead of random.

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -3,7 +3,7 @@
 import json
 import time
 import hashlib
-import random
+import secrets
 
 from django.conf import settings
 from django.http import JsonResponse
@@ -346,7 +346,7 @@ def register_view(request):
             user.save()
 
             # Generate 6-digit OTP
-            otp = str(random.randint(100000, 999999))
+            otp = str(secrets.randbelow(900000) + 100000)
             request.session['registration_user_id'] = user.id
             # Hash OTP with SECRET_KEY as salt to prevent reading from signed cookies
             otp_hash = hashlib.sha256(f"{otp}:{settings.SECRET_KEY}".encode()).hexdigest()


### PR DESCRIPTION
random.randint isn't cryptographically secure — given enough observed OTPs
the output becomes predictable. python's secrets module is the right tool
for this, backed by a CSPRNG.

swapped the import (random isn't used anywhere else in views.py) and
replaced the call. same 100000-999999 range, different entropy source.