### PR TITLE
fix: declare missing gameOverStartBtn DOM reference and fix: dead pass branch in get_state — clock never pauses when tab is inactive

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -69,6 +69,7 @@
             const gameOverOverlay = document.getElementById('gameOverOverlay');
             const gameOverTitle = document.getElementById('gameOverTitle');
             const gameOverMessage = document.getElementById('gameOverMessage');
+            const gameOverStartBtn = document.getElementById('gameOverStartBtn');
             const gameOverPvPBtn = document.getElementById('gameOverPvPBtn');
             const gameOverAIBtn = document.getElementById('gameOverAIBtn');
 

--- a/game/views.py
+++ b/game/views.py
@@ -171,7 +171,7 @@ def get_state(request):
         # Skip clock deduction if tab was closed for too long
         elapsed = time.time() - game.last_ts
         if elapsed > 10 and not game.paused:
-            pass  # Force pause without time penalty
+            game.paused = True  # pause without deducting lost time
         else:
             game.update_clock()
 


### PR DESCRIPTION
  gameOverStartBtn was used in event listeners but never declared 
  in the DOM references section, causing a ReferenceError at runtime.

 Added `const gameOverStartBtn = document.getElementById('gameOverStartBtn');`
 to the DOM references block alongside other game over elements.
 
 closes #340 
 closes #246 