### PR TITLE
templates: Wrap header logo in anchor tag for home navigation.

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -33,6 +33,14 @@ body {
     gap: 8px;   /* tighter = better */
 }
 
+/* Logo home link */
+.logo-link {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    text-decoration: none;
+}
+
 /* Logo image */
 .logo-icon-img {
     animation: logoGlow 2.5s ease-in-out infinite alternate;

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -114,7 +114,7 @@
     <!-- ========== HEADER ========== -->
     <div class="header">
         <div class="logo-container">
-            <a href="/" class="logo-link">
+            <a href="{% url 'landing' %}" class="logo-link">
                 <img src="{% static 'game/checkora_icon_only.png' %}" class="logo-icon-img" alt="Checkora">
                 <span class="logo-text">Checkora</span>
             </a>

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -114,8 +114,10 @@
     <!-- ========== HEADER ========== -->
     <div class="header">
         <div class="logo-container">
-            <img src="{% static 'game/checkora_icon_only.png' %}" class="logo-icon-img" alt="Checkora">
-            <span class="logo-text">Checkora</span>
+            <a href="/" class="logo-link">
+                <img src="{% static 'game/checkora_icon_only.png' %}" class="logo-icon-img" alt="Checkora">
+                <span class="logo-text">Checkora</span>
+            </a>
             <span class="badge" id="modeBadge">PVP</span>
         </div>
 


### PR DESCRIPTION
### Description
Resolved the issue where the header logo was not wrapped in an anchor tag. Clicking the logo now correctly navigates the user back to the homepage (`/`) instead of triggering a "refused to connect" error.

### Changes
- **Templates**: Wrapped the logo image and text in an `<a "{% url 'Landing' %}" class="logo-link">` tag in `game/templates/game/board.html`.
- **Styling**: Added `.logo-link` styles in `game/static/game/css/board.css` to maintain flex alignment and remove default link text decoration.

### Verification
- Verified locally.
- Confirmed the logo is clickable and redirects to the home path.
- Confirmed the UI layout remains unchanged and visually consistent.

Fixes #535