### PR TITLE
Fix: Misleading password reset confirmation message to neutral

### DIFF
--- a/game/templates/game/password_reset_done.html
+++ b/game/templates/game/password_reset_done.html
@@ -17,7 +17,7 @@
 
     <div class="auth-card">
         <p style="text-align:center; margin-bottom: 1.5rem;">
-            We've sent a password reset link to your email address.
+            If an account exists for the email address you entered, we've sent a password reset link.
             Please check your inbox and follow the instructions.
         </p>
 


### PR DESCRIPTION
## Description

This PR fixes a bug where the password reset flow displayed a success message indicating that a reset link had been sent, even when the entered email address was not registered in the system.

The confirmation message now uses neutral wording that applies to both registered and unregistered email addresses, preventing unintended account enumeration.

## Changes
- Updated `game/templates/game/password_reset_done.html`
- Replaced the password reset confirmation message with neutral wording
- Avoided implying whether an email address exists in the system

## Related Issue

Fixes #374 

## Screenshot
<img width="442" height="316" alt="Screenshot 2026-05-11 at 9 48 03 PM" src="https://github.com/user-attachments/assets/15aa1008-c8a5-43a9-b82d-8ee961bb4917" />
