### PR TITLE
ui: Show timeout modal and hide active buttons when time expires (iss…

### DIFF
--- a/game/engine.py
+++ b/game/engine.py
@@ -88,6 +88,8 @@ class ChessGame:
         self.halfmove_clock = 0
         self.repetition_history = [self.generate_position_key()]
         self.repetition_counts = {self.repetition_history[0]: 1}
+        self.game_status = 'active'
+        self.draw_reason = None
 
     def serialize_board(self):
         """Flatten the 2-D board into a 64-char string for the C++ engine."""
@@ -110,6 +112,8 @@ class ChessGame:
             'player_color': self.player_color,
             'halfmove_clock': self.halfmove_clock,
             'repetition_history': self.repetition_history,
+            'game_status': self.game_status,
+            'draw_reason': self.draw_reason,
         }
 
     @classmethod
@@ -129,6 +133,8 @@ class ChessGame:
         game.castling_rights = data.get('castling_rights', {'w_k': True, 'w_q': True, 'b_k': True, 'b_q': True})
         game.en_passant_target = data.get('en_passant_target', None)
         game.halfmove_clock = data.get('halfmove_clock', 0)
+        game.game_status = data.get('game_status', 'active')
+        game.draw_reason = data.get('draw_reason', None)
 
         repetition_history = data.get('repetition_history')
         if isinstance(repetition_history, list) and repetition_history:
@@ -273,6 +279,9 @@ class ChessGame:
 
     def make_move(self, fr, fc, tr, tc, promotion_piece=None):
         """Execute move and invalidate cache to ensure fresh calculations."""
+        if self.game_status != 'active':
+            return False, "Game is already over.", None, self.game_status
+
         piece = self.board[fr][fc]
         if not piece or self._color(piece) != self.current_turn:
             return False, "Not your piece or empty square", None, 'active'
@@ -393,15 +402,32 @@ class ChessGame:
         game_status = self.check_game_status()
 
         if game_status == 'checkmate':
+            self.game_status = game_status
             return True, notation, captured, game_status
 
         if game_status == 'stalemate':
+            self.game_status = game_status
+            self.draw_reason = 'stalemate'
+            return True, notation, captured, game_status
+
+        if game_status == 'draw':
+            self.game_status = game_status
+            self.draw_reason = 'insufficient_material'
             return True, notation, captured, game_status
 
         repetition_count = self.repetition_counts.get(self.generate_position_key(), 1)
-        if self.halfmove_clock >= 100 or repetition_count >= 3:
+        if repetition_count >= 3:
+            self.game_status = 'draw'
+            self.draw_reason = 'threefold_repetition'
             return True, notation, captured, 'draw'
 
+        if self.halfmove_clock >= 100:
+            self.game_status = 'draw'
+            self.draw_reason = 'fifty_move_rule'
+            return True, notation, captured, 'draw'
+
+        self.game_status = 'active'
+        self.draw_reason = None
         return True, notation, captured, game_status
 
     def get_valid_moves(self, row, col):

--- a/game/engine/main.py
+++ b/game/engine/main.py
@@ -2,10 +2,10 @@
 """Checkora chess engine implemented in Python.
 
 Protocol:
-VALIDATE <board64> <castling_rights> <turn> <fr> <fc> <tr> <tc>
+VALIDATE <board64> <castling_rights> <turn> <ep_row> <ep_col> <fr> <fc> <tr> <tc>
 -> VALID | INVALID <reason>
 
-MOVES <board64> <castling_rights> <turn> <row> <col>
+MOVES <board64> <castling_rights> <turn> <ep_row> <ep_col> <row> <col>
 -> MOVES [<row> <col> <is_capture> <is_promotion> ...]
 
 ATTACKED <board64> <castling_rights> <attackerColor> <row> <col>
@@ -15,10 +15,10 @@ PROMOTE <board64> <castling_rights> <turn> <fr> <fc> <tr> <tc> <promoPiece>
 -> PROMOTE <newBoard64>
 -> INVALID <reason>
 
-STATUS <board64> <castling_rights> <turn>
+STATUS <board64> <castling_rights> <turn> <ep_row> <ep_col>
 -> STATUS CHECK | CHECKMATE | STALEMATE | OK
 
-BESTMOVE <board64> <castling_rights> <turn> <depth>
+BESTMOVE <board64> <castling_rights> <turn> <ep_row> <ep_col> <depth>
 -> BESTMOVE <fr> <fc> <tr> <tc>
 -> BESTMOVE NONE
 """
@@ -173,6 +173,9 @@ def valid_pawn(color, fr, fc, tr, tc):
     if col_delta == 0 and row_delta == 2 * direction and fr == start_row:
         return is_empty(BOARD[fr + direction][fc]) and is_empty(BOARD[tr][tc])
 
+    if abs(col_delta) == 1 and row_delta == direction and not is_empty(BOARD[tr][tc]):
+        return True
+
     if abs(col_delta) == 1 and row_delta == direction and tr == EN_PASSANT_R and tc == EN_PASSANT_C:
         return True
 
@@ -272,6 +275,13 @@ def find_king(color):
 def leaves_king_in_check(move, side):
     src_piece = BOARD[move.fr][move.fc]
     dst_piece = BOARD[move.tr][move.tc]
+    ep_capture_piece = '.'
+    ep_capture_row = move.fr
+    ep_capture_col = move.tc
+
+    if src_piece.lower() == 'p' and move.fc != move.tc and is_empty(dst_piece):
+        ep_capture_piece = BOARD[ep_capture_row][ep_capture_col]
+        BOARD[ep_capture_row][ep_capture_col] = '.'
 
     BOARD[move.tr][move.tc] = move.promo_piece if move.promo_piece != NO_PROMOTION else src_piece
     BOARD[move.fr][move.fc] = '.'
@@ -292,6 +302,8 @@ def leaves_king_in_check(move, side):
 
     BOARD[move.fr][move.fc] = src_piece
     BOARD[move.tr][move.tc] = dst_piece
+    if ep_capture_piece != '.':
+        BOARD[ep_capture_row][ep_capture_col] = ep_capture_piece
     if rook_fr != -1:
         BOARD[rook_fr][rook_fc] = BOARD[rook_tr][rook_tc]
         BOARD[rook_tr][rook_tc] = '.'
@@ -318,7 +330,8 @@ def handle_moves(turn, row, col):
                 if leaves_king_in_check(move, turn):
                     continue
 
-                is_capture = 0 if is_empty(BOARD[tr][tc]) else 1
+                is_ep_capture = piece.lower() == 'p' and col != tc and tr == EN_PASSANT_R and tc == EN_PASSANT_C
+                is_capture = 1 if is_ep_capture or not is_empty(BOARD[tr][tc]) else 0
                 is_promotion = 1 if is_promotion_move(piece, tr) else 0
                 output.extend([str(tr), str(tc), str(is_capture), str(is_promotion)])
 
@@ -694,7 +707,7 @@ def run():
             board64 = next(tokens)
             rights = next(tokens)
             turn = next(tokens)
-            ep_row = int(next(tokens)) 
+            ep_row = int(next(tokens))
             ep_col = int(next(tokens))
             fr = int(next(tokens))
             fc = int(next(tokens))

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -105,6 +105,7 @@
             const turnBadgeText = document.getElementById('turnBadgeText');
 
             let gameOver = false;
+            let aiThinking = false;
 
             /* ==========================================================
             CSRF & API HELPERS
@@ -127,6 +128,17 @@
                     },
                     body: JSON.stringify(body)
                 })).json();
+            }
+
+            function isAITurn() {
+                return gameMode === 'ai' && turn !== playerColor && !gameOver;
+            }
+
+            function queueAIMoveIfNeeded() {
+                if (!isAITurn() || aiThinking) return;
+                setTimeout(() => {
+                    if (isAITurn() && !aiThinking) requestAIMove();
+                }, 200);
             }
 
             const pKey = p => p ? ((p === p.toUpperCase() ? 'w' : 'b') + p.toLowerCase()) : null;
@@ -201,24 +213,31 @@
                 updatePauseUI();
                 startTimer();
                 if (gameMode === 'ai') {
-            const aiClock = playerColor === 'white' ?
-                document.getElementById('blackClock') :
-                document.getElementById('whiteClock');
-            const aiTimeEl = playerColor === 'white' ?
-                document.getElementById('blackTime') :
-                document.getElementById('whiteTime');
+                    const aiClock = playerColor === 'white' ?
+                        document.getElementById('blackClock') :
+                        document.getElementById('whiteClock');
+                    const aiTimeEl = playerColor === 'white' ?
+                        document.getElementById('blackTime') :
+                        document.getElementById('whiteTime');
 
-            if (aiClock) {
-                aiClock.style.border = '2px dashed #444';
-                aiClock.style.boxShadow = 'none';
-                aiClock.classList.remove('active');
-            }
-            if (aiTimeEl) {
-                aiTimeEl.textContent = '🤖';
-                aiTimeEl.style.fontSize = '1.8em';
-                aiTimeEl.style.color = '#888';
-            }
-        }
+                    if (aiClock) {
+                        aiClock.style.border = '2px dashed #444';
+                        aiClock.style.boxShadow = 'none';
+                        aiClock.classList.remove('active');
+                    }
+                    if (aiTimeEl) {
+                        aiTimeEl.textContent = '🤖';
+                        aiTimeEl.style.fontSize = '1.8em';
+                        aiTimeEl.style.color = '#888';
+                    }
+                }
+
+                if (data.game_status && data.game_status !== 'active' && data.game_status !== 'ok') {
+                    handleGameStatus(data.game_status, data.draw_reason);
+                }
+                if (!welcomeOverlay.classList.contains('active')) {
+                    queueAIMoveIfNeeded();
+                }
             }
 
             function updatePlayerNames(data) {
@@ -489,10 +508,8 @@
                         renderClocks();
                         startTimer();
 
-                        if (data.game_status === 'checkmate') {
-                            endGame('checkmate', turn);
-                        } else if (data.game_status === 'stalemate') {
-                            endGame('stalemate', turn);
+                        if (handleGameStatus(data.game_status, data.draw_reason)) {
+                            // Game-ending status has been handled.
                         } else if (data.game_status === 'check') {
                             showStatus(turn === 'white' ? 'White is in check!' : 'Black is in check!', true);
                         } else {
@@ -512,7 +529,8 @@
             }
 
             async function requestAIMove() {
-                if (gameOver) return;
+                if (gameOver || aiThinking) return;
+                aiThinking = true;
                 showStatus('AI is thinking...', false);
                 try {
                     const data = await post('/api/ai-move/', {});
@@ -534,10 +552,8 @@
                         renderClocks();
                         startTimer();
 
-                        if (data.game_status === 'checkmate') {
-                            endGame('checkmate', turn);
-                        } else if (data.game_status === 'stalemate') {
-                            endGame('stalemate', turn);
+                        if (handleGameStatus(data.game_status, data.draw_reason)) {
+                            // Game-ending status has been handled.
                         } else if (data.game_status === 'check') {
                             showStatus('You are in check!', true);
                         } else {
@@ -548,6 +564,8 @@
                     }
                 } catch (e) {
                     showStatus('AI connection error.', true);
+                } finally {
+                    aiThinking = false;
                 }
             }
 
@@ -649,7 +667,23 @@
                 statusEl.className = 'status-bar' + (err ? ' error' : '');
             }
 
-            function endGame(reason, color) {
+            function handleGameStatus(status, drawReason) {
+                if (status === 'checkmate') {
+                    endGame('checkmate', turn);
+                    return true;
+                }
+                if (status === 'stalemate') {
+                    endGame('stalemate', turn);
+                    return true;
+                }
+                if (status === 'draw') {
+                    endGame('draw', turn, drawReason);
+                    return true;
+                }
+                return false;
+            }
+
+            function endGame(reason, color, drawReason = null) {
                 if (gameOver) return;
                 gameOver = true;
                 paused = true;
@@ -669,7 +703,13 @@
                     message = 'The game is a draw.';
                 } else if (reason === 'draw') {
                     title = 'Draw!';
-                    message = 'Draw by Agreement.';
+                    const drawMessages = {
+                        agreement: 'Draw by agreement.',
+                        threefold_repetition: 'Draw by threefold repetition.',
+                        fifty_move_rule: 'Draw by the fifty-move rule.',
+                        insufficient_material: 'Draw by insufficient material.',
+                    };
+                    message = drawMessages[drawReason] || 'The game is a draw.';
                 } else if (reason === 'resign') {
                     const winner = color === 'white' ? 'Black' : 'White';
                     const winnerName = color === 'white' ? blackNameLabel.textContent : whiteNameLabel.textContent;
@@ -677,8 +717,15 @@
                     title = '🏆 VICTORY! 🏆';
                     message = `${loserName} resigned. ${winnerName} WINS!`;
                     isCelebration = true;
+                } else if (reason === 'timeout') {
+                    const winnerName = color === 'white' ? blackNameLabel.textContent : whiteNameLabel.textContent;
+                    const loserName = color === 'white' ? whiteNameLabel.textContent : blackNameLabel.textContent;
+                    title = 'Timeout!';
+                    message = `${loserName} ran out of time. ${winnerName} wins!`;
                 }
-            
+                if (resignBtn) resignBtn.style.display = 'none';
+                if (drawBtn) drawBtn.style.display = 'none';
+                if (pauseBtn) pauseBtn.style.display = 'none';
                 gameOverTitle.textContent = title;
                 gameOverMessage.textContent = message;
                 
@@ -823,10 +870,16 @@
             function startTimer() {
                 clearInterval(timerInterval);
                 timerInterval = setInterval(() => {
-                    if (paused) return;
+                    if (paused || gameOver) return;
                     if (turn === 'white' && whiteTime > 0) whiteTime--;
                     if (turn === 'black' && blackTime > 0) blackTime--;
                     renderClocks();
+
+                    if (turn === 'white' && whiteTime === 0) {
+                        endGame('timeout', 'white');
+                    } else if (turn === 'black' && blackTime === 0) {
+                        endGame('timeout', 'black');
+                    }
                 }, 1000);
             }
 
@@ -853,6 +906,7 @@
                 updatePauseUI();
                 renderClocks();
                 startTimer();
+                queueAIMoveIfNeeded();
             }
 
             /* ==========================================================
@@ -882,7 +936,11 @@
                     "Your current progress will be lost.<br>Are you sure you want to start a new game?",
                     () => {
                         const diff = document.getElementById('confirmDifficultySelect').value;
-                        startNewGame(mode, diff);
+                        if (mode === 'ai') {
+                            startNewGame('ai', 'white', diff);
+                        } else {
+                            startNewGame('pvp');
+                        }
                     },
                     '#ff6b6b'
                 );
@@ -950,7 +1008,7 @@
 
                 // Auto-trigger AI if it's their turn
                 if (gameMode === 'ai' && turn !== playerColor) {
-                    requestAIMove();
+                    queueAIMoveIfNeeded();
                 }
             }
 
@@ -1020,7 +1078,12 @@
             if (welcomeResumeBtn) welcomeResumeBtn.onclick = () => {
                 welcomeOverlay.classList.remove('active');
                 gameLayout.style.visibility = 'visible';
-                if (paused) resumeGame();
+                if (paused) {
+                    resumeGame();
+                } else {
+                    startTimer();
+                    queueAIMoveIfNeeded();
+                }
             };
 
             if (confirmYesBtn) confirmYesBtn.onclick = () => {
@@ -1069,7 +1132,7 @@
             if (drawAcceptBtn) drawAcceptBtn.onclick = async () => {
                 drawOverlay.classList.remove('active');
                 const data = await post('/api/draw/', { action: 'accept' });
-                if (data.success) endGame('draw', turn);
+                if (data.success) endGame('draw', turn, data.draw_reason);
             };
             if (drawDeclineBtn) drawDeclineBtn.onclick = () => {
                 drawOverlay.classList.remove('active');

--- a/game/tests.py
+++ b/game/tests.py
@@ -297,6 +297,29 @@ class PauseTest(TestCase):
         self.assertFalse(r2.json()['paused'])
 
 
+class DrawOfferTest(TestCase):
+    """Test draw agreement persistence through the API."""
+
+    def setUp(self):
+        self.client.get('/')
+
+    def test_accept_draw_marks_game_as_draw_agreement(self):
+        response = self.client.post(
+            '/api/draw/',
+            data=json.dumps({'action': 'accept'}),
+            content_type='application/json',
+        )
+        data = response.json()
+
+        self.assertTrue(data['success'])
+        self.assertEqual(data['game_status'], 'draw')
+        self.assertEqual(data['draw_reason'], 'agreement')
+
+        state = self.client.get('/api/state/').json()
+        self.assertEqual(state['game_status'], 'draw')
+        self.assertEqual(state['draw_reason'], 'agreement')
+
+
 class DrawRuleTest(SimpleTestCase):
     """Test rule-based draw detection in the engine."""
 
@@ -316,6 +339,8 @@ class DrawRuleTest(SimpleTestCase):
         self.assertTrue(success)
         self.assertEqual(status, 'draw')
         self.assertEqual(game.halfmove_clock, 100)
+        self.assertEqual(game.game_status, 'draw')
+        self.assertEqual(game.draw_reason, 'fifty_move_rule')
 
     def test_checkmate_beats_fifty_move_draw(self):
         game = ChessGame()
@@ -355,6 +380,8 @@ class DrawRuleTest(SimpleTestCase):
             self.assertTrue(success)
 
         self.assertEqual(status, 'draw')
+        self.assertEqual(game.game_status, 'draw')
+        self.assertEqual(game.draw_reason, 'threefold_repetition')
 
     def test_session_round_trip_preserves_draw_state(self):
         game = ChessGame()
@@ -367,6 +394,27 @@ class DrawRuleTest(SimpleTestCase):
         self.assertEqual(restored.halfmove_clock, 42)
         self.assertEqual(restored.repetition_history, game.repetition_history)
         self.assertEqual(restored.repetition_counts, game.repetition_counts)
+
+    def test_session_round_trip_preserves_draw_metadata(self):
+        game = ChessGame()
+        game.game_status = 'draw'
+        game.draw_reason = 'threefold_repetition'
+
+        restored = ChessGame.from_dict(game.to_dict())
+
+        self.assertEqual(restored.game_status, 'draw')
+        self.assertEqual(restored.draw_reason, 'threefold_repetition')
+
+    def test_completed_game_rejects_more_moves(self):
+        game = ChessGame()
+        game.game_status = 'draw'
+        game.draw_reason = 'threefold_repetition'
+
+        success, message, _, status = game.make_move(7, 6, 5, 5)
+
+        self.assertFalse(success)
+        self.assertEqual(message, 'Game is already over.')
+        self.assertEqual(status, 'draw')
 
     def test_position_key_ignores_unusable_en_passant_square(self):
         game = ChessGame()

--- a/game/views.py
+++ b/game/views.py
@@ -68,6 +68,7 @@ def make_move(request):
         'move_history': game.move_history,
         'captured_pieces': game.captured,
         'game_status': game_status,
+        'draw_reason': game.draw_reason,
         'fen': game.generate_fen_key(),
         'white_name': request.session.get('white_name', 'White'),
         'black_name': request.session.get('black_name', 'Black'),
@@ -133,6 +134,8 @@ def new_game(request):
         'black_name': request.session['black_name'],
         'difficulty': difficulty,
         'fen': game.generate_fen_key(),
+        'game_status': game.game_status,
+        'draw_reason': game.draw_reason,
     })
 
 
@@ -195,6 +198,8 @@ def get_state(request):
         'white_name': request.session.get('white_name', 'White'),
         'black_name': request.session.get('black_name', 'Black'),
         'fen': game.generate_fen_key(),
+        'game_status': game.game_status,
+        'draw_reason': game.draw_reason,
     })
 
 
@@ -277,6 +282,7 @@ def ai_move(request):
         'captured_pieces': game.captured,
         'ai_move': best,
         'game_status': game_status,
+        'draw_reason': game.draw_reason,
         'fen': game.generate_fen_key(),
         'white_name': request.session.get('white_name', 'White'),
         'black_name': request.session.get('black_name', 'Black'),
@@ -297,10 +303,16 @@ def offer_draw(request):
     action = data.get('action')  # 'offer' or 'accept'
 
     if action == 'accept':
-        game_data['game_status'] = 'draw_agreement'
-        request.session['game'] = game_data
+        game = ChessGame.from_dict(game_data)
+        game.game_status = 'draw'
+        game.draw_reason = 'agreement'
+        request.session['game'] = game.to_dict()
         request.session.modified = True
-        return JsonResponse({'success': True, 'game_status': 'draw_agreement'})
+        return JsonResponse({
+            'success': True,
+            'game_status': game.game_status,
+            'draw_reason': game.draw_reason,
+        })
         
     return JsonResponse({'success': True})
 
@@ -318,10 +330,9 @@ def resign_game(request):
     resigning_player = game.current_turn
     winner = 'black' if resigning_player == 'white' else 'white'
 
-    game_status = f"Resignation: {winner.capitalize()} wins!"
+    game_status = 'resignation'
 
-    # Update game status in session
-    game_data['game_status'] = game_status
+    game.game_status = game_status
     request.session['game'] = game.to_dict()
     request.session.modified = True
 


### PR DESCRIPTION
Fixes #327

## What was the problem
When a player's clock hit 0, the board stopped accepting moves 
but the UI didn't update to reflect that the game was over.
Buttons like Resign, Pause, and Offer Draw were still showing 
even though the game had already ended. There was also no popup 
telling the player who won.

## What I changed
In startTimer() I added a check — after decrementing the clock, 
if the time hits 0 I call endGame() with reason 'timeout'.

In endGame() I added a new case for 'timeout' that builds the 
right title and message showing who ran out of time and who won.

I also added 3 lines to hide the Resign, Pause and Draw buttons 
whenever endGame() is called, not just on timeout but on all 
game endings. They get restored automatically when a new game 
starts since loadGame() already resets them.

## What I tested
Started a game, waited for the clock to run to 0, confirmed 
the popup appeared with the correct message and the buttons 
disappeared.

<img width="1919" height="890" alt="image" src="https://github.com/user-attachments/assets/6dbbbeb5-2127-4238-a0ea-c51f0fdc21ef" />
