### PR TITLE
core: add HttpOnly, Secure, SameSite flags to session cookies.

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -133,6 +133,9 @@ STATICFILES_DIRS = [
 STATIC_ROOT = BASE_DIR / "staticfiles"
 
 SESSION_ENGINE = 'django.contrib.sessions.backends.signed_cookies'
+SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_SECURE = not DEBUG
+SESSION_COOKIE_SAMESITE = 'Lax'
 
 # Email Configuration for OTP
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'


### PR DESCRIPTION
SESSION_ENGINE is signed_cookies but no cookie flags were set. without
HttpOnly, any XSS can read the session token. without Secure, it gets sent
over plain HTTP. without SameSite, it ships on cross-site requests.

SECURE is gated on `not DEBUG` so local dev over HTTP still works.
didn't add SECURE_SSL_REDIRECT — that should be handled at the reverse
proxy / Vercel level, not in Django, since Vercel terminates TLS.