### PR TITLE
feat: add non-destructive analysis takeback for AI games

### DIFF
--- a/game/urls.py
+++ b/game/urls.py
@@ -15,6 +15,8 @@ urlpatterns = [
     path('api/resign/', views.resign_game, name='resign_game'),
     path('api/ai-move/', views.ai_move, name='ai_move'),
     path('api/draw/', views.offer_draw, name='offer_draw'),
+    path('api/takeback/', views.analysis_takeback, name='analysis_takeback'),
+    path('api/resume/', views.analysis_resume, name='analysis_resume'),
     path('stats/', views.stats_view, name='stats'),
 
     # Authentication

--- a/game/views.py
+++ b/game/views.py
@@ -1,5 +1,6 @@
 """Game views for the Checkora chess platform."""
 
+import copy
 import json
 import time
 import hashlib
@@ -60,8 +61,9 @@ def make_move(request):
     game_data = request.session.get('game')
     game = ChessGame.from_dict(game_data) if game_data else ChessGame()
 
-    # Snapshot current state before the move so analysis takeback can restore it
-    pre_move_snapshot = game.to_dict() if game_data else None
+    # Deep-copy the dict so mutable nested objects (board, move_history, etc.)
+    # aren't shared with the game instance that make_move is about to mutate.
+    pre_move_snapshot = copy.deepcopy(game.to_dict()) if game_data else None
 
     success, message, captured, game_status = game.make_move(
         from_row, from_col, to_row, to_col, promotion_piece,
@@ -143,6 +145,7 @@ def new_game(request):
     game.paused = False
 
     request.session['game'] = game.to_dict()
+    request.session.pop('analysis_snapshot', None)
     request.session.modified = True
 
     return JsonResponse({
@@ -550,9 +553,9 @@ def analysis_takeback(request):
         )
 
     difficulty = request.session.get('difficulty', 'medium')
-    if difficulty == 'hard':
+    if difficulty not in ('easy', 'medium'):
         return JsonResponse(
-            {'valid': False, 'message': 'Takeback is not available on hard difficulty.'}, status=403
+            {'valid': False, 'message': 'Takeback is only available on easy or medium difficulty.'}, status=403
         )
 
     snapshot = request.session.get('analysis_snapshot')

--- a/game/views.py
+++ b/game/views.py
@@ -60,11 +60,17 @@ def make_move(request):
     game_data = request.session.get('game')
     game = ChessGame.from_dict(game_data) if game_data else ChessGame()
 
+    # Snapshot current state before the move so analysis takeback can restore it
+    pre_move_snapshot = game.to_dict() if game_data else None
+
     success, message, captured, game_status = game.make_move(
         from_row, from_col, to_row, to_col, promotion_piece,
     )
 
     if success:
+        # Save pre-move snapshot for analysis takeback (AI mode only)
+        if pre_move_snapshot and game.mode == 'ai':
+            request.session['analysis_snapshot'] = pre_move_snapshot
         request.session['game'] = game.to_dict()
         request.session.modified = True
         if game_status == 'checkmate':
@@ -520,4 +526,77 @@ def stats_view(request):
         'ai_total': ai_total,
         'ai_wins': ai_wins,
         'ai_draws': ai_draws,
+    })
+
+
+@require_POST
+def analysis_takeback(request):
+    """Temporarily revert to the board state before the player's last move.
+
+    Available only in AI mode at easy or medium difficulty.  Does NOT
+    modify move history or save a game result — it is a non-destructive
+    analysis tool.  The real game state is preserved in the session under
+    ``game`` so the player can resume at any time.
+    """
+    game_data = request.session.get('game')
+    if not game_data:
+        return JsonResponse({'valid': False, 'message': 'No active game.'}, status=400)
+
+    game = ChessGame.from_dict(game_data)
+
+    if game.mode != 'ai':
+        return JsonResponse(
+            {'valid': False, 'message': 'Takeback is only available in AI mode.'}, status=403
+        )
+
+    difficulty = request.session.get('difficulty', 'medium')
+    if difficulty == 'hard':
+        return JsonResponse(
+            {'valid': False, 'message': 'Takeback is not available on hard difficulty.'}, status=403
+        )
+
+    snapshot = request.session.get('analysis_snapshot')
+    if not snapshot:
+        return JsonResponse(
+            {'valid': False, 'message': 'No previous move to revert to.'}, status=400
+        )
+
+    analysis_game = ChessGame.from_dict(snapshot)
+
+    return JsonResponse({
+        'valid': True,
+        'message': 'Analysis takeback applied. This is a temporary view — your real game is preserved.',
+        'board': analysis_game.board,
+        'current_turn': analysis_game.current_turn,
+        'move_history': analysis_game.move_history,
+        'captured_pieces': analysis_game.captured,
+        'white_time': analysis_game.white_time,
+        'black_time': analysis_game.black_time,
+        'fen': analysis_game.generate_fen_key(),
+        'pgn': analysis_game.generate_pgn(),
+        'in_analysis': True,
+    })
+
+
+@require_POST
+def analysis_resume(request):
+    """Restore the real game state after analysis takeback."""
+    game_data = request.session.get('game')
+    if not game_data:
+        return JsonResponse({'valid': False, 'message': 'No active game.'}, status=400)
+
+    game = ChessGame.from_dict(game_data)
+
+    return JsonResponse({
+        'valid': True,
+        'message': 'Resumed real game.',
+        'board': game.board,
+        'current_turn': game.current_turn,
+        'move_history': game.move_history,
+        'captured_pieces': game.captured,
+        'white_time': game.white_time,
+        'black_time': game.black_time,
+        'fen': game.generate_fen_key(),
+        'pgn': game.generate_pgn(),
+        'in_analysis': False,
     })


### PR DESCRIPTION
## Summary

Adds an **Analysis Mode Takeback** that lets players temporarily revert to the board state before their last move in AI games, for learning and analysis — without affecting the actual game history.

### How it works

1. **Snapshot on every human move**: When `make_move` succeeds in AI mode, the pre-move game state is saved to `session['analysis_snapshot']`. The real game continues normally in `session['game']`.

2. **`POST /api/takeback/`** — restores the snapshot and returns the previous board/turn/history. The real game state is untouched in the session.
   - Returns `403` in PvP mode and on hard difficulty (per the issue spec)
   - Returns `400` if no snapshot exists (e.g. first move)
   - Returns `in_analysis: true` so the frontend can show an "analysis" banner

3. **`POST /api/resume/`** — returns the real current game state, letting the client switch back from analysis view to the live game.
   - Returns `in_analysis: false`

### Scope (matches issue requirements)

| Mode | Available? |
|------|-----------|
| AI easy | ✅ |
| AI medium | ✅ |
| AI hard | ❌ 403 |
| PvP | ❌ 403 |

No database writes occur during takeback — it is purely session-based and non-destructive.

Closes #463

## Test plan

- [ ] Play an AI game (easy/medium) — after your move, click "Analyze" → board reverts to before your move
- [ ] Click "Resume" → board restores to current real game state
- [ ] Hard difficulty → takeback returns 403
- [ ] PvP mode → takeback returns 403
- [ ] First move of the game → takeback returns 400 (no snapshot yet)
- [ ] `python manage.py check` passes