### PR TITLE
refactor: Move CustomUserCreationForm to forms.py.

### DIFF
--- a/game/forms.py
+++ b/game/forms.py
@@ -1,0 +1,8 @@
+from django import forms
+from django.contrib.auth.forms import UserCreationForm
+
+class CustomUserCreationForm(UserCreationForm):
+    email = forms.EmailField(required=True)
+
+    class Meta(UserCreationForm.Meta):
+        fields = UserCreationForm.Meta.fields + ('email',)

--- a/game/views.py
+++ b/game/views.py
@@ -10,10 +10,11 @@ from django.http import JsonResponse
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth import login, logout
 from django.contrib.auth.models import User
-from django.contrib.auth.forms import UserCreationForm, AuthenticationForm
+from django.contrib.auth.forms import AuthenticationForm
 from django.core.mail import send_mail
 from django.contrib import messages
 from django import forms
+from .forms import CustomUserCreationForm
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_GET, require_POST
 
@@ -330,13 +331,6 @@ def resign_game(request):
         'winner': winner,
         'game_status': game_status
     })
-
-class CustomUserCreationForm(UserCreationForm):
-    email = forms.EmailField(required=True)
-
-    class Meta(UserCreationForm.Meta):
-        fields = UserCreationForm.Meta.fields + ('email',)
-
 
 def register_view(request):
     if request.user.is_authenticated:


### PR DESCRIPTION
## Description

This PR reorganizes the codebase by moving the `CustomUserCreationForm` out of `game/views.py` into a dedicated `game/forms.py` file.

While working through the project, I noticed that the form logic was defined directly inside `views.py`. Although it works, this approach can make the file harder to read and maintain as the project grows. In Django projects, it’s generally a best practice to keep forms in a separate `forms.py` file to maintain a clear separation of concerns.

By moving the form into its own file, this change:

* Keeps `views.py` cleaner and more focused on handling requests
* Aligns the project structure with standard Django conventions
* Makes the code easier to navigate and extend in the future

All imports have been updated accordingly, and this refactor does not change any existing functionality.

---

## Type of Change

* [ ] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Documentation update

---

## Related Issue

N/A

---

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] I have commented my code where necessary
* [x] I have updated the documentation if needed
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix/feature works
* [x] New and existing tests pass locally

---

## Screenshots (if applicable)

N/A

---

## Additional Notes

This is a small structural improvement aimed at keeping the codebase clean and maintainable as it evolves. It does not introduce any functional changes.
This contribution is part of GSSoC.
