### PR TITLE
Fix mobile header layout overlapping

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -434,6 +434,8 @@ body {
         gap: 10px;
         flex-wrap: wrap;
         justify-content: center;
+        flex-wrap: wrap;
+        justify-content: center;
     }
 
     .game-layout {

--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -432,6 +432,8 @@ body {
         right: auto;
         top: auto;
         gap: 10px;
+        flex-wrap: wrap;
+        justify-content: center;
     }
 
     .game-layout {

--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -416,10 +416,22 @@ body {
 
     .header {
         padding: 16px 0 10px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 12px;
     }
 
     .header h1 {
         font-size: 1.5rem;
+        margin: 0;
+    }
+
+    .auth-buttons {
+        position: relative;
+        right: auto;
+        top: auto;
+        gap: 10px;
     }
 
     .game-layout {


### PR DESCRIPTION
## Description

Fixes the mobile view header where elements were cluttered and overlapping. 
Modified the CSS media query for mobile (`max-width: 768px`) to change the header to a flex column layout and override the absolute positioning of the authentication buttons. 

Closes #249

## Changes

- In `game/static/game/css/board.css`, added a flex-column layout to `.header` under the mobile media query.
- Overrode `position: absolute` for `.auth-buttons` in mobile view by setting `position: relative`, `top: auto`, and `right: auto`, along with some gap adjustments to stack neatly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Verified that the header elements ("Checkora VS AI", "Sign In", "Register") stack cleanly and do not overlap at screen sizes `<= 768px` while ensuring desktop styling remains completely unaffected.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked that the code does not break any existing tests or functionality
 Updatd:UI
 
<img width="376" height="795" alt="Screenshot 2026-05-04 145723" src="https://github.com/user-attachments/assets/65d45ab6-ae01-4267-9878-9d7d8c07e8d0" />
