### PR TITLE
fix: sync python engine protocol with backend commands

### DIFF
--- a/game/engine/main.py
+++ b/game/engine/main.py
@@ -687,6 +687,9 @@ def run():
             board64 = next(tokens)
             rights = next(tokens)
             turn = next(tokens)
+            # Consume en-passant coordinates sent by backend
+            ep_row = int(next(tokens))
+            ep_col = int(next(tokens))
             fr = int(next(tokens))
             fc = int(next(tokens))
             tr = int(next(tokens))
@@ -698,6 +701,9 @@ def run():
             board64 = next(tokens)
             rights = next(tokens)
             turn = next(tokens)
+            # consume en-passant coordinates sent by backend
+            ep_row = int(next(tokens))
+            ep_col = int(next(tokens))
             row = int(next(tokens))
             col = int(next(tokens))
             load_board(board64)
@@ -716,6 +722,9 @@ def run():
             board64 = next(tokens)
             rights = next(tokens)
             turn = next(tokens)
+            # Consume en-passant coordinates sent by backend
+            ep_row = int(next(tokens))
+            ep_col = int(next(tokens))
             fr = int(next(tokens))
             fc = int(next(tokens))
             tr = int(next(tokens))
@@ -728,6 +737,9 @@ def run():
             board64 = next(tokens)
             rights = next(tokens)
             turn = next(tokens)
+            # Consume en-passant coordinates sent by backend
+            ep_row = int(next(tokens))
+            ep_col = int(next(tokens))
             load_board(board64)
             load_castling_rights(rights)
             handle_status(turn)
@@ -735,6 +747,9 @@ def run():
             board64 = next(tokens)
             rights = next(tokens)
             turn = next(tokens)
+            # Consume en-passant coordinates sent by backend
+            ep_row = int(next(tokens))
+            ep_col = int(next(tokens))
             depth = int(next(tokens))
             load_board(board64)
             load_castling_rights(rights)


### PR DESCRIPTION
## Description

This PR fixes the Python fallback engine issue where pieces were not moving correctly when the C++ engine was unavailable.

After testing with only the Python engine enabled, I found that the backend was already sending en-passant coordinates in engine commands, but the Python engine parser was still using the older protocol format.

Because of this, token parsing shifted incorrectly and commands like `MOVES` started interpreting en-passant values as board coordinates, which caused empty valid move responses and prevented gameplay from working properly.

The parser has now been updated to correctly consume en-passant coordinates across all affected commands.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

## Related Issue

Fixes #337

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] I have commented my code where necessary
* [ ] I have updated the documentation if needed
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix/feature works
* [x] New and existing tests pass locally

## Screenshots (if applicable)
<img width="782" height="548" alt="Screenshot from 2026-05-06 12-49-47" src="https://github.com/user-attachments/assets/170c90cd-e5d9-4d19-a957-8a985903d9df" />


## Additional Notes

Updated Python engine command parsing for:

* `MOVES`
* `VALIDATE`
* `STATUS`
* `BESTMOVE`
* `PROMOTE`

Tested locally using only the Python fallback engine:

* PvP mode works correctly
* valid move generation works as expected
* gameplay no longer gets stuck due to empty move responses
