### PR TITLE
views: sanitize registration error message, log SMTP details server-side.

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -3,7 +3,10 @@
 import json
 import time
 import hashlib
+import logging
 import random
+
+logger = logging.getLogger(__name__)
 
 from django.conf import settings
 from django.http import JsonResponse
@@ -395,13 +398,13 @@ def register_view(request):
                 )
                 return redirect('verify_otp')
             except Exception as e:
-                # If email fails, delete the user so they can try again
+                logger.error('failed to send OTP email: %s', e)
                 user.delete()
-                err_msg = (
-                    f'Failed to send OTP email: {str(e)}. '
-                    'Please check your email address and try again.'
+                messages.error(
+                    request,
+                    'couldn\'t send the verification email. '
+                    'please check your address and try again.'
                 )
-                messages.error(request, err_msg)
     else:
         form = CustomUserCreationForm()
     


### PR DESCRIPTION
## Description

views.py:400-404 — when sending the OTP email fails, the error handler
builds a message with str(e), which dumps the raw SMTP error string
into the user-facing response. depending on what fails, this can
expose the email host, port, auth method, or even the backend password.

replaced with a generic user-facing message and moved the actual error
to python's logging module. same information, just not in the user's
browser.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #218

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

n/a — backend-only change.

## Additional Notes

the user-deleted-on-error flow stays the same — if the email fails, the
incomplete user account still gets deleted so they can re-register.
only the message they see changed.