### PR TITLE
feat: improve password visibility toggle on login & register pages

### DIFF
--- a/game/static/game/css/auth.css
+++ b/game/static/game/css/auth.css
@@ -122,40 +122,45 @@ body {
     color: #fff;
 }
 
-.pw-parent {
+/* ── Password visibility toggle ── */
+.pw-input-wrapper {
     position: relative;
+    display: flex;
+    align-items: center;
 }
-.password-with-toggle {
+.pw-input-wrapper input {
     padding-right: 2.5rem;
 }
 .pw-toggle {
     position: absolute;
-    right: 0.6rem;
-    top: 2.45rem;
+    right: 0.75rem;
+    top: 50%;
     transform: translateY(-50%);
     background: none;
     border: none;
     outline: none;
     -webkit-appearance: none;
     cursor: pointer;
-    color: #f0c040;
-    padding: 0;
+    color: #8a8aaa;
+    padding: 4px;
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 1.5rem;
-    height: 1.5rem;
+    border-radius: 4px;
+    transition: color 0.2s ease;
     z-index: 2;
 }
 .pw-toggle:hover {
-    color: #fff;
+    color: #f0c040;
 }
 .pw-toggle:focus-visible {
-    outline: 2px solid #c9a84c;
-    border-radius: 3px;
+    outline: 2px solid #f0c040;
+    outline-offset: 2px;
+    border-radius: 4px;
 }
 .pw-toggle svg {
     display: block;
+    pointer-events: none;
 }
 
 body.login-page .helptext {

--- a/game/static/game/js/auth.js
+++ b/game/static/game/js/auth.js
@@ -1,36 +1,49 @@
 document.addEventListener("DOMContentLoaded", () => {
-  const eyeIcon = '<svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>';
-  const eyeOffIcon = '<svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94"/><path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19"/><line x1="1" y1="1" x2="23" y2="23"/></svg>';
+  /* ── SVG icons (inline – no external dependency) ── */
+  const eyeIcon =
+    '<svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" ' +
+    'width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" ' +
+    'stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+    '<path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>' +
+    '<circle cx="12" cy="12" r="3"/></svg>';
 
-  function togglePw(id, btn) {
-    const input = document.getElementById(id);
+  const eyeOffIcon =
+    '<svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" ' +
+    'width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" ' +
+    'stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+    '<path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94"/>' +
+    '<path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19"/>' +
+    '<line x1="1" y1="1" x2="23" y2="23"/></svg>';
+
+  /* ── Toggle handler ── */
+  function togglePassword(input, btn) {
     const isHidden = input.type === "password";
     input.type = isHidden ? "text" : "password";
     btn.innerHTML = isHidden ? eyeOffIcon : eyeIcon;
     btn.setAttribute("aria-label", isHidden ? "Hide password" : "Show password");
-    btn.setAttribute("aria-pressed", isHidden ? "true" : "false");
+    btn.setAttribute("aria-pressed", String(isHidden));
   }
 
+  /* ── Inject toggle into every password field ── */
   document.querySelectorAll('input[type="password"]').forEach((input, i) => {
     if (!input.id) input.id = "pw-field-" + i;
-    input.classList.add("password-with-toggle");
-    const parent = input.closest(".form-group") || input.parentNode;
-    if (parent && parent.classList) parent.classList.add("pw-parent");
+
+    /* Create a wrapper that sits inside .form-group, around the input only.
+       This keeps the toggle button positioned relative to the input,
+       regardless of labels, help-text or error messages around it. */
+    const wrapper = document.createElement("div");
+    wrapper.className = "pw-input-wrapper";
+    input.parentNode.insertBefore(wrapper, input);
+    wrapper.appendChild(input);
+
+    /* Build toggle button */
     const btn = document.createElement("button");
     btn.type = "button";
     btn.className = "pw-toggle";
     btn.setAttribute("aria-label", "Show password");
     btn.setAttribute("aria-pressed", "false");
     btn.innerHTML = eyeIcon;
-    btn.onclick = () => togglePw(input.id, btn);
-    parent.appendChild(btn);
-
-    const positionToggle = () => {
-      const top = input.offsetTop + input.offsetHeight / 2;
-      btn.style.top = top + "px";
-    };
-
-    positionToggle();
-    window.addEventListener("resize", positionToggle);
+    btn.addEventListener("click", () => togglePassword(input, btn));
+    wrapper.appendChild(btn);
   });
 });

--- a/game/templates/game/login.html
+++ b/game/templates/game/login.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sign In | Checkora</title>
-    <link rel="stylesheet" href="{% static 'game/css/auth.css' %}?v=5">
+    <link rel="stylesheet" href="{% static 'game/css/auth.css' %}?v=6">
     <link rel="icon" type="image/jpeg" href="{% static 'game/favicon.jpeg' %}">
 </head>
 <body class="login-page">
@@ -45,6 +45,6 @@
         </div>
     </div>
 
-    <script src="{% static 'game/js/auth.js' %}?v=5"></script>
+    <script src="{% static 'game/js/auth.js' %}?v=6"></script>
 </body>
 </html>

--- a/game/templates/game/register.html
+++ b/game/templates/game/register.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Register | Checkora</title>
-    <link rel="stylesheet" href="{% static 'game/css/auth.css' %}?v=5" />
+    <link rel="stylesheet" href="{% static 'game/css/auth.css' %}?v=6" />
     <link
       rel="icon"
       type="image/jpeg"
@@ -50,6 +50,6 @@
       </div>
     </div>
 
-    <script src="{% static 'game/js/auth.js' %}?v=5"></script>
+    <script src="{% static 'game/js/auth.js' %}?v=6"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
Fixes #449 — Improves the password visibility toggle (eye icon) on the Login and Register pages.

## What Changed

### Problem with the previous implementation
The existing toggle used `.pw-parent` (the entire `.form-group`) as the positioning context. The JS calculated `btn.style.top` from `input.offsetTop`, which is fragile — it breaks when help-text, labels, or error messages shift the layout. On the Register page (which has help-text under password fields), the toggle icon could misalign.

### Solution
- **Introduced `.pw-input-wrapper`** — a dedicated `<div>` that wraps only the `<input>` and the toggle `<button>`. This ensures `position: absolute; top: 50%; transform: translateY(-50%)` always centers the icon vertically on the input, regardless of surrounding content.
- **Removed JS-based positioning** (`offsetTop` calculations + resize listener) in favor of pure CSS positioning — simpler and more reliable.
- **Better UX**: icon starts as muted (`#8a8aaa`) and highlights to gold (`#f0c040`) on hover, with a smooth transition.
- **Accessibility**: proper `aria-label`, `aria-pressed`, `pointer-events: none` on SVG to prevent click-through issues.
- **No external dependencies**: uses inline SVG icons instead of FontAwesome — zero extra network requests.

## Files Changed
| File | Change |
|------|--------|
| `game/static/game/js/auth.js` | Rewrote toggle injection to use `.pw-input-wrapper`; removed JS positioning |
| `game/static/game/css/auth.css` | Replaced `.pw-parent`/`.password-with-toggle` with `.pw-input-wrapper`; improved hover/focus styles |
| `game/templates/game/login.html` | Bumped cache-busting version `v=5` → `v=6` |
| `game/templates/game/register.html` | Bumped cache-busting version `v=5` → `v=6` |

## Testing
- Works on both `/login/` and `/register/` pages
- Toggle correctly shows/hides password on click
- Works on mobile and desktop viewports
- Toggle stays aligned even when error messages or help-text are displayed

## Expected Behavior
- 👁️ Click eye icon → password becomes visible
- 👁️‍🗨️ Click again → password is hidden
- Works on both mobile and desktop
