### PR TITLE
fix: remove AI timer in PvE mode, show robot icon instead

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -181,6 +181,25 @@
                 renderClocks();
                 updatePauseUI();
                 startTimer();
+                if (gameMode === 'ai') {
+            const aiClock = playerColor === 'white' ?
+                document.getElementById('blackClock') :
+                document.getElementById('whiteClock');
+            const aiTimeEl = playerColor === 'white' ?
+                document.getElementById('blackTime') :
+                document.getElementById('whiteTime');
+
+            if (aiClock) {
+                aiClock.style.border = '2px dashed #444';
+                aiClock.style.boxShadow = 'none';
+                aiClock.classList.remove('active');
+            }
+            if (aiTimeEl) {
+                aiTimeEl.textContent = '🤖';
+                aiTimeEl.style.fontSize = '1.8em';
+                aiTimeEl.style.color = '#888';
+            }
+        }
             }
 
             function updatePlayerNames(data) {
@@ -638,14 +657,31 @@
             function renderClocks() {
                 const wTime = document.getElementById('whiteTime');
                 const bTime = document.getElementById('blackTime');
-                if (wTime) wTime.textContent = formatTime(whiteTime);
-                if (bTime) bTime.textContent = formatTime(blackTime);
+                
 
                 const whiteClock = document.getElementById('whiteClock');
                 const blackClock = document.getElementById('blackClock');
-                if (whiteClock) whiteClock.classList.toggle('active', turn === 'white');
-                if (blackClock) blackClock.classList.toggle('active', turn === 'black');
+                if (gameMode === 'ai') {
+        const playerClock = playerColor === 'white' ? whiteClock : blackClock;
+        const playerTimeEl = playerColor === 'white' ? wTime : bTime;
+        const aiClock = playerColor === 'white' ? blackClock : whiteClock;
+        const aiTimeEl = playerColor === 'white' ? bTime : wTime;
 
+        // Player clock — update time and highlight on their turn
+        if (playerTimeEl) playerTimeEl.textContent = formatTime(playerColor === 'white' ? whiteTime : blackTime);
+        if (playerClock) playerClock.classList.toggle('active', turn === playerColor);
+
+        // AI clock — static, never highlights, never updates time
+        if (aiTimeEl) aiTimeEl.textContent = '🤖';
+        if (aiClock) aiClock.classList.remove('active');
+
+    } else {
+        // PvP — both clocks update normally
+        if (wTime) wTime.textContent = formatTime(whiteTime);
+        if (bTime) bTime.textContent = formatTime(blackTime);
+        if (whiteClock) whiteClock.classList.toggle('active', turn === 'white');
+        if (blackClock) blackClock.classList.toggle('active', turn === 'black');
+    }
                 const wYou = document.getElementById('whiteYouTag');
                 const bYou = document.getElementById('blackYouTag');
                 if (wYou) wYou.style.display = (gameMode === 'ai' && playerColor === 'white') ? 'inline' : 'none';


### PR DESCRIPTION
## Description
In AI vs Player mode, the AI's timer was frozen at 10:00 the entire game 
while the human's timer counted down normally. This created an unfair and confusing display for the player.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issue
Fixes #158 

## What Changed
- `startTimer()` — AI clock no longer decrements in PvE mode, only the human player's clock counts down
- `renderClocks()` — AI clock shows 🤖 icon with dashed border instead of a countdown timer
- Fix works correctly regardless of whether the user picks white or black

## Screenshots
<img width="779" height="642" alt="image" src="https://github.com/user-attachments/assets/2ccc620c-77a0-4a1a-97d6-8793c9f54d85" />


<img width="756" height="636" alt="image" src="https://github.com/user-attachments/assets/0391cb35-3e68-4225-bdf8-7fbd2ef9b516" />
