### PR TITLE
Fix Vercel insights 404 in local environment

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -32,6 +32,9 @@ DEBUG = os.environ.get('DEBUG', 'True').lower() == 'true'
 
 ALLOWED_HOSTS = ['.vercel.app', '*']
 
+# Required for django.template.context_processors.debug to expose `debug=True` to templates
+INTERNAL_IPS = ['127.0.0.1', 'localhost']
+
 
 # Application definition
 
@@ -68,6 +71,7 @@ TEMPLATES = [
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
+                'django.template.context_processors.debug',
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -9,19 +9,23 @@
     <link rel="icon" type="image/jpeg" href="{% static 'game/favicon.jpeg' %}">
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
 
+    {% if not debug %}
     <!-- Vercel Speed Insights -->
     <script>
         window.si = window.si || function () { (window.siq = window.siq || []).push(arguments); };
     </script>
     <script defer src="/_vercel/speed-insights/script.js"></script>
+    {% endif %}
 
     <link rel="stylesheet" href="{% static 'game/css/board.css' %}">
 
+    {% if not debug %}
     <!-- Vercel Web Analytics -->
     <script>
         window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
     </script>
     <script defer src="/_vercel/insights/script.js"></script>
+    {% endif %}
 
     <script>
         (function () {


### PR DESCRIPTION
## Description

This PR fixes the 404 errors caused by Vercel Insights scripts loading in the local development environment.

## Changes Made

* Added Django debug context processor support
* Configured INTERNAL_IPS for local debug detection
* Wrapped Vercel analytics scripts in template debug guards

## Result

Vercel analytics scripts now load only in production environments, preventing unnecessary 404 errors during local development.

Fixes #525
