### PR TITLE
views: use secrets module for OTP generation instead of random.

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -3,7 +3,7 @@
 import json
 import time
 import hashlib
-import random
+import secrets
 
 from django.conf import settings
 from django.http import JsonResponse
@@ -346,7 +346,7 @@ def register_view(request):
             user.save()
 
             # Generate 6-digit OTP
-            otp = str(random.randint(100000, 999999))
+            otp = str(secrets.randbelow(900000) + 100000)
             request.session['registration_user_id'] = user.id
             # Hash OTP with SECRET_KEY as salt to prevent reading from signed cookies
             otp_hash = hashlib.sha256(f"{otp}:{settings.SECRET_KEY}".encode()).hexdigest()


### PR DESCRIPTION
## Description

otp generation in views.py:349 uses random.randint(), which isn't
cryptographically secure — the output becomes predictable if an
attacker observes enough OTPs. python's secrets module is the right
tool for this, backed by a CSPRNG.

swapped the import (random isn't used anywhere else in views.py) and
replaced the call. same 100000-999999 range, different entropy source.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #217

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

n/a — backend-only change.

## Additional Notes

verified random isn't imported or used anywhere else in views.py after
the swap, so this is a clean 1-for-1 replacement with no side effects.