### PR TITLE
fix: reset copy button state on new game

### DIFF
--- a/board.test.js
+++ b/board.test.js
@@ -11,7 +11,8 @@ document.body.innerHTML = `
   <div id="modeBadge"></div>
   <button id="autoFlipBtn"></button>
   <div id="flipControls"></div>
-  <button id="copyFenBtn"></button>
+  <button id="copyFenBtn">Copy FEN</button>
+  <button id="copyPgnBtn">Copy PGN</button>
   <div id="welcomeOverlay"></div>
   <button id="welcomeResumeBtn"></button>
   <button id="welcomePvPBtn"></button>
@@ -49,7 +50,7 @@ document.body.innerHTML = `
   <div id="turnBadgeText"></div>
 `;
 
-const { pColor, getSquareLabel, formatTime } = require("./game/static/game/js/board");
+const { pColor, getSquareLabel, formatTime, resetCopyButtonState } = require("./game/static/game/js/board");
 
 describe("pColor", () => {
   test("returns white for uppercase piece", () => {
@@ -90,5 +91,20 @@ describe("formatTime", () => {
 
   test("formats 0 seconds as 0:00", () => {
     expect(formatTime(0)).toBe("0:00");
+  });
+});
+
+describe("resetCopyButtonState", () => {
+  test("restores copied button labels before starting a new game", () => {
+    const fenButton = document.getElementById("copyFenBtn");
+    const pgnButton = document.getElementById("copyPgnBtn");
+
+    fenButton.textContent = "Copied!";
+    pgnButton.textContent = "Copied!";
+
+    resetCopyButtonState();
+
+    expect(fenButton.textContent).toBe("Copy FEN");
+    expect(pgnButton.textContent).toBe("Copy PGN");
   });
 });

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1122,6 +1122,7 @@
                 gameOver = false;
                 gameMode = d.mode;
                 playerColor = d.player_color || 'white';
+                resetCopyButtonState();
                 
                 if (gameMode === 'ai') {
                     flipped = (playerColor === 'black');
@@ -1268,6 +1269,7 @@
         navigator.clipboard.writeText(data.pgn);
 
         const oldText = copyPgnBtn.textContent;
+        rememberCopyButtonDefault(copyPgnBtn);
 
         copyPgnBtn.textContent = 'Copied!';
 
@@ -1277,11 +1279,30 @@
     }
 };
 
+            const copyButtonDefaultText = new Map();
+
+            function rememberCopyButtonDefault(button) {
+                if (button && !copyButtonDefaultText.has(button)) {
+                    copyButtonDefaultText.set(button, button.textContent);
+                }
+            }
+
+            function resetCopyButtonState() {
+                [copyPgnBtn, copyFenBtn].forEach(button => {
+                    if (!button) return;
+                    rememberCopyButtonDefault(button);
+                    button.textContent = copyButtonDefaultText.get(button);
+                });
+            }
+
+            [copyPgnBtn, copyFenBtn].forEach(rememberCopyButtonDefault);
+
             if (copyFenBtn) copyFenBtn.onclick = async () => {
                 const data = await get('/api/state/');
                 if (data.fen) {
                     navigator.clipboard.writeText(data.fen);
                     const oldText = copyFenBtn.textContent;
+                    rememberCopyButtonDefault(copyFenBtn);
                     copyFenBtn.textContent = 'Copied!';
                     setTimeout(() => copyFenBtn.textContent = oldText, 2000);
                 }
@@ -1422,7 +1443,7 @@
             
 
           if (typeof module !== "undefined" && module.exports) {
-          module.exports = { pColor, getSquareLabel, formatTime };
+          module.exports = { pColor, getSquareLabel, formatTime, resetCopyButtonState };
         } else {
           loadGame();
         }


### PR DESCRIPTION
## Summary
- Fixes copy button feedback getting stuck as `Copied!` after starting a new game.
- Stores the default FEN/PGN copy labels and resets them during new game initialization.
- Adds a Jest regression test for resetting both copy buttons.

Fixes #536

## Test Plan
- `npm test -- --runInBand`
