### PR TITLE
issue #308 solved

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -872,11 +872,7 @@
 
             async function pauseGame() {
                 if (paused) return;
-                const d = await post('/api/pause/', {
-                    pause: true,
-                    white_time: whiteTime,
-                    black_time: blackTime
-                });
+                const d = await post('/api/pause/', { pause: true });
                 paused = d.paused;
                 whiteTime = d.white_time;
                 blackTime = d.black_time;
@@ -1165,9 +1161,7 @@
             document.addEventListener('visibilitychange', () => { if (document.hidden) pauseGame(); });
             window.addEventListener('beforeunload', () => {
                 if (!paused) {
-                    navigator.sendBeacon('/api/pause/', JSON.stringify({
-                        pause: true, white_time: whiteTime, black_time: blackTime
-                    }));
+                    navigator.sendBeacon('/api/pause/', JSON.stringify({ pause: true }));
                 }
             });
 

--- a/game/tests.py
+++ b/game/tests.py
@@ -4,6 +4,7 @@ import json
 import sys
 from unittest import mock
 
+from django.conf import settings
 from django.test import SimpleTestCase, TestCase
 
 from .engine import ChessGame
@@ -268,6 +269,12 @@ class GameStateTest(TestCase):
     def setUp(self):
         self.client.get('/')
 
+    def _set_game_session(self, game):
+        session = self.client.session
+        session['game'] = game.to_dict()
+        session.save()
+        self.client.cookies[settings.SESSION_COOKIE_NAME] = session.session_key
+
     def test_get_state(self):
         r = self.client.get('/api/state/')
         data = r.json()
@@ -276,12 +283,54 @@ class GameStateTest(TestCase):
         self.assertEqual(data['mode'], 'pvp')
         self.assertIn('board', data)
 
+    def test_get_state_preserves_paused_games(self):
+        game = ChessGame()
+        game.paused = True
+        game.last_ts = 100.0
+        self._set_game_session(game)
+
+        with (
+            mock.patch('game.views.time.time', return_value=105.0),
+            mock.patch('game.engine.time.time', return_value=105.0),
+        ):
+            response = self.client.get('/api/state/')
+
+        data = response.json()
+        self.assertTrue(data['paused'])
+        self.assertEqual(data['white_time'], game.white_time)
+        self.assertEqual(data['black_time'], game.black_time)
+
+    def test_get_state_auto_pauses_long_idle_running_games(self):
+        game = ChessGame()
+        game.paused = False
+        game.last_ts = 100.0
+        game.white_time = 600
+        game.black_time = 600
+        self._set_game_session(game)
+
+        with (
+            mock.patch('game.views.time.time', return_value=111.0),
+            mock.patch('game.engine.time.time', return_value=111.0),
+        ):
+            response = self.client.get('/api/state/')
+
+        data = response.json()
+        self.assertTrue(data['paused'])
+        self.assertEqual(data['white_time'], 600)
+        self.assertEqual(data['black_time'], 600)
+
 
 class PauseTest(TestCase):
     """Test the /api/pause/ endpoint."""
 
     def setUp(self):
         self.client.get('/')
+
+    def _set_game_session(self, game):
+        session = self.client.session
+        session['game'] = game.to_dict()
+        session.save()
+        self.client.cookies[settings.SESSION_COOKIE_NAME] = session.session_key
 
     def test_pause_toggle(self):
         r1 = self.client.post(
@@ -295,6 +344,33 @@ class PauseTest(TestCase):
             content_type='application/json'
         )
         self.assertFalse(r2.json()['paused'])
+
+    def test_pause_endpoint_ignores_client_supplied_clock_values(self):
+        game = ChessGame()
+        game.white_time = 600
+        game.black_time = 600
+        game.last_ts = 100.0
+        game.paused = False
+        self._set_game_session(game)
+
+        with (
+            mock.patch('game.views.time.time', return_value=103.0),
+            mock.patch('game.engine.time.time', return_value=103.0),
+        ):
+            response = self.client.post(
+                '/api/pause/',
+                data=json.dumps({
+                    'pause': True,
+                    'white_time': 1,
+                    'black_time': 2,
+                }),
+                content_type='application/json',
+            )
+
+        data = response.json()
+        self.assertTrue(data['paused'])
+        self.assertEqual(data['white_time'], 597)
+        self.assertEqual(data['black_time'], 600)
 
 
 class DrawOfferTest(TestCase):

--- a/game/views.py
+++ b/game/views.py
@@ -164,7 +164,7 @@ def check_promotion(request):
 
 @require_GET
 def get_state(request):
-    """Return the full current game state, pausing on page load."""
+    """Return the full current game state without mutating pause state."""
     game_data = request.session.get('game')
     if not game_data:
         game = ChessGame()
@@ -177,10 +177,6 @@ def get_state(request):
             game.paused = True  # pause without deducting lost time
         else:
             game.update_clock()
-
-    # Always start in paused state on page load/refresh
-    game.paused = False
-    game.last_ts = time.time()
 
     request.session['game'] = game.to_dict()
     request.session.modified = True
@@ -215,7 +211,9 @@ def set_pause(request):
 
     game = ChessGame.from_dict(game_data)
 
-    game.update_clock()
+    # Only deduct elapsed time when transitioning from running to paused.
+    if pause and not game.paused:
+        game.update_clock()
     game.paused = pause
     game.last_ts = time.time()
 


### PR DESCRIPTION
Implemented the pause/resume fix and kept the rest of the codebase green.

GET /api/state/ in game/views.py no longer flips game.paused to False on refresh.

It now preserves paused state, still auto-pauses long-idle running games without deducting surprise time, and saves state back without implicitly resuming the clock. I also tightened /api/pause/ so clock deduction only happens when we are actually transitioning from running to paused.



On the frontend, game/static/game/js/board.js no longer sends white_time and black_time to /api/pause/, which makes the client/server contract clearer and keeps the backend authoritative for timer values. I added regression coverage in game/tests.py for paused-state preservation, long-idle auto-pause, and ignoring client-supplied clock values.

Verification: python manage.py test passed with 54 tests.

closes #308 