### PR TITLE
test: add unit tests for C++ engine output parsing #266 

### DIFF
--- a/game/engine.py
+++ b/game/engine.py
@@ -454,7 +454,7 @@ class ChessGame:
         if resp and resp.startswith("MOVES"):
             parts = resp.split()[1:]
             # C++ now returns 4 fields per move: row col is_capture is_promotion
-            for i in range(0, len(parts), 4):
+            for i in range(0, len(parts) - 3, 4):
                 moves.append({
                     'row': int(parts[i]),
                     'col': int(parts[i+1]),
@@ -478,7 +478,9 @@ class ChessGame:
         cmd = f"PROMOTE {board_str} {rights_str} {self.current_turn} {ep_str} {fr} {fc} {tr} {tc} {choice}"
         resp = self._call_engine(cmd)
         if resp and resp.startswith("PROMOTE"):
-            return resp.split()[1]
+            parts = resp.split()
+            if len(parts) >= 2 and len(parts[1]) == 64:
+                return parts[1]
         return None
 
     @staticmethod
@@ -584,9 +586,11 @@ class ChessGame:
         cmd = f"STATUS {board_str} {rights_str} {self.current_turn} {ep_str}"
         resp = self._call_engine(cmd)
         if resp and resp.startswith("STATUS"):
-            status = resp.split()[1].lower()
-            if status in ('checkmate', 'stalemate', 'draw', 'check', 'ok'):
-                return status
+            parts = resp.split()
+            if len(parts) >= 2:
+                status = parts[1].lower()
+                if status in ('checkmate', 'stalemate', 'draw', 'check', 'ok'):
+                    return status
         return 'ok'
 
     # ------------------------------------------------------------------

--- a/game/tests.py
+++ b/game/tests.py
@@ -733,9 +733,40 @@ class EngineParsingTest(SimpleTestCase):
             status = self.game.check_game_status()
             self.assertEqual(status, "checkmate")
 
+    def test_check_game_status_defaults_to_ok_for_none_response(self):
+        """Test that a None engine response safely falls back to the default status."""
+        with mock.patch.object(ChessGame, '_call_engine', return_value=None):
+            status = self.game.check_game_status()
+            self.assertEqual(status, "ok")
+
+    def test_check_game_status_defaults_to_ok_for_empty_response(self):
+        """Test that an empty engine response safely falls back to the default status."""
+        with mock.patch.object(ChessGame, '_call_engine', return_value=""):
+            status = self.game.check_game_status()
+            self.assertEqual(status, "ok")
+
+    def test_check_game_status_defaults_to_ok_for_unknown_status(self):
+        """Test that an unknown STATUS value safely falls back to the default status."""
+        with mock.patch.object(ChessGame, '_call_engine', return_value="STATUS mystery"):
+            status = self.game.check_game_status()
+            self.assertEqual(status, "ok")
+
     def test_call_engine_promote_parses_board(self):
         """Test that the new board string is correctly parsed from the PROMOTE response."""
         fake_board = "rnbqkbnrpppppppp................................PPPPPPPPRNBQKBNR"
         with mock.patch.object(ChessGame, '_call_engine', return_value=f"PROMOTE {fake_board}"):
             board = self.game._call_engine_promote(1, 0, 0, 0, 'q')
             self.assertEqual(board, fake_board)
+
+    def test_call_engine_promote_handles_malformed_output(self):
+        """Test that malformed PROMOTE responses return None rather than raising."""
+        malformed_responses = [
+            "PROMOTE",
+            "PROMOTE short",
+            "PROMOTE too many tokens",
+        ]
+        for response in malformed_responses:
+            with self.subTest(response=response):
+                with mock.patch.object(ChessGame, '_call_engine', return_value=response):
+                    board = self.game._call_engine_promote(1, 0, 0, 0, 'q')
+                    self.assertIsNone(board)

--- a/game/tests.py
+++ b/game/tests.py
@@ -719,6 +719,14 @@ class EngineParsingTest(SimpleTestCase):
             self.assertEqual(moves[1], {'row': 3, 'col': 3, 'is_capture': True, 'is_promotion': False})
             self.assertEqual(moves[2], {'row': 0, 'col': 0, 'is_capture': False, 'is_promotion': True})
 
+    def test_get_engine_moves_ignores_incomplete_trailing_tokens(self):
+        """Test that malformed MOVES output with a trailing partial move is handled safely."""
+        with mock.patch.object(ChessGame, '_call_engine', return_value="MOVES 4 4 0 0 3 3 1"):
+            moves = self.game._get_engine_moves(6, 4)
+            self.assertEqual(moves, [
+                {'row': 4, 'col': 4, 'is_capture': False, 'is_promotion': False}
+            ])
+
     def test_check_game_status_parses_status(self):
         """Test that game status is correctly parsed from the STATUS response."""
         with mock.patch.object(ChessGame, '_call_engine', return_value="STATUS checkmate"):

--- a/game/tests.py
+++ b/game/tests.py
@@ -688,6 +688,13 @@ class EngineParsingTest(SimpleTestCase):
                 self.assertEqual(len(parts), 7)
                 self.assertEqual(parts[0], "BESTMOVE")
                 self.assertEqual(len(parts[1]), 64)
+                
+                # Assert specific token values
+                self.assertEqual(parts[2], "KQkq")  # Default castling rights
+                self.assertEqual(parts[3], "white") # Default current turn
+                self.assertEqual(parts[4], "-1")    # Default en-passant row
+                self.assertEqual(parts[5], "-1")    # Default en-passant col
+                self.assertEqual(parts[6], "3")     # Requested depth
 
     def test_get_ai_move_handles_none(self):
         """Test that get_ai_move handles a BESTMOVE NONE response."""

--- a/game/tests.py
+++ b/game/tests.py
@@ -663,3 +663,64 @@ class OpeningBookTest(SimpleTestCase):
         self.assertEqual(move['from_row'], 6)
         self.assertEqual(move['to_row'], 4)
         ChessGame._opening_book = None
+
+
+class EngineParsingTest(SimpleTestCase):
+    """Test that Python correctly parses engine responses and serialises data."""
+
+    def setUp(self):
+        self.game = ChessGame()
+
+    def test_get_ai_move_parses_bestmove(self):
+        """Test that get_ai_move correctly parses the BESTMOVE response from the engine."""
+        with mock.patch.object(ChessGame, '_call_engine', return_value="BESTMOVE 6 4 4 4") as mock_engine:
+            with mock.patch.object(ChessGame, 'get_opening_book_move', return_value=None):
+                move = self.game.get_ai_move(depth=3)
+                
+                self.assertIsNotNone(move)
+                self.assertEqual(move, {'from_row': 6, 'from_col': 4, 'to_row': 4, 'to_col': 4})
+                
+                mock_engine.assert_called_once()
+                cmd = mock_engine.call_args[0][0]
+                self.assertTrue(cmd.startswith("BESTMOVE"))
+                parts = cmd.split()
+                # Command format: BESTMOVE <board> <rights> <turn> <ep_row> <ep_col> <depth>
+                self.assertEqual(len(parts), 7)
+                self.assertEqual(parts[0], "BESTMOVE")
+                self.assertEqual(len(parts[1]), 64)
+
+    def test_get_ai_move_handles_none(self):
+        """Test that get_ai_move handles a BESTMOVE NONE response."""
+        with mock.patch.object(ChessGame, '_call_engine', return_value="BESTMOVE NONE"):
+            with mock.patch.object(ChessGame, 'get_opening_book_move', return_value=None):
+                move = self.game.get_ai_move()
+                self.assertIsNone(move)
+
+    def test_get_ai_move_handles_malformed_output(self):
+        """Test that get_ai_move handles malformed or unexpected engine output gracefully."""
+        with mock.patch.object(ChessGame, '_call_engine', return_value="UNKNOWN OUTPUT"):
+            with mock.patch.object(ChessGame, 'get_opening_book_move', return_value=None):
+                move = self.game.get_ai_move()
+                self.assertIsNone(move)
+
+    def test_get_engine_moves_parses_moves(self):
+        """Test that valid moves are correctly parsed from the MOVES response."""
+        with mock.patch.object(ChessGame, '_call_engine', return_value="MOVES 4 4 0 0 3 3 1 0 0 0 0 1"):
+            moves = self.game._get_engine_moves(6, 4)
+            self.assertEqual(len(moves), 3)
+            self.assertEqual(moves[0], {'row': 4, 'col': 4, 'is_capture': False, 'is_promotion': False})
+            self.assertEqual(moves[1], {'row': 3, 'col': 3, 'is_capture': True, 'is_promotion': False})
+            self.assertEqual(moves[2], {'row': 0, 'col': 0, 'is_capture': False, 'is_promotion': True})
+
+    def test_check_game_status_parses_status(self):
+        """Test that game status is correctly parsed from the STATUS response."""
+        with mock.patch.object(ChessGame, '_call_engine', return_value="STATUS checkmate"):
+            status = self.game.check_game_status()
+            self.assertEqual(status, "checkmate")
+
+    def test_call_engine_promote_parses_board(self):
+        """Test that the new board string is correctly parsed from the PROMOTE response."""
+        fake_board = "rnbqkbnrpppppppp................................PPPPPPPPRNBQKBNR"
+        with mock.patch.object(ChessGame, '_call_engine', return_value=f"PROMOTE {fake_board}"):
+            board = self.game._call_engine_promote(1, 0, 0, 0, 'q')
+            self.assertEqual(board, fake_board)


### PR DESCRIPTION
## Description

Adds a comprehensive unit test suite for parsing C++ engine responses (`BESTMOVE`, `MOVES`, `STATUS`, `PROMOTE`) and hardens the Python parsers in `engine.py` to safely handle malformed, truncated, or unexpected engine output without crashing.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #266

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

N/A — backend-only changes (unit tests + parser hardening).

## Additional Notes


