### PR TITLE
Feature/pvp emote panel

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -1142,3 +1142,37 @@ body {
     white-space: nowrap;
     border: 0;
 }
+
+/* ================= EMOTE PANEL ================= */
+.emote-btn:hover {
+    transform: scale(1.2);
+}
+.floating-emote {
+    position: absolute;
+    font-size: 2.5rem;
+    pointer-events: none;
+    z-index: 1000;
+    animation: floatUp 2s ease-out forwards;
+}
+.floating-emote.white-emote {
+    left: 10%;
+    filter: drop-shadow(0 0 8px rgba(255, 255, 255, 0.8));
+}
+.floating-emote.black-emote {
+    right: 10%;
+    filter: drop-shadow(0 0 8px rgba(0, 100, 255, 0.8));
+}
+@keyframes floatUp {
+    0% {
+        opacity: 0;
+        transform: translateY(20px) scale(0.5);
+    }
+    10% {
+        opacity: 1;
+        transform: translateY(0) scale(1.2);
+    }
+    100% {
+        opacity: 0;
+        transform: translateY(-100px) scale(1);
+    }
+}

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -323,6 +323,11 @@
 
                 if (modeBadge) modeBadge.textContent = gameMode === 'ai' ? 'VS AI' : 'PVP';
 
+                const emotePanel = document.getElementById('emotePanel');
+                if (emotePanel) {
+                    emotePanel.style.display = gameMode === 'pvp' ? 'block' : 'none';
+                }
+
                 // Show Resume button if we have an ongoing game
                 const hasMoves = data.move_history && data.move_history.length > 0;
                 const isResumable = hasMoves && data.game_status === 'active';
@@ -1321,6 +1326,11 @@
                 }
 
                 if (modeBadge) modeBadge.textContent = gameMode === 'ai' ? 'VS AI' : 'PVP';
+
+                const emotePanel = document.getElementById('emotePanel');
+                if (emotePanel) {
+                    emotePanel.style.display = gameMode === 'pvp' ? 'block' : 'none';
+                }
                 movesEl.innerHTML = '<span class="placeholder">No moves yet</span>';
                 wCapEl.innerHTML = bCapEl.innerHTML = '';
 
@@ -1753,6 +1763,31 @@
                     drawBtn.click();
                 }
             });
+            // Emote Logic
+            let emoteCooldown = false;
+            document.querySelectorAll('.emote-btn').forEach(btn => {
+                btn.addEventListener('click', (e) => {
+                    if (gameMode !== 'pvp') return;
+                    if (emoteCooldown) {
+                        showStatus('Emote cooldown (1s)', true);
+                        setTimeout(() => showStatus(''), 1000);
+                        return;
+                    }
+                    emoteCooldown = true;
+                    setTimeout(() => emoteCooldown = false, 1000);
+
+                    const emoteChar = e.currentTarget.getAttribute('data-emote');
+                    const emoteEl = document.createElement('div');
+                    emoteEl.className = 'floating-emote ' + (turn === 'white' ? 'white-emote' : 'black-emote');
+                    emoteEl.textContent = emoteChar;
+                    const boardOuter = document.querySelector('.board-outer');
+                    if (boardOuter) {
+                        boardOuter.appendChild(emoteEl);
+                        setTimeout(() => emoteEl.remove(), 2000);
+                    }
+                });
+            });
+
             // Show browser confirmation dialog if user tries to leave during an active game
             window.addEventListener('beforeunload', (e) => {
                 if (!paused) {

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -196,6 +196,17 @@
                 <div class="captured-list" id="blackCaptured"></div>
                 <div class="captured-score">Points: <span id="blackPoints">+0</span></div>
             </div>
+
+            <div class="card" id="emotePanel" style="display: none;">
+                <div class="card-title">React</div>
+                <div style="display: flex; gap: 8px; justify-content: space-around; font-size: 1.5rem; flex-wrap: wrap;">
+                    <button class="emote-btn" data-emote="👍" style="background:none;border:none;cursor:pointer;transition:transform 0.2s;">👍</button>
+                    <button class="emote-btn" data-emote="🤝" style="background:none;border:none;cursor:pointer;transition:transform 0.2s;">🤝</button>
+                    <button class="emote-btn" data-emote="😂" style="background:none;border:none;cursor:pointer;transition:transform 0.2s;">😂</button>
+                    <button class="emote-btn" data-emote="😮" style="background:none;border:none;cursor:pointer;transition:transform 0.2s;">😮</button>
+                    <button class="emote-btn" data-emote="🏳️" style="background:none;border:none;cursor:pointer;transition:transform 0.2s;">🏳️</button>
+                </div>
+            </div>
         </div>
 
         <!-- Board -->


### PR DESCRIPTION
## Description

Adds an emote panel to the left sidebar that is visible only in PvP mode. Players can click emoji reactions (👍 🤝 😂 😮 🏳️) which trigger an animated floating emoji on the board. White player's emotes float from the left side, black player's from the right, making it easy to distinguish who sent the emote. A 1-second cooldown prevents spamming.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #240 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

## Screenshots (if applicable)

Add screenshots to demonstrate visual changes.
<img width="1882" height="904" alt="Screenshot 2026-05-10 145912" src="https://github.com/user-attachments/assets/79032f99-0a66-40f5-be94-1125c486ee8a" />
<img width="1893" height="907" alt="Screenshot 2026-05-10 150139" src="https://github.com/user-attachments/assets/85fb0352-91d6-401c-bdb7-b7fa16602892" />




## Additional Notes
- Frontend-only change — no backend or API modifications required
- Changes isolated to `game/templates/game/board.html`, `game/static/game/css/board.css`, and `game/static/game/js/board.js`
- Emote panel auto-hides when switching to vs AI mode
- White player's emotes float from the left with a white glow, black player's from the right with a blue glow
- 1-second cooldown prevents spamming with a status bar feedback message that auto-clears
- README updated to reflect the new emote panel feature
