### PR TITLE
fix: move history and last-move highlight not cleared after new game (#140)

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1407,7 +1407,11 @@
                 const mode = document.querySelector('input[name="go_mode"]:checked').value;
                 const diff = document.getElementById('goDifficultySelect').value;
                 gameOverOverlay.classList.remove('active');
-                startNewGame(mode, 'white', diff);
+                if (mode === 'ai') {
+                    showSideSelectionModal(side => startNewGame('ai', side, diff));
+                } else {
+                    startNewGame('pvp');
+                }
             };
 
             // Theme Switcher

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1153,6 +1153,9 @@
                 gameOver = false;
                 gameMode = d.mode;
                 playerColor = d.player_color || 'white';
+                lastMove = null;
+                selected = null;
+                hints = [];
                 
                 if (gameMode === 'ai') {
                     flipped = (playerColor === 'black');
@@ -1161,14 +1164,20 @@
                 }
 
                 if (modeBadge) modeBadge.textContent = gameMode === 'ai' ? 'VS AI' : 'PVP';
+                lastMove = null;
+                selected = null;
+                hints = [];
                 movesEl.innerHTML = '<span class="placeholder">No moves yet</span>';
                 wCapEl.innerHTML = bCapEl.innerHTML = '';
 
-                await loadGame();
-                // Apply active state after UI reload
-                updateModeButtonsUI(gameMode);
+                updateMoves([]);
+                updateCaptured({ white: [], black: [] });
+                updateTurn();
+                buildBoard();
+                renderClocks();
                 paused = false;
                 updatePauseUI();
+                startTimer();
 
                 // Auto-trigger AI if it's their turn
                 if (gameMode === 'ai' && turn !== playerColor) {
@@ -1398,19 +1407,7 @@
                 const mode = document.querySelector('input[name="go_mode"]:checked').value;
                 const diff = document.getElementById('goDifficultySelect').value;
                 gameOverOverlay.classList.remove('active');
-                gameOverOverlay.classList.remove('game-over-celebration');
-                
-                // Add this: Clear confetti container
-                const confettiContainer = gameOverOverlay.querySelector('.confetti-container');
-                if (confettiContainer) {
-                    confettiContainer.remove();
-                }
-                
-                if (mode === 'ai') {
-                    showSideSelectionModal(side => startNewGame(mode, side, diff));
-                } else {
-                    startNewGame(mode, 'white', diff);
-                }
+                startNewGame(mode, 'white', diff);
             };
 
             // Theme Switcher


### PR DESCRIPTION
Fixes #140

## Problem

After resigning and starting a new game:

* previous move history was still visible
* last move yellow highlight was still remaining on the fresh board

## Root Cause

* `lastMove` state was not reset during new game initialization
* `startNewGame()` flow was reloading stale previous session state
* incorrect argument order caused inconsistent restart behavior from game over screen

## Fix

* reset `lastMove`, `selected`, and `hints` on new game start
* removed stale state re-render during restart flow
* passed correct parameters to `startNewGame()` from game over start button

## Verification

Manually tested by:

* playing a few moves
* resigning the game
* starting a new game

Confirmed that:

* move history starts empty
* no previous last-move highlight remains
* fresh board loads correctly