### PR TITLE
fix: Add back navigation to game(board), rules, and stats screens

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -459,6 +459,23 @@ body {
     transform: translateY(-1px);
 }
 .btn-danger:active { transform: translateY(0); }
+.back-btn {
+    font-size: small;
+    background: var(--bg);
+    color: var(--bg) !important;
+    font-weight: bold;
+    margin-bottom: 2rem;
+    text-decoration: none;
+    display: flex; 
+    justify-content: flex-start;
+    
+}
+
+.back-btn:hover {
+    color: #d4a72d;
+    text-decoration: underline !important;
+    transform: scale(1.05);
+}
 
 /* ============================================================
    PvE Side Selection

--- a/game/static/game/css/landing.css
+++ b/game/static/game/css/landing.css
@@ -123,7 +123,23 @@ body {
     transform: translateY(-1px);
     box-shadow: 0 4px 16px rgba(240, 192, 64, 0.25);
 }
+.back-btn {
+    font-size: small !important;
+    background: var(--bg);
+    color: var(--bg) !important;
+    font-weight: bold;
+    margin-bottom: 2rem;
+    text-decoration: none;
+    display: flex; 
+    justify-content: flex-start;
+    
+}
 
+.back-btn:hover {
+    color: #d4a72d;
+    text-decoration: underline !important;
+    transform: scale(1.05);
+}
 .hero {
     display: flex;
     flex-direction: column;
@@ -370,3 +386,4 @@ body {
         margin-top: 1rem;
     }
 }
+

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -42,6 +42,9 @@
 
     <div class="promo-overlay active" id="welcomeOverlay" style="background: var(--page-bg); z-index: 9999;">
         <div class="promo-dialog" style="min-width: 320px; padding: 35px;">
+            <div style="margin-bottom: 20px; color:#f0c040;">
+                <a href="/" class="back-btn">← Back to Home</a>
+            </div>
             <div class="promo-title"
                 style="font-size: 1.6rem; margin-bottom: 10px; display: flex; align-items: center; justify-content: center; gap: 8px;">
                 <div class="promo-title promo-logo">
@@ -74,6 +77,7 @@
 
             <!-- Rest stays the same -->
             <div id="modeSelection" style="display: flex; flex-direction: column; gap: 14px;">
+                
                 <button class="btn btn-gold" id="welcomePvPBtn" style="padding: 12px; font-size: 1.05rem;">Pass & Play
                     (PvP)</button>
                 <button class="btn btn-gold" id="welcomeAIBtn" style="padding: 12px; font-size: 1.05rem;">Play vs
@@ -110,15 +114,17 @@
             </div>
         </div>
     </div>
-
+    
     <!-- ========== HEADER ========== -->
+    
     <div class="header">
+        
         <div class="logo-container">
             <img src="{% static 'game/checkora_icon_only.png' %}" class="logo-icon-img" alt="Checkora">
             <span class="logo-text">Checkora</span>
             <span class="badge" id="modeBadge">PVP</span>
         </div>
-
+        
         <div class="auth-buttons">
             {% if user.is_authenticated %}
             <span class="welcome-msg">Welcome, <span class="username">{{ user.username }}</span></span>
@@ -133,7 +139,7 @@
             <a href="/stats/" class="btn-signin">Stats</a>
         </div>
     </div>
-
+    
     <!-- ========== GAME ========== -->
     <div class="game-layout" style="visibility: hidden;">
 
@@ -231,6 +237,10 @@
                 <div class="keyboard-hints" style="font-size: 0.8rem; color: #888; margin-top: 8px;">
                     ⌨️ Shortcuts: <kbd>F</kbd> Flip &nbsp; <kbd>R</kbd> Resign &nbsp; <kbd>D</kbd> Draw
                 </div>
+                <a href="/" class="btn" 
+   style="background: #2a1414; color: #ff6b6b;margin-top: 1rem;margin-bottom: 1.5rem; border: 1px solid #632424; text-decoration: none; text-align: center; display: block; line-height: 2.5;">
+    EXIT TO HOME
+</a>
             </div>
             <div class="card">
                 <div class="card-title">Move History</div>

--- a/game/templates/game/rules.html
+++ b/game/templates/game/rules.html
@@ -374,6 +374,9 @@
 <div class="layout">
     <!-- Sidebar -->
     <nav class="sidebar">
+        <div style="margin-bottom: 20px; margin-top: 10px; text-align: center;">
+            <a href="/" class="back-btn">← Back to Home</a>
+        </div>
         <div class="sidebar-title">Rulebook</div>
         <div class="rule-nav-item active" onclick="showRule('basics')" id="nav-basics">
             <span class="icon">📖</span> The Basics

--- a/game/templates/game/stats.html
+++ b/game/templates/game/stats.html
@@ -22,6 +22,9 @@
     </style>
 </head>
 <body>
+    <div style="margin-bottom: 20px;">
+        <a href="/" class="back-btn">← Back to Home</a>
+    </div>
     <h1>CHECK<span>ORA</span> &mdash; Game Statistics</h1>
 
     <h2>AI Game Summary</h2>
@@ -57,6 +60,5 @@
     <p class="empty">No games played yet. Play a game to see stats here!</p>
     {% endif %}
 
-    <div class="back"><a href="/">Back to Game</a></div>
 </body>
 </html>


### PR DESCRIPTION
(fix: Add back navigation to game, rules, and stats screens)

## Description
I identified several navigation 'dead-ends' where users were unable to return to the home page or previous views. I have added 'Back' and 'Exit' buttons to the Start Game modal, the active Game screen, the Rulebook sidebar, and the Statistics page header to ensure a seamless UX.
- Added a distinct "Exit to Home" button within the Game Controls panel in board.html, styled with a high-contrast danger theme to clearly differentiate it from standard game actions.
- Relocated the "Back to Game" navigation to "Back to Home" in rules.html and stats.html to sidebar positions and applied CSS styling across all templates .


## Type of Change

- [✓ ] Bug fix (non-breaking change that fixes an issue)
- [x ] New feature (non-breaking change that adds functionality)
- [x ] Breaking change (fix or feature that would cause existing functionality to change)
- [x ] Documentation update

## Related Issue
Fixes #533 

## Checklist

- [✓ ] My code follows the project's style guidelines
- [✓ ] I have performed a self-review of my code
- [✓ ] I have commented my code where necessary
- [x ] I have updated the documentation if needed
- [✓ ] My changes generate no new warnings
- [x ] I have added tests that prove my fix/feature works
- [✓ ] New and existing tests pass locally

## Screenshots
<img width="975" height="582" alt="image" src="https://github.com/user-attachments/assets/2fa3f68c-a50d-47cf-a24c-1b8c5e27175a" />

<br><hr>
<img width="637" height="330" alt="image" src="https://github.com/user-attachments/assets/e13cb014-cb07-44eb-a43a-bdbb846e0809" />

<br><hr>
<img width="1107" height="634" alt="image" src="https://github.com/user-attachments/assets/f7a48c8a-98ea-4cc5-afd2-48938167a6ae" />
<br><hr>
<img width="1346" height="617" alt="image" src="https://github.com/user-attachments/assets/eb4ac03f-86a6-4204-ac9e-0c843fd2d493" />
<br><hr>