### PR TITLE
fix: add en passant parameter handling to Python fallback engine

### DIFF
--- a/game/engine/main.py
+++ b/game/engine/main.py
@@ -35,6 +35,8 @@ W_K_CASTLE = False
 W_Q_CASTLE = False
 B_K_CASTLE = False
 B_Q_CASTLE = False
+EN_PASSANT_R = -1
+EN_PASSANT_C = -1
 
 
 def load_board(board64):
@@ -50,6 +52,11 @@ def load_castling_rights(rights_str):
         elif char == 'Q': W_Q_CASTLE = True
         elif char == 'k': B_K_CASTLE = True
         elif char == 'q': B_Q_CASTLE = True
+
+def load_en_passant(row, col):
+    global EN_PASSANT_R, EN_PASSANT_C
+    EN_PASSANT_R = row
+    EN_PASSANT_C = col
 
 
 def serialize_board():
@@ -166,7 +173,7 @@ def valid_pawn(color, fr, fc, tr, tc):
     if col_delta == 0 and row_delta == 2 * direction and fr == start_row:
         return is_empty(BOARD[fr + direction][fc]) and is_empty(BOARD[tr][tc])
 
-    if abs(col_delta) == 1 and row_delta == direction and not is_empty(BOARD[tr][tc]):
+    if abs(col_delta) == 1 and row_delta == direction and tr == EN_PASSANT_R and tc == EN_PASSANT_C:
         return True
 
     return False
@@ -687,21 +694,27 @@ def run():
             board64 = next(tokens)
             rights = next(tokens)
             turn = next(tokens)
+            ep_row = int(next(tokens)) 
+            ep_col = int(next(tokens))
             fr = int(next(tokens))
             fc = int(next(tokens))
             tr = int(next(tokens))
             tc = int(next(tokens))
             load_board(board64)
             load_castling_rights(rights)
+            load_en_passant(ep_row, ep_col)
             validate_move(turn, fr, fc, tr, tc)
         elif command == 'MOVES':
             board64 = next(tokens)
             rights = next(tokens)
             turn = next(tokens)
+            ep_row = int(next(tokens))
+            ep_col = int(next(tokens))
             row = int(next(tokens))
             col = int(next(tokens))
             load_board(board64)
             load_castling_rights(rights)
+            load_en_passant(ep_row, ep_col)
             handle_moves(turn, row, col)
         elif command == 'ATTACKED':
             board64 = next(tokens)
@@ -716,6 +729,8 @@ def run():
             board64 = next(tokens)
             rights = next(tokens)
             turn = next(tokens)
+            ep_row = int(next(tokens))
+            ep_col = int(next(tokens))
             fr = int(next(tokens))
             fc = int(next(tokens))
             tr = int(next(tokens))
@@ -723,21 +738,28 @@ def run():
             promo_piece = next(tokens)
             load_board(board64)
             load_castling_rights(rights)
+            load_en_passant(ep_row, ep_col)
             handle_promote(turn, fr, fc, tr, tc, promo_piece)
         elif command == 'STATUS':
             board64 = next(tokens)
             rights = next(tokens)
             turn = next(tokens)
+            ep_row = int(next(tokens))
+            ep_col = int(next(tokens))
             load_board(board64)
             load_castling_rights(rights)
+            load_en_passant(ep_row, ep_col)
             handle_status(turn)
         elif command == 'BESTMOVE':
             board64 = next(tokens)
             rights = next(tokens)
             turn = next(tokens)
+            ep_row = int(next(tokens))
+            ep_col = int(next(tokens))
             depth = int(next(tokens))
             load_board(board64)
             load_castling_rights(rights)
+            load_en_passant(ep_row, ep_col)
             handle_bestmove(turn, depth)
 
 


### PR DESCRIPTION
## Description

Picked this up while working on PR #256 — the Python fallback engine was silently consuming `ep_row` and `ep_col` as `row` and `col`, so every command was targeting the wrong square. Result: all pieces frozen, empty valid moves whenever the C++ binary wasn't available.

Added `EN_PASSANT_R/C` globals, `load_en_passant()`, the ep check in `valid_pawn()`, and fixed all command handlers in `run()` to read params in the right order.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issue
Fixes #302 

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally

> All 48 tests pass. Verified manually by running without the C++ binary — pieces move correctly using Python fallback.

## Additional Notes
Production unaffected since Vercel compiles C++ successfully. This fixes the experience for contributors running locally without a compiled binary.

<img width="1364" height="824" alt="Screenshot 2026-05-05 175943" src="https://github.com/user-attachments/assets/5bbc16e7-3cb7-4710-b67f-6d88031a5810" />
