### PR TITLE
Fix/clock low warning and gameover color

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -849,6 +849,12 @@
                     if (turn === 'white' && whiteTime > 0) whiteTime--;
                     if (turn === 'black' && blackTime > 0) blackTime--;
                     renderClocks();
+
+                    // Apply low-time warning class when under 60 seconds
+                    const whiteClock = document.getElementById('whiteClock');
+                    const blackClock = document.getElementById('blackClock');
+                    if (whiteClock) whiteClock.classList.toggle('low', whiteTime > 0 && whiteTime < 60);
+                    if (blackClock) blackClock.classList.toggle('low', blackTime > 0 && blackTime < 60);
                 }, 1000);
             }
 
@@ -1110,7 +1116,7 @@
                     confettiContainer.remove();
                 }
                 
-                startNewGame(mode, 'white', diff);
+                startNewGame(mode, mode === 'ai' ? playerColor : 'white', diff);
             };
 
             // Theme Switcher

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -930,7 +930,7 @@
                     () => {
                         const diff = document.getElementById('confirmDifficultySelect').value;
                         if (mode === 'ai') {
-                            startNewGame('ai', 'white', diff);
+                            startNewGame('ai', playerColor, diff);
                         } else {
                             startNewGame('pvp');
                         }


### PR DESCRIPTION
## Description 

Fixes two UI bugs in `board.js`:

1. **Low-time clock warning never triggered** — `board.css` had a `.clock.low` style (red background, red border) defined but `board.js` never applied it. Players had no visual warning as their clock approached zero. Added a `classList.toggle('low', ...)` call inside `startTimer()` to apply the warning when time drops below 60 seconds.

2. **Game Over restart always forced White color** — When restarting from the Game Over overlay in AI mode, `startNewGame()` was hardcoded to `'white'`, ignoring the player's previously chosen color. Fixed to pass `playerColor` when restarting in AI mode.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issue

Fixes #341 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots 

<img width="1422" height="919" alt="image" src="https://github.com/user-attachments/assets/fc137152-cb9d-4642-9d7c-85a099eb8049" />

## Additional Notes

Both fixes are isolated to `game/static/game/js/board.js` only. No backend changes, no new dependencies. The CSS for `.clock.low` was already correct and required no modification.

