### PR TITLE
game: Fix missing DB save for AI checkmates and refine stats calculation

### DIFF
--- a/game/migrations/0002_gameresult_human_color.py
+++ b/game/migrations/0002_gameresult_human_color.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('game', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='gameresult',
+            name='human_color',
+            field=models.CharField(
+                blank=True,
+                choices=[('white', 'White'), ('black', 'Black')],
+                max_length=10,
+                null=True,
+            ),
+        ),
+    ]

--- a/game/models.py
+++ b/game/models.py
@@ -11,9 +11,14 @@ class GameResult(models.Model):
         ("timeout", "Timeout"),
         ("agreement", "Agreement"),
     ]
+    COLOR_CHOICES = [("white", "White"), ("black", "Black")]
     mode = models.CharField(max_length=10, choices=MODE_CHOICES)
     winner = models.CharField(max_length=10, choices=WINNER_CHOICES)
     end_reason = models.CharField(max_length=15, choices=END_REASON_CHOICES)
+    # Only populated for AI games; stores which color the human was playing.
+    human_color = models.CharField(
+        max_length=10, choices=COLOR_CHOICES, null=True, blank=True
+    )
     played_at = models.DateTimeField(auto_now_add=True)
 
     def __str__(self):

--- a/game/views.py
+++ b/game/views.py
@@ -38,6 +38,8 @@ def index(request):
 
 def record_game_result(mode, winner, reason, human_color=None):
     """Save a completed game result to the database."""
+    if human_color not in ('white', 'black'):
+        human_color = None
     GameResult.objects.create(
         mode=mode, winner=winner, end_reason=reason, human_color=human_color
     )
@@ -74,7 +76,8 @@ def make_move(request):
             winner = 'black' if game.current_turn == 'white' else 'white'
             record_game_result(game.mode, winner, 'checkmate', human_color)
         elif game_status in ('stalemate', 'draw'):
-            record_game_result(game.mode, 'draw', 'stalemate', human_color)
+            end_reason = game.draw_reason or game_status
+            record_game_result(game.mode, 'draw', end_reason, human_color)
 
     return JsonResponse({
         'valid': success,
@@ -294,7 +297,8 @@ def ai_move(request):
             winner = 'black' if game.current_turn == 'white' else 'white'
             record_game_result(game.mode, winner, 'checkmate', human_color)
         elif game_status in ('stalemate', 'draw'):
-            record_game_result(game.mode, 'draw', 'stalemate', human_color)
+            end_reason = game.draw_reason or game_status
+            record_game_result(game.mode, 'draw', end_reason, human_color)
 
     return JsonResponse({
         'valid': success,

--- a/game/views.py
+++ b/game/views.py
@@ -36,9 +36,11 @@ def index(request):
     return render(request, 'game/board.html')
 
 
-def record_game_result(mode, winner, reason):
+def record_game_result(mode, winner, reason, human_color=None):
     """Save a completed game result to the database."""
-    GameResult.objects.create(mode=mode, winner=winner, end_reason=reason)
+    GameResult.objects.create(
+        mode=mode, winner=winner, end_reason=reason, human_color=human_color
+    )
 
 
 @require_POST
@@ -67,11 +69,12 @@ def make_move(request):
     if success:
         request.session['game'] = game.to_dict()
         request.session.modified = True
+        human_color = request.session.get('player_color') if game.mode == 'ai' else None
         if game_status == 'checkmate':
             winner = 'black' if game.current_turn == 'white' else 'white'
-            record_game_result(game.mode, winner, 'checkmate')
+            record_game_result(game.mode, winner, 'checkmate', human_color)
         elif game_status in ('stalemate', 'draw'):
-            record_game_result(game.mode, 'draw', 'stalemate')
+            record_game_result(game.mode, 'draw', 'stalemate', human_color)
 
     return JsonResponse({
         'valid': success,
@@ -286,6 +289,12 @@ def ai_move(request):
     if success:
         request.session['game'] = game.to_dict()
         request.session.modified = True
+        human_color = request.session.get('player_color')
+        if game_status == 'checkmate':
+            winner = 'black' if game.current_turn == 'white' else 'white'
+            record_game_result(game.mode, winner, 'checkmate', human_color)
+        elif game_status in ('stalemate', 'draw'):
+            record_game_result(game.mode, 'draw', 'stalemate', human_color)
 
     return JsonResponse({
         'valid': success,
@@ -508,13 +517,23 @@ def logout_view(request):
 
 def stats_view(request):
     """Display game statistics."""
-    # from django.db.models import Count
     recent = GameResult.objects.order_by('-played_at')[:20]
     ai_results = GameResult.objects.filter(mode='ai')
-    ai_wins = ai_results.filter(winner='white').count() + ai_results.filter(winner='black').count()
     ai_draws = ai_results.filter(winner='draw').count()
     ai_total = ai_results.count()
-    # ai_losses = 0
+
+    # Count AI wins: games where human_color is set and the winner is the
+    # opposite color (i.e. the AI side won).
+    ai_wins = (
+        ai_results.filter(human_color='white', winner='black').count()
+        + ai_results.filter(human_color='black', winner='white').count()
+    )
+    # For legacy rows that have no human_color recorded, fall back to treating
+    # all non-draw decisive results as AI wins to preserve historical counts.
+    ai_wins += ai_results.filter(
+        human_color__isnull=True, winner__in=['white', 'black']
+    ).count()
+
     return render(request, 'game/stats.html', {
         'recent': recent,
         'ai_total': ai_total,


### PR DESCRIPTION
## Summary

Fixes two related issues with how AI game results are tracked and displayed on the stats page.

**1. AI checkmates were not saved to the database**

In `ai_move`, when the engine delivers checkmate or causes stalemate, there was no call to `record_game_result`. This meant AI victories never appeared in the Recent Games table or counted toward any stats. The fix mirrors the identical logic already present in `make_move`.

**2. Stats page counted all decisive AI games as "AI wins"**

`stats_view` summed both white and black wins from AI games and labelled that total "AI Wins". Since the `GameResult` model had no way to know which color the human was playing, human victories were being counted as AI wins too.

## Changes

- `game/models.py` — add nullable `human_color` field to `GameResult` to record which color the human controlled in AI games.
- `game/migrations/0002_gameresult_human_color.py` — migration for the new field.
- `game/views.py`:
  - `record_game_result` now accepts an optional `human_color` argument.
  - `make_move` and `ai_move` both pass `player_color` from the session as `human_color` for AI games.
  - `ai_move` now calls `record_game_result` on checkmate and stalemate outcomes.
  - `stats_view` now counts AI wins correctly: only games where the winner is the opposite of `human_color`. Legacy rows without `human_color` fall back to the old counting to preserve historical data.

## Test plan

- [ ] Play a game vs AI, let the AI checkmate you — confirm result appears in Recent Games.
- [ ] Play a game vs AI, checkmate the AI — confirm result appears and is not counted as an AI win.
- [ ] Verify stalemate in AI mode is recorded correctly.
- [ ] Check stats page shows correct AI win/draw/total counts.
- [ ] Confirm PvP games are unaffected (`human_color` is `null` for PvP rows).

Fixes #467