### PR TITLE
views: sanitize registration error message, log SMTP details server-side.

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -3,7 +3,10 @@
 import json
 import time
 import hashlib
+import logging
 import random
+
+logger = logging.getLogger(__name__)
 
 from django.conf import settings
 from django.http import JsonResponse
@@ -395,13 +398,13 @@ def register_view(request):
                 )
                 return redirect('verify_otp')
             except Exception as e:
-                # If email fails, delete the user so they can try again
+                logger.error('failed to send OTP email: %s', e)
                 user.delete()
-                err_msg = (
-                    f'Failed to send OTP email: {str(e)}. '
-                    'Please check your email address and try again.'
+                messages.error(
+                    request,
+                    'couldn\'t send the verification email. '
+                    'please check your address and try again.'
                 )
-                messages.error(request, err_msg)
     else:
         form = CustomUserCreationForm()
     


### PR DESCRIPTION
views.py was building error messages with str(e), which dumps the raw SMTP
error string into the user-facing response. depending on what fails, this
exposes the email host, port, auth method, or even the backend password.

replaced with a generic message and moved the actual error to python's
logging module. same information, just not in the user's browser.