### PR TITLE
ui: Show timeout modal and hide active buttons when time expires (issue #327)

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -740,8 +740,15 @@
                     title = '🏆 VICTORY! 🏆';
                     message = `${loserName} resigned. ${winnerName} WINS!`;
                     isCelebration = true;
+                } else if (reason === 'timeout') {
+                    const winnerName = color === 'white' ? blackNameLabel.textContent : whiteNameLabel.textContent;
+                    const loserName = color === 'white' ? whiteNameLabel.textContent : blackNameLabel.textContent;
+                    title = 'Timeout!';
+                    message = `${loserName} ran out of time. ${winnerName} wins!`;
                 }
-            
+                if (resignBtn) resignBtn.style.display = 'none';
+                if (drawBtn) drawBtn.style.display = 'none';
+                if (pauseBtn) pauseBtn.style.display = 'none';
                 gameOverTitle.textContent = title;
                 gameOverMessage.textContent = message;
                 
@@ -886,10 +893,16 @@
             function startTimer() {
                 clearInterval(timerInterval);
                 timerInterval = setInterval(() => {
-                    if (paused) return;
+                    if (paused || gameOver) return;
                     if (turn === 'white' && whiteTime > 0) whiteTime--;
                     if (turn === 'black' && blackTime > 0) blackTime--;
                     renderClocks();
+
+                    if (turn === 'white' && whiteTime === 0) {
+                        endGame('timeout', 'white');
+                    } else if (turn === 'black' && blackTime === 0) {
+                        endGame('timeout', 'black');
+                    }
                 }, 1000);
             }
 


### PR DESCRIPTION
Fixes #327

## What was the problem
When a player's clock hit 0, the board stopped accepting moves 
but the UI didn't update to reflect that the game was over.
Buttons like Resign, Pause, and Offer Draw were still showing 
even though the game had already ended. There was also no popup 
telling the player who won.

## What I changed
In startTimer() I added a check — after decrementing the clock, 
if the time hits 0 I call endGame() with reason 'timeout'.

In endGame() I added a new case for 'timeout' that builds the 
right title and message showing who ran out of time and who won.

I also added 3 lines to hide the Resign, Pause and Draw buttons 
whenever endGame() is called, not just on timeout but on all 
game endings. They get restored automatically when a new game 
starts since loadGame() already resets them.

## What I tested
Started a game, waited for the clock to run to 0, confirmed 
the popup appeared with the correct message and the buttons 
disappeared.

<img width="1919" height="890" alt="image" src="https://github.com/user-attachments/assets/6dbbbeb5-2127-4238-a0ea-c51f0fdc21ef" />
