### PR TITLE
Fix: Protect stats page with login_required

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -30,7 +30,7 @@ SECRET_KEY = os.environ.get('SECRET_KEY', 'django-insecure-dev-key-for-local-tes
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get('DEBUG', 'True').lower() == 'true'
 
-ALLOWED_HOSTS = ['.vercel.app', '*']
+ALLOWED_HOSTS = ['.vercel.app', 'localhost', '127.0.0.1']
 
 
 # Application definition

--- a/game/views.py
+++ b/game/views.py
@@ -17,6 +17,8 @@ from django import forms
 from .forms import CustomUserCreationForm
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_GET, require_POST
+from django.contrib.auth.decorators import login_required
+
 
 from .engine import ChessGame
 from .models import GameResult
@@ -499,7 +501,7 @@ def logout_view(request):
     logout(request)
     return redirect('index')
 
-
+@login_required
 def stats_view(request):
     """Display game statistics."""
     # from django.db.models import Count


### PR DESCRIPTION
## Description
This PR fixes a security issue where the `/stats/` page was publicly accessible without authentication.

## Changes Made
- Added `@login_required` decorator to `stats_view`
- Restricted access to game statistics page
- Improved application security and privacy
- Removed wildcard `*` from ALLOWED_HOSTS for safer configuration

## Impact
- Prevents unauthorized access to user/game history
- Ensures only logged-in users can view stats

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have tested changes locally
- [x] My changes do not break existing features
<img width="1600" height="784" alt="e24d8fc9-2b88-475f-81a2-ea91fe8ec363" src="https://github.com/user-attachments/assets/9e66b257-610d-4658-b8a7-51c852560768" />
