### PR TITLE
views: rotate session key after login to prevent session fixation.

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -435,6 +435,7 @@ def verify_otp(request):
                 del request.session['registration_otp_hash']
 
                 login(request, user)
+                request.session.cycle_key()
                 return redirect('index')
             except User.DoesNotExist:
                 messages.error(
@@ -456,6 +457,7 @@ def login_view(request):
         if form.is_valid():
             user = form.get_user()
             login(request, user)
+            request.session.cycle_key()
             return redirect('index')
     else:
         form = AuthenticationForm()


### PR DESCRIPTION
both login paths (OTP verify and regular login) call django's login() but
never rotate the session key. an attacker who plants a known session ID on
a victim gets full access because the key stays the same after login.

added request.session.cycle_key() after each login() call — django creates
a new session key and invalidates the old one. one line per login path,
no dependencies.