### PR TITLE
fix: resolve persistent "Copied!" state for PGN/FEN actions

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1090,6 +1090,15 @@
             }
 
             async function startNewGame(mode, pColor = 'white', difficulty = 'medium') {
+
+                if (copyPgnBtn) {
+                    copyPgnBtn.textContent = 'Export as PGN';
+                }
+
+                if (copyFenBtn) {
+                    copyFenBtn.textContent = 'Copy FEN';
+                }
+
                 // Clear celebration effects
                 const overlay = document.getElementById('gameOverOverlay');
                 overlay.classList.remove('game-over-celebration');
@@ -1137,6 +1146,8 @@
                     queueAIMoveIfNeeded();
                 }
             }
+
+            
 
             /* ==========================================================
             EVENT LISTENERS

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -133,6 +133,8 @@
             let gameOver = false;
             let aiThinking = false;
 
+            let pgnCopyTimeout = null;
+            let fenCopyTimeout = null;
             /* ==========================================================
             CSRF & API HELPERS
             ========================================================== */
@@ -1091,6 +1093,9 @@
 
             async function startNewGame(mode, pColor = 'white', difficulty = 'medium') {
 
+                clearTimeout(pgnCopyTimeout);
+                clearTimeout(fenCopyTimeout);
+
                 if (copyPgnBtn) {
                     copyPgnBtn.textContent = 'Export as PGN';
                 }
@@ -1098,7 +1103,6 @@
                 if (copyFenBtn) {
                     copyFenBtn.textContent = 'Copy FEN';
                 }
-
                 // Clear celebration effects
                 const overlay = document.getElementById('gameOverOverlay');
                 overlay.classList.remove('game-over-celebration');
@@ -1271,12 +1275,14 @@
     if (data.pgn) {
         navigator.clipboard.writeText(data.pgn);
 
-        const oldText = copyPgnBtn.textContent;
+        
 
         copyPgnBtn.textContent = 'Copied!';
 
-        setTimeout(() => {
-            copyPgnBtn.textContent = oldText;
+        clearTimeout(pgnCopyTimeout);
+
+        pgnCopyTimeout = setTimeout(() => {
+            copyPgnBtn.textContent = 'Export as PGN';
         }, 2000);
     }
 };
@@ -1285,9 +1291,13 @@
                 const data = await get('/api/state/');
                 if (data.fen) {
                     navigator.clipboard.writeText(data.fen);
-                    const oldText = copyFenBtn.textContent;
+                    
                     copyFenBtn.textContent = 'Copied!';
-                    setTimeout(() => copyFenBtn.textContent = oldText, 2000);
+                    clearTimeout(fenCopyTimeout);
+
+                    fenCopyTimeout = setTimeout(() => {
+                        copyFenBtn.textContent = 'Copy FEN';
+                    }, 2000);
                 }
             };
 


### PR DESCRIPTION
## Fixes #536

### Issue

The PGN/FEN copy buttons could remain stuck in the `"Copied!"` state during repeated copy actions or after starting a new game due to overlapping timeout behavior.

### Changes Made

* Added timeout cleanup for PGN and FEN copy actions
* Reset button states properly when starting a new game
* Prevented stale async timeout updates from restoring incorrect button text
* Ensured buttons always return to their default labels correctly

### Testing

Tested locally by:

* performing repeated PGN/FEN copy actions
* starting new games during active timeout periods
* verifying button state resets correctly in all scenarios
