### PR TITLE
views: use secrets module for OTP generation instead of random.

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -3,7 +3,7 @@
 import json
 import time
 import hashlib
-import random
+import secrets
 from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.conf import settings
 from django.http import JsonResponse
@@ -367,7 +367,7 @@ def register_view(request):
             user.save()
 
             # Generate 6-digit OTP
-            otp = str(random.randint(100000, 999999))
+            otp = str(secrets.randbelow(900000) + 100000)
             request.session['registration_user_id'] = user.id
             # Hash OTP with SECRET_KEY as salt to prevent reading from signed cookies
             otp_hash = hashlib.sha256(f"{otp}:{settings.SECRET_KEY}".encode()).hexdigest()


### PR DESCRIPTION
## Description
OTP generation in views.py used random.randint(100000, 999999). random is a PRNG, not a CSPRNG — the output is predictable if an attacker observes enough OTPs.
swapped to secrets.randbelow(900000) + 100000 for the same 6-digit range with a cryptographically secure backing. also switched the import from random to secrets since random isn't used anywhere else in views.py.
## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
## Related Issue
Fixes #217
## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
## Screenshots (if applicable)
no visual changes.
## Additional Notes
two-line change in game/views.py — one import swap, one function call swap. same 6-digit range, same behavior, just backed by the right tool for the job.