### PR TITLE
views: validate and sanitize player names before storing in session.

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -104,8 +104,18 @@ def new_game(request):
     
     player_color = data.get('player_color', 'white')
 
-    request.session['white_name'] = data.get('white_name', 'White')
-    request.session['black_name'] = data.get('black_name', 'Black')
+    def _clean_name(raw, fallback):
+        name = (raw or '').strip()
+        if not name or len(name) > 30:
+            return fallback
+        return name
+
+    request.session['white_name'] = _clean_name(
+        data.get('white_name'), 'White'
+    )
+    request.session['black_name'] = _clean_name(
+        data.get('black_name'), 'Black'
+    )
     player_color = data.get('player_color', 'white')
     request.session['difficulty'] = difficulty
     request.session['player_color'] = player_color


### PR DESCRIPTION
white_name and black_name come straight from the POST body and get dumped
into the session as-is. empty strings, whitespace-only names, and
absurdly long inputs all get accepted — then rendered in the UI.

added a _clean_name helper that strips whitespace, rejects empty strings
and names longer than 30 chars, and falls back to 'White'/'Black' if
validation fails. frontend still gets the cleaned name back in the
response so it can update the display.