### PR TITLE
feat: add /dev-settings/ toggle for Python fallback vs C++ engine

### DIFF
--- a/game/engine.py
+++ b/game/engine.py
@@ -67,9 +67,14 @@ class ChessGame:
     #  Construction / serialization
     # ------------------------------------------------------------------
 
+    # Class-level Python engine path (last entry in candidates list)
+    PYTHON_ENGINE_PATH = os.path.join(ENGINE_DIR, 'main.py')
+
     def __init__(self):
         self.board = [row[:] for row in self.INITIAL_BOARD]
         self.current_turn = 'white'
+        # When True, skip the compiled binary and always use the Python fallback
+        self.force_python = False
         self.move_history = []
         self.captured = {'white': [], 'black': []}
         # DP Table: {(row, col): [list of moves]}
@@ -178,10 +183,15 @@ DP cache is intentionally excluded to save cookie space."""
     #  C++ engine communication
     # ------------------------------------------------------------------
 
-    @classmethod
-    def _resolve_engine_path(cls):
-        """Return the first available engine entrypoint for this platform."""
-        for path in cls.ENGINE_CANDIDATES:
+    def _resolve_engine_path(self):
+        """Return the engine entrypoint for this platform.
+
+        When ``self.force_python`` is True the Python fallback script is
+        returned directly (if it exists), bypassing any compiled binary.
+        """
+        if self.force_python:
+            return self.PYTHON_ENGINE_PATH if os.path.exists(self.PYTHON_ENGINE_PATH) else None
+        for path in self.ENGINE_CANDIDATES:
             if os.path.exists(path):
                 return path
         return None

--- a/game/engine.py
+++ b/game/engine.py
@@ -130,6 +130,7 @@ DP cache is intentionally excluded to save cookie space."""
         return {
             'board': self.board,
             'current_turn': self.current_turn,
+            'force_python': self.force_python,
             'move_history': self.move_history,
             'captured': self.captured,
             'white_time': self.white_time,
@@ -152,6 +153,7 @@ DP cache is intentionally excluded to save cookie space."""
         game = cls.__new__(cls)
         game.board = data['board']
         game.current_turn = data['current_turn']
+        game.force_python = data.get('force_python', False)
         game.move_history = data.get('move_history', [])
         game.captured = data.get('captured', {'white': [], 'black': []})
         game.paused = data.get('paused', False)

--- a/game/templates/game/dev_settings.html
+++ b/game/templates/game/dev_settings.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Checkora - Developer Settings</title>
+    <style>
+        body { background: #0f0f1a; color: #d0d0d0; font-family: Arial, sans-serif; padding: 40px; }
+        h1 { color: #f0c040; text-align: center; letter-spacing: 2px; }
+        .container { max-width: 560px; margin: 40px auto; background: #16162a; border: 1px solid #252545; border-radius: 10px; padding: 32px; }
+        .status { font-size: 15px; margin-bottom: 24px; color: #8a8aaa; }
+        .status strong { color: #f0c040; }
+        .radio-group { display: flex; flex-direction: column; gap: 14px; margin-bottom: 28px; }
+        .radio-group label { display: flex; align-items: center; gap: 10px; cursor: pointer; font-size: 15px; }
+        .radio-group input[type="radio"] { accent-color: #f0c040; width: 16px; height: 16px; }
+        .desc { color: #6a6a8a; font-size: 13px; margin-left: 26px; margin-top: 2px; }
+        button { background: #f0c040; color: #0f0f1a; border: none; border-radius: 6px; padding: 10px 28px; font-size: 15px; font-weight: bold; cursor: pointer; }
+        button:hover { background: #e0b030; }
+        .messages { margin-bottom: 20px; }
+        .messages li { list-style: none; background: #1e3a1e; border: 1px solid #2a5a2a; border-radius: 6px; padding: 10px 14px; color: #7fd07f; margin-bottom: 8px; }
+        .back { text-align: center; margin-top: 28px; }
+        a { color: #f0c040; text-decoration: none; }
+        a:hover { text-decoration: underline; }
+        .badge { display: inline-block; padding: 2px 10px; border-radius: 12px; font-size: 12px; font-weight: bold; margin-left: 8px; }
+        .badge-python { background: #2a3a5a; color: #7ab4f0; }
+        .badge-cpp { background: #3a2a1a; color: #f0a840; }
+    </style>
+</head>
+<body>
+    <h1>CHECK<span style="color:#fff">ORA</span> &mdash; Developer Settings</h1>
+
+    <div class="container">
+        {% if messages %}
+        <ul class="messages">
+            {% for message in messages %}
+            <li>{{ message }}</li>
+            {% endfor %}
+        </ul>
+        {% endif %}
+
+        <div class="status">
+            Current engine:
+            {% if force_python %}
+                <strong>Python fallback</strong>
+                <span class="badge badge-python">python</span>
+            {% else %}
+                <strong>C++ (auto-detect)</strong>
+                <span class="badge badge-cpp">c++</span>
+            {% endif %}
+        </div>
+
+        <form method="post">
+            {% csrf_token %}
+            <div class="radio-group">
+                <div>
+                    <label>
+                        <input type="radio" name="engine_mode" value="auto" {% if not force_python %}checked{% endif %}>
+                        C++ engine (auto-detect)
+                    </label>
+                    <div class="desc">Default. Uses the compiled binary when available; falls back to Python automatically.</div>
+                </div>
+                <div>
+                    <label>
+                        <input type="radio" name="engine_mode" value="python" {% if force_python %}checked{% endif %}>
+                        Python fallback (force)
+                    </label>
+                    <div class="desc">Always use the pure-Python minimax engine. Slower but useful when build tools are unavailable.</div>
+                </div>
+            </div>
+            <button type="submit">Save</button>
+        </form>
+    </div>
+
+    <div class="back"><a href="{% url 'index' %}">&larr; Back to game</a></div>
+</body>
+</html>

--- a/game/urls.py
+++ b/game/urls.py
@@ -17,6 +17,9 @@ urlpatterns = [
     path('api/draw/', views.offer_draw, name='offer_draw'),
     path('stats/', views.stats_view, name='stats'),
 
+    # Developer settings
+    path('dev-settings/', views.dev_settings_view, name='dev_settings'),
+
     # Authentication
     path('register/', views.register_view, name='register'),
     path('verify-otp/', views.verify_otp, name='verify_otp'),

--- a/game/views.py
+++ b/game/views.py
@@ -6,7 +6,7 @@ import hashlib
 import secrets
 from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.conf import settings
-from django.http import JsonResponse
+from django.http import JsonResponse, HttpResponseForbidden
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth import login, logout
 from django.contrib.auth.models import User
@@ -59,6 +59,7 @@ def make_move(request):
 
     game_data = request.session.get('game')
     game = ChessGame.from_dict(game_data) if game_data else ChessGame()
+    game.force_python = bool(request.session.get('force_python_engine', False))
 
     success, message, captured, game_status = game.make_move(
         from_row, from_col, to_row, to_col, promotion_piece,
@@ -109,6 +110,7 @@ def valid_moves(request):
         return JsonResponse({'valid_moves': []})
 
     game = ChessGame.from_dict(game_data)
+    game.force_python = bool(request.session.get('force_python_engine', False))
     moves = game.get_valid_moves(row, col)
     return JsonResponse({'valid_moves': moves})
 
@@ -526,6 +528,8 @@ def stats_view(request):
 
 def dev_settings_view(request):
     """Developer settings: toggle between C++ engine and Python fallback."""
+    if not settings.DEBUG:
+        return HttpResponseForbidden('Not available in production.')
     if request.method == 'POST':
         force_python = request.POST.get('engine_mode') == 'python'
         request.session['force_python_engine'] = force_python

--- a/game/views.py
+++ b/game/views.py
@@ -257,6 +257,7 @@ def ai_move(request):
         )
 
     game = ChessGame.from_dict(game_data)
+    game.force_python = bool(request.session.get('force_python_engine', False))
 
     if game.mode != 'ai':
         err_msg = 'Not in AI mode.'
@@ -521,3 +522,18 @@ def stats_view(request):
         'ai_wins': ai_wins,
         'ai_draws': ai_draws,
     })
+
+
+def dev_settings_view(request):
+    """Developer settings: toggle between C++ engine and Python fallback."""
+    if request.method == 'POST':
+        force_python = request.POST.get('engine_mode') == 'python'
+        request.session['force_python_engine'] = force_python
+        messages.success(
+            request,
+            'Engine set to Python fallback.' if force_python else 'Engine set to C++ (auto-detect).',
+        )
+        return redirect('dev_settings')
+
+    current = bool(request.session.get('force_python_engine', False))
+    return render(request, 'game/dev_settings.html', {'force_python': current})


### PR DESCRIPTION
## Summary

- Adds a `force_python` flag to `ChessGame` that, when `True`, bypasses the compiled C++ binary and always runs the pure-Python fallback engine
- Converts `_resolve_engine_path` from a `@classmethod` to an instance method so it can read `self.force_python`
- In the `ai_move` view, reads `force_python_engine` from the Django session and applies it to the game object before calling `get_ai_move` — no extra DB queries, session-scoped per developer
- Adds `dev_settings_view` (GET/POST) at `/dev-settings/` that renders a radio-button form and writes the toggle into the session
- Adds `game/templates/game/dev_settings.html` styled to match the existing dark theme

No database migration is needed — the preference is stored in the session.

Closes #503

## Test plan

- [ ] Navigate to `/dev-settings/` — page loads with current engine mode displayed
- [ ] Select "Python fallback" and submit — success message appears, current engine updates to Python
- [ ] Play an AI game — engine uses the Python fallback (slower but functional)
- [ ] Switch back to "C++ (auto-detect)" — normal engine resumes
- [ ] Confirm session is preserved across page reloads until manually changed
- [ ] `python manage.py check` passes with no errors