### PR TITLE
core: add HttpOnly, Secure, SameSite flags to session cookies.

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -133,6 +133,9 @@ STATICFILES_DIRS = [
 STATIC_ROOT = BASE_DIR / "staticfiles"
 
 SESSION_ENGINE = 'django.contrib.sessions.backends.signed_cookies'
+SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_SECURE = not DEBUG
+SESSION_COOKIE_SAMESITE = 'Lax'
 
 # Email Configuration for OTP
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'


### PR DESCRIPTION
## Description

settings.py:135 sets SESSION_ENGINE to signed_cookies but doesn't
configure any cookie security flags. without HttpOnly, any XSS can
read the session token. without Secure, it gets sent over plain HTTP.
without SameSite, it ships on cross-site requests.

added SESSION_COOKIE_HTTPONLY, SESSION_COOKIE_SECURE, and
SESSION_COOKIE_SAMESITE. SECURE is gated on `not DEBUG` so local dev
over HTTP still works.

didn't add SECURE_SSL_REDIRECT — that should be handled at the reverse
proxy / Vercel level, not in Django, since Vercel terminates TLS.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #219

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

n/a — backend-only change.

## Additional Notes

gated SESSION_COOKIE_SECURE on `not DEBUG` instead of a separate env
var — keeps it simple and already works with the existing DEBUG setup
from PR #168.