### PR TITLE
ui: Fix visual feedback for selected game mode buttons.

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -349,6 +349,13 @@ body {
     background: linear-gradient(135deg, #f0c040, #d4a020);
     color: #1a1a2e;
 }
+/* Highlight selected game mode button */
+.active-mode {
+    background: #facc15 !important;
+    color: #000 !important;
+    transform: scale(1.05);
+    border: 2px solid #facc15;
+}
 .btn-gold:hover {
     background: linear-gradient(135deg, #f5cc55, #e0b030);
     transform: translateY(-1px);

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -31,9 +31,8 @@
                 const aiBtn = document.getElementById("newAIBtn");
 
                 if (!pvpBtn || !aiBtn) return;
-
-                    pvpBtn.classList.remove("active-mode");
-                    aiBtn.classList.remove("active-mode");
+                pvpBtn.classList.remove("active-mode");
+                aiBtn.classList.remove("active-mode");
 
                 if (mode === "pvp") {
                     pvpBtn.classList.add("active-mode");

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -31,6 +31,7 @@
                 const aiBtn = document.getElementById("newAIBtn");
 
                 if (!pvpBtn || !aiBtn) return;
+                
                 pvpBtn.classList.remove("active-mode");
                 aiBtn.classList.remove("active-mode");
 

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -25,6 +25,22 @@
             let pendingPromo = null;
 
             let gameMode = 'pvp';
+            // Updates UI to highlight selected game mode button
+            function updateModeButtonsUI(mode) {
+                const pvpBtn = document.getElementById("newPvPBtn");
+                const aiBtn = document.getElementById("newAIBtn");
+
+                if (!pvpBtn || !aiBtn) return;
+
+                    pvpBtn.classList.remove("active-mode");
+                    aiBtn.classList.remove("active-mode");
+
+                if (mode === "pvp") {
+                    pvpBtn.classList.add("active-mode");
+                } else {
+                    aiBtn.classList.add("active-mode");
+                }
+            }
             let playerColor = 'white';
             let flipped = false;
             let autoFlip = false;
@@ -147,6 +163,8 @@
                 paused = data.paused;
 
                 gameMode = data.mode || 'pvp';
+                // Sync UI with current game mode
+                updateModeButtonsUI(gameMode);
                 playerColor = data.player_color || 'white';
                 
                 if (flipControls) {
@@ -771,6 +789,8 @@
                 wCapEl.innerHTML = bCapEl.innerHTML = '';
 
                 await loadGame();
+                // Apply active state after UI reload
+                updateModeButtonsUI(gameMode);
                 paused = false;
                 updatePauseUI();
 


### PR DESCRIPTION
## Description

This PR fixes the issue where the game mode buttons ("Pass & Play" and "Play vs AI") were not showing any visual indication when selected.
Earlier, both buttons looked the same even after clicking, which made it unclear which mode was active. To fix this, I added a simple UI update so that the selected mode is clearly highlighted.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #176

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

## Screenshots (if applicable)
Before the changes both buttons looked identical with no indication of selection.
<img width="901" height="880" alt="Screenshot from 2026-05-04 23-48-13" src="https://github.com/user-attachments/assets/22f28761-e564-4df5-be16-c27259249a8a" />
 
---
After the changes made the selected game mode button is highlighted and only one remains active at a time.
<img width="1056" height="765" alt="Screenshot from 2026-05-05 00-31-07" src="https://github.com/user-attachments/assets/037b4269-77ab-4d1a-8982-0ba8729edd04" />



## Additional Notes

I handled this by introducing a small UI helper function (updateModeButtonsUI) that syncs the button state with the `gameMode` variable.
Also ensured the UI updates:

* on initial load (loadGame)
* when a new game mode is selected (startNewGame)

No backend changes were required for this fix.

