### PR TITLE
views: validate and sanitize player names before storing in session.

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -104,8 +104,18 @@ def new_game(request):
     
     player_color = data.get('player_color', 'white')
 
-    request.session['white_name'] = data.get('white_name', 'White')
-    request.session['black_name'] = data.get('black_name', 'Black')
+    def _clean_name(raw, fallback):
+        name = (raw or '').strip()
+        if not name or len(name) > 30:
+            return fallback
+        return name
+
+    request.session['white_name'] = _clean_name(
+        data.get('white_name'), 'White'
+    )
+    request.session['black_name'] = _clean_name(
+        data.get('black_name'), 'Black'
+    )
     player_color = data.get('player_color', 'white')
     request.session['difficulty'] = difficulty
     request.session['player_color'] = player_color


### PR DESCRIPTION
## Description

white_name and black_name come straight from the POST body and get
dumped into the session as-is. empty strings, whitespace-only names,
and absurdly long inputs all get accepted — then rendered in the UI
(player labels, move history, timer display).

added a _clean_name helper in new_game() that strips whitespace,
rejects empty strings and names longer than 30 chars, and falls back
to 'White'/'Black' if validation fails. frontend still gets the
cleaned name back in the response so the display stays consistent.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #220

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

n/a — backend-only change.

## Additional Notes

session test in the existing suite still passes — the default
values ('White'/'Black') mean existing flows that don't pass names
behave identically. only the validation path changes for bad input.