### PR TITLE
fix: show confirmation dialog on tab close during active game (#369)

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1209,9 +1209,14 @@
                     drawBtn.click();
                 }
             });
-            window.addEventListener('beforeunload', () => {
+            // Show browser confirmation dialog if user tries to leave during an active game
+            window.addEventListener('beforeunload', (e) => {
                 if (!paused) {
                     navigator.sendBeacon('/api/pause/', JSON.stringify({ pause: true }));
+                }
+                if (!gameOver && !welcomeOverlay.classList.contains('active')) {
+                    e.preventDefault();
+                    e.returnValue = '';
                 }
             });
 


### PR DESCRIPTION
Added confirmation dialog for unsaved changes during active game.

## Description
Added a confirmation dialog when the user tries to close or refresh 
the tab during an active game to prevent accidental game loss.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue
Fixes #369

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

## Screenshots (if applicable)
<img width="1469" height="835" alt="Screenshot 2026-05-07 at 10 06 26 AM" src="https://github.com/user-attachments/assets/ba06e65a-5000-42e1-9b70-3013c0fc20cc" />
<img width="1470" height="833" alt="Screenshot 2026-05-07 at 10 05 56 AM" src="https://github.com/user-attachments/assets/db4aade1-0199-45b6-a7af-d9ec6afcaef9" />

## Additional Notes
Modified the existing beforeunload event listener in board.js. 
The dialog only appears during an active game (not on welcome 
screen or after game over).

