### PR TITLE
fix: rotate session key after login to prevent session fixation

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -439,7 +439,9 @@ def verify_otp(request):
                 del request.session['registration_otp_hash']
 
                 login(request, user)
+                request.session.cycle_key()  
                 return redirect('index')
+            
             except User.DoesNotExist:
                 messages.error(
                     request, 'User not found. Please register again.'
@@ -460,7 +462,9 @@ def login_view(request):
         if form.is_valid():
             user = form.get_user()
             login(request, user)
+            request.session.cycle_key()  
             return redirect('index')
+        
     else:
         form = AuthenticationForm()
 


### PR DESCRIPTION
## Description
Added `request.session.cycle_key()` after `login()` in both `verify_otp` and `login_view` to prevent session fixation attacks. Without this, an attacker who plants a known session ID on a victim's browser retains access after the victim logs in.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issue
Fixes #221 

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings

## Additional Notes
Two one-line additions, no dependencies, no behavioural change for the user. Session data is fully preserved across the key rotation.