### PR TITLE
fix: replace signed_cookies with db session backend to prevent 4KB overflow

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -132,7 +132,7 @@ STATICFILES_DIRS = [
 ]
 STATIC_ROOT = BASE_DIR / "staticfiles"
 
-SESSION_ENGINE = 'django.contrib.sessions.backends.signed_cookies'
+SESSION_ENGINE = 'django.contrib.sessions.backends.db'
 
 # Email Configuration for OTP
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'


### PR DESCRIPTION
## Description

The project was using `signed_cookies` as the session backend, which stores the
entire session data inside the browser cookie. Browser cookies have a hard limit
of 4096 bytes (~4 KB).

A chess game state grows approximately 331 bytes per move. This means the cookie
silently overflows around move 12, causing the session to roll back to an older
state — board positions revert, captured pieces reappear, and the game becomes
corrupted with no error shown to the user.

This PR switches the session backend to `db`, which stores session data in the
database. No size limit. No data loss.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #434

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

[SS 1 — Terminal showing game state is 1325 bytes after 4 moves, overflowing at ~move 12]
<img width="625" height="369" alt="image" src="https://github.com/user-attachments/assets/f803aab6-fb38-44fb-b0cf-91def7f0a6f4" />


[SS 2 — Terminal confirming Session Backend is now `django.contrib.sessions.backends.db`]
<img width="745" height="194" alt="image" src="https://github.com/user-attachments/assets/a7e292e5-ce88-40b2-bd20-a2b916cac832" />


## Additional Notes

No code changes are needed in views.py or anywhere else. The `request.session`
API is identical regardless of backend — Django handles everything internally.

The infrastructure was already fully in place:
- `django.contrib.sessions` is already in `INSTALLED_APPS`
- `SessionMiddleware` is already active
- The `django_session` database table was already created by the existing migration
