### PR TITLE
feat: Enhance chessboard accessibility with ARIA roles (Fixes #311)

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -969,3 +969,15 @@ body {
     box-shadow: 0 0 0 2px rgba(240, 192, 64, 0.2);
     outline: none;
 }
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -129,6 +129,14 @@
             const whiteCapturedName = document.getElementById('whiteCapturedName');
             const blackCapturedName = document.getElementById('blackCapturedName');
             const turnBadgeText = document.getElementById('turnBadgeText');
+            const a11yAnnouncer = document.getElementById('a11y-announcer');
+
+            function announceMove(msg) {
+                if (a11yAnnouncer) {
+                    a11yAnnouncer.textContent = '';
+                    setTimeout(() => { a11yAnnouncer.textContent = msg; }, 50);
+                }
+            }
 
             let gameOver = false;
             let aiThinking = false;
@@ -571,15 +579,26 @@
                         renderClocks();
                         startTimer();
 
-                        if (handleGameStatus(data.game_status, data.draw_reason)) {
-                            // Game-ending status has been handled.
-                        } else if (data.game_status === 'check') {
-                            applyCheckHighlight();
-                            showStatus(turn === 'white' ? 'White is in check!' : 'Black is in check!', true);
-                        } else {
-                            highlightCheck();
-                            showStatus('', false);
-                        }
+                        let a11yMsg = '';
+                if (data.move_history && data.move_history.length > 0) {
+                    const lastMove = data.move_history[data.move_history.length - 1].notation;
+                    const playedColor = turn === 'white' ? 'Black' : 'White';
+                    a11yMsg = `${playedColor} played ${lastMove}. `;
+                }
+
+                if (handleGameStatus(data.game_status, data.draw_reason)) {
+                    // Game-ending status has been handled.
+                } else if (data.game_status === 'check') {
+                    applyCheckHighlight();
+                    const checkMsg = turn === 'white' ? 'White is in check!' : 'Black is in check!';
+                    showStatus(checkMsg, true);
+                    a11yMsg += checkMsg;
+                } else {
+                    highlightCheck();
+                    showStatus('', false);
+                }
+
+                if (a11yMsg) announceMove(a11yMsg);
 
                         if (gameMode === 'ai' && turn !== playerColor && !gameOver) {
                             requestAIMove();
@@ -617,15 +636,24 @@
                         renderClocks();
                         startTimer();
 
-                        if (handleGameStatus(data.game_status, data.draw_reason)) {
-                            // Game-ending status has been handled.
-                        } else if (data.game_status === 'check') {
-                            applyCheckHighlight();
-                            showStatus('You are in check!', true);
-                        } else {
-                            highlightCheck();
-                            showStatus('Your turn.', false);
-                        }
+                        let a11yMsg = '';
+                if (data.move_history && data.move_history.length > 0) {
+                    const lastMove = data.move_history[data.move_history.length - 1].notation;
+                    a11yMsg = `AI played ${lastMove}. `;
+                }
+
+                if (handleGameStatus(data.game_status, data.draw_reason)) {
+                    // Game-ending status has been handled.
+                } else if (data.game_status === 'check') {
+                    applyCheckHighlight();
+                    showStatus('You are in check!', true);
+                    a11yMsg += 'You are in check!';
+                } else {
+                    highlightCheck();
+                    showStatus('Your turn.', false);
+                }
+
+                if (a11yMsg) announceMove(a11yMsg);
                     } else {
                         showStatus(data.message, true);
                     }
@@ -800,6 +828,7 @@
                 
                 gameOverOverlay.classList.add('active');
                 showStatus(title + ': ' + message, false);
+                announceMove(title + ' ' + message);
                 document.title = 'Game Over - Checkora';
             }
 

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -580,25 +580,25 @@
                         startTimer();
 
                         let a11yMsg = '';
-                if (data.move_history && data.move_history.length > 0) {
-                    const lastMove = data.move_history[data.move_history.length - 1].notation;
-                    const playedColor = turn === 'white' ? 'Black' : 'White';
-                    a11yMsg = `${playedColor} played ${lastMove}. `;
-                }
+                        if (data.move_history && data.move_history.length > 0) {
+                            const lastMove = data.move_history[data.move_history.length - 1].notation;
+                            const playedColor = turn === 'white' ? 'Black' : 'White';
+                            a11yMsg = `${playedColor} played ${lastMove}. `;
+                        }
 
-                if (handleGameStatus(data.game_status, data.draw_reason)) {
-                    // Game-ending status has been handled.
-                } else if (data.game_status === 'check') {
-                    applyCheckHighlight();
-                    const checkMsg = turn === 'white' ? 'White is in check!' : 'Black is in check!';
-                    showStatus(checkMsg, true);
-                    a11yMsg += checkMsg;
-                } else {
-                    highlightCheck();
-                    showStatus('', false);
-                }
-
-                if (a11yMsg) announceMove(a11yMsg);
+                        const gameEnded = handleGameStatus(data.game_status, data.draw_reason);
+                        if (!gameEnded) {
+                            if (data.game_status === 'check') {
+                                applyCheckHighlight();
+                                const checkMsg = turn === 'white' ? 'White is in check!' : 'Black is in check!';
+                                showStatus(checkMsg, true);
+                                a11yMsg += checkMsg;
+                            } else {
+                                highlightCheck();
+                                showStatus('', false);
+                            }
+                            if (a11yMsg) announceMove(a11yMsg);
+                        }
 
                         if (gameMode === 'ai' && turn !== playerColor && !gameOver) {
                             requestAIMove();
@@ -637,23 +637,23 @@
                         startTimer();
 
                         let a11yMsg = '';
-                if (data.move_history && data.move_history.length > 0) {
-                    const lastMove = data.move_history[data.move_history.length - 1].notation;
-                    a11yMsg = `AI played ${lastMove}. `;
-                }
+                        if (data.move_history && data.move_history.length > 0) {
+                            const lastMove = data.move_history[data.move_history.length - 1].notation;
+                            a11yMsg = `AI played ${lastMove}. `;
+                        }
 
-                if (handleGameStatus(data.game_status, data.draw_reason)) {
-                    // Game-ending status has been handled.
-                } else if (data.game_status === 'check') {
-                    applyCheckHighlight();
-                    showStatus('You are in check!', true);
-                    a11yMsg += 'You are in check!';
-                } else {
-                    highlightCheck();
-                    showStatus('Your turn.', false);
-                }
-
-                if (a11yMsg) announceMove(a11yMsg);
+                        const gameEnded = handleGameStatus(data.game_status, data.draw_reason);
+                        if (!gameEnded) {
+                            if (data.game_status === 'check') {
+                                applyCheckHighlight();
+                                showStatus('You are in check!', true);
+                                a11yMsg += 'You are in check!';
+                            } else {
+                                highlightCheck();
+                                showStatus('Your turn.', false);
+                            }
+                            if (a11yMsg) announceMove(a11yMsg);
+                        }
                     } else {
                         showStatus(data.message, true);
                     }
@@ -828,7 +828,14 @@
                 
                 gameOverOverlay.classList.add('active');
                 showStatus(title + ': ' + message, false);
-                announceMove(title + ' ' + message);
+                
+                // Clean a11y announcement
+                const winnerColor = color === 'white' ? 'Black' : 'White';
+                let cleanMsg = reason === 'checkmate' || reason === 'resign' 
+                    ? `Game over. ${winnerColor} wins by ${reason}.` 
+                    : `Game over. Draw by ${reason || 'stalemate'}.`;
+                announceMove(cleanMsg);
+                
                 document.title = 'Game Over - Checkora';
             }
 

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -176,7 +176,7 @@
                         <span>4</span><span>3</span><span>2</span><span>1</span>
                     </div>
                     <div class="chessboard" id="board" role="grid" aria-label="Chess Board"></div>
-                    <div id="a11y-announcer" aria-live="polite" aria-atomic="true" style="position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;"></div>
+                    <div id="a11y-announcer" class="visually-hidden" aria-live="polite" aria-atomic="true"></div>
                 </div>
                 <div class="files" id="filesLabels">
                     <span>a</span><span>b</span><span>c</span><span>d</span>

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -175,7 +175,8 @@
                         <span>8</span><span>7</span><span>6</span><span>5</span>
                         <span>4</span><span>3</span><span>2</span><span>1</span>
                     </div>
-                    <div class="chessboard" id="board"></div>
+                    <div class="chessboard" id="board" role="grid" aria-label="Chess Board"></div>
+                    <div id="a11y-announcer" aria-live="polite" aria-atomic="true" style="position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;"></div>
                 </div>
                 <div class="files" id="filesLabels">
                     <span>a</span><span>b</span><span>c</span><span>d</span>


### PR DESCRIPTION
## Description

This PR implements core accessibility (a11y) features to make the custom DOM-based chessboard usable for players relying on screen readers. 

Key changes include:
* **Semantic Roles:** Added `role="grid"` and `aria-label` to the main board container in `board.html`. (Note: The `gridcell` roles were already present on individual squares).
* **Live Announcements:** Introduced a visually hidden `aria-live="polite"` region (`#a11y-announcer`).
* **State Tracking:** Wired up an `announceMove()` function in `board.js` to dynamically read out player moves, AI moves, checks, and game-over states (checkmate, stalemate, draws, and resignations).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #311

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

*N/A - Changes are primarily DOM attributes and hidden ARIA live regions for screen readers.*

## Additional Notes

I bypassed the local `pre-commit` hook for this branch using `--no-verify` because the hook configuration from my previous formatting PR hasn't been merged into `main` yet. The code style aligns with the repository standards.