### PR TITLE
UI: Add loading spinner to Sign In and Register buttons.

### DIFF
--- a/game/static/game/css/auth.css
+++ b/game/static/game/css/auth.css
@@ -161,3 +161,30 @@ body {
 body.login-page .helptext {
     display: none;
 }
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+.btn-loading {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+}
+
+.spinner {
+    width: 18px;
+    height: 18px;
+    border: 2px solid rgba(26, 26, 46, 0.3);
+    border-top: 2px solid #1a1a2e;
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+}
+
+.btn:disabled {
+    opacity: 0.9;
+    cursor: not-allowed;
+    pointer-events: none;
+}

--- a/game/static/game/js/auth.js
+++ b/game/static/game/js/auth.js
@@ -1,6 +1,7 @@
 document.addEventListener("DOMContentLoaded", () => {
   const eyeIcon = '<svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>';
   const eyeOffIcon = '<svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94"/><path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19"/><line x1="1" y1="1" x2="23" y2="23"/></svg>';
+  const originalButtonText = {};
 
   function togglePw(id, btn) {
     const input = document.getElementById(id);
@@ -32,5 +33,29 @@ document.addEventListener("DOMContentLoaded", () => {
 
     positionToggle();
     window.addEventListener("resize", positionToggle);
+  });
+
+  const submitBtn = document.getElementById("submit-btn");
+  if (submitBtn) {
+    originalButtonText[submitBtn.id] = submitBtn.textContent;
+
+    const form = submitBtn.closest("form");
+    if (form) {
+      form.addEventListener("submit", (e) => {
+        if (!submitBtn.disabled) {
+          submitBtn.disabled = true;
+          submitBtn.classList.add("btn-loading");
+          submitBtn.innerHTML = `<div class="spinner"></div>${originalButtonText[submitBtn.id]}`;
+        }
+      });
+    }
+  }
+
+  window.addEventListener("pageshow", () => {
+    if (submitBtn) {
+      submitBtn.disabled = false;
+      submitBtn.classList.remove("btn-loading");
+      submitBtn.textContent = originalButtonText[submitBtn.id] || "Submit";
+    }
   });
 });

--- a/game/templates/game/login.html
+++ b/game/templates/game/login.html
@@ -35,7 +35,7 @@
                 </div>
             {% endfor %}
             
-            <button type="submit" class="btn btn-gold">Sign In</button>
+            <button type="submit" class="btn btn-gold" id="submit-btn">Sign In</button>
         </form>
         
         <div class="auth-footer">

--- a/game/templates/game/register.html
+++ b/game/templates/game/register.html
@@ -42,7 +42,7 @@
         </div>
         {% endfor %}
 
-        <button type="submit" class="btn btn-gold">Create Account</button>
+        <button type="submit" class="btn btn-gold" id="submit-btn">Create Account</button>
       </form>
 
       <div class="auth-footer">


### PR DESCRIPTION
## Description

Add a loading spinner inside the Sign In and Register buttons so users get immediate visual feedback while the server processes the request. The button is disabled after click to prevent double submission, and the state resets if the user navigates back.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #452 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## How to Test

1. Open `/login/`
2. Click **Sign In**
3. Confirm spinner appears and button disables
4. Open `/register/`
5. Click **Create Account**
6. Confirm spinner appears and button disables
7. Use browser **Back** and confirm button resets