### PR TITLE
ui: Add side selection modal when starting new AI game after resign.

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1058,6 +1058,24 @@
                 confirmOverlay.classList.add('active');
             }
 
+            function showSideSelectionModal(onChoose) {
+                const modal = document.getElementById('sideModal');
+                modal.style.display = 'flex';
+
+                function pick(side) {
+                    modal.style.display = 'none';
+                    document.getElementById('chooseWhite').onclick = null;
+                    document.getElementById('chooseBlack').onclick = null;
+                    document.getElementById('chooseRandom').onclick = null;
+                    onChoose(side);
+                }
+
+                document.getElementById('chooseWhite').onclick = () => pick('white');
+                document.getElementById('chooseBlack').onclick = () => pick('black');
+                document.getElementById('chooseRandom').onclick = () =>
+                    pick(Math.random() < 0.5 ? 'white' : 'black');
+            }
+
             function requestNewGame(mode) {
                 const diffContainer = document.getElementById('confirmDifficultyContainer');
                 if (mode === 'ai') {
@@ -1072,7 +1090,7 @@
                     () => {
                         const diff = document.getElementById('confirmDifficultySelect').value;
                         if (mode === 'ai') {
-                            startNewGame('ai', 'white', diff);
+                            showSideSelectionModal(side => startNewGame('ai', side, diff));
                         } else {
                             startNewGame('pvp');
                         }
@@ -1385,7 +1403,11 @@
                     confettiContainer.remove();
                 }
                 
-                startNewGame(mode, 'white', diff);
+                if (mode === 'ai') {
+                    showSideSelectionModal(side => startNewGame(mode, side, diff));
+                } else {
+                    startNewGame(mode, 'white', diff);
+                }
             };
 
             // Theme Switcher

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -336,6 +336,29 @@
             </div>
         </div>
     </div>
+
+    <!-- ========== SIDE SELECTION MODAL ========== -->
+    <div class="promo-overlay" id="sideModal" style="display: none;">
+        <div class="promo-dialog" style="min-width: 300px; padding: 35px; text-align: center;">
+            <div class="promo-title" style="font-size: 1.4rem; color: #f0c040; margin-bottom: 10px;">Choose Your Side
+            </div>
+            <p style="color: #aaa; margin-bottom: 25px; font-size: 0.9rem;">Which color do you want to play?</p>
+            <div style="display: flex; flex-direction: column; gap: 12px;">
+                <button class="btn" id="chooseWhite"
+                    style="padding: 12px; background: #fff; color: #000; font-size: 1rem; border-radius: 6px;">
+                    Play as White
+                </button>
+                <button class="btn" id="chooseBlack"
+                    style="padding: 12px; background: #000; color: #fff; font-size: 1rem; border-radius: 6px; border: 1px solid #555;">
+                    Play as Black
+                </button>
+                <button class="btn btn-gold" id="chooseRandom" style="padding: 12px; font-size: 1rem;">
+                    Random
+                </button>
+            </div>
+        </div>
+    </div>
+
     <!-- RULEBOOK MODAL -->
     <div id="rulebookModal"
         style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.85); z-index:9999; align-items:center; justify-content:center;">


### PR DESCRIPTION
Fixes #459 

## What does this PR do?
Adds a side selection modal (White / Black / Random) that appears 
when a user starts a new AI game after the game ends, so the player 
always gets to choose their color instead of being assigned White automatically.

## Changes made
- templates/game/board.html: Added side selection modal HTML.
- static/game/js/board.js: Added showSideSelectionModal() function and 
  wired it into the game over and new game flows.

## How to test
1. Start a game vs AI.
2. Play a few moves.
3. Click Resign and confirm.
4. In the game over screen, select "vs AI" and click Start New Game.
5. Verify the side selection modal appears.
6. Choose a side and confirm the game starts correctly with that color.

 
<img width="1366" height="768" alt="Screenshot (283)" src="https://github.com/user-attachments/assets/7ecc0193-e324-4bb0-981b-69e79d53c77c" />

