### PR TITLE
ui: Clear last-move highlight and selection state on new game start.

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1153,6 +1153,9 @@
                 gameOver = false;
                 gameMode = d.mode;
                 playerColor = d.player_color || 'white';
+                lastMove = null;
+                selected = null;
+                hints = [];
                 
                 if (gameMode === 'ai') {
                     flipped = (playerColor === 'black');


### PR DESCRIPTION
Fixes #140

## What was the problem
After resigning or finishing a game and starting a new one, 
the yellow highlight from the last move of the previous game 
was still visible on the board. This made it look like the 
new game had a pre-existing move.

## What I changed
Added lastMove = null, selected = null, and hints = [] in 
startNewGame() before the board is rebuilt. This clears all 
leftover highlight state from the previous game so the new 
board starts completely clean.

## What I tested
Started a game, made moves, resigned, started a new game — 
confirmed the yellow highlight was gone and the board was clean.