### PR TITLE
fix: Game-over restart passes difficulty as player_color

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -718,7 +718,7 @@
                     "Your current progress will be lost.<br>Are you sure you want to start a new game?",
                     () => {
                         const diff = document.getElementById('confirmDifficultySelect').value;
-                        startNewGame(mode, diff);
+                        startNewGame(mode, 'white', diff);
                     },
                     '#ff6b6b'
                 );
@@ -885,7 +885,7 @@
                 const mode = document.querySelector('input[name="go_mode"]:checked').value;
                 const diff = document.getElementById('goDifficultySelect').value;
                 gameOverOverlay.classList.remove('active');
-                startNewGame(mode, diff);
+                startNewGame(mode, 'white', diff);
             };
 
             // Theme Switcher


### PR DESCRIPTION
## Description

`startNewGame(mode, pColor, difficulty)` expects `player_color` as the second argument, but both the **Game Over** restart button and the **Abandon Game** confirm dialog pass `difficulty` as the second argument instead:

```js
// Before (broken) — difficulty goes into pColor
startNewGame(mode, diff);

// After (fixed) — explicit 'white' for pColor, difficulty as third arg
startNewGame(mode, 'white', diff);
