### PR TITLE
feat: add visual pause indicator with board blur and red button

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -208,6 +208,7 @@ body {
     display: flex;
     flex-direction: column;
     margin-top: 15px;
+    position: relative;
 }
 
 .board-row {
@@ -944,4 +945,15 @@ body {
         box-shadow: inset 0 0 14px rgba(220, 38, 38, 0.5), 
                     0 0 20px rgba(220, 38, 38, 0.4);
     }
+}
+
+/* ================= PAUSE STATE ================= */
+.chessboard.paused {
+    filter: blur(4px);
+    pointer-events: none;
+}
+
+#pauseBtn.paused {
+    background: linear-gradient(135deg, #ff4444, #cc0000);
+    color: #fff;
 }

--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -949,7 +949,7 @@ body {
 
 /* ================= PAUSE STATE ================= */
 .chessboard.paused {
-    filter: blur(4px);
+    filter: blur(1px);
     pointer-events: none;
 }
 

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -883,6 +883,8 @@
 
             function updatePauseUI() {
                 pauseBtn.textContent = paused ? 'Resume' : 'Pause';
+                pauseBtn.classList.toggle('paused', paused);
+                boardEl.classList.toggle('paused', paused);
             }
 
             function startTimer() {


### PR DESCRIPTION
## Description
When the game is paused, the chessboard now shows a subtle blur effect 
and the Pause button turns red, making it visually clear that the game 
is paused. Both effects revert instantly on resume.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue
Fixes #430 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

## Screenshots (if applicable)
<img width="1469" height="766" alt="Screenshot 2026-05-08 at 1 13 58 AM" src="https://github.com/user-attachments/assets/3517c866-c823-49d5-bf60-01c062af8399" />


## Additional Notes
Blur intensity is set to 1px