### PR TITLE
fix: toggle piece selection on repeated click

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -720,6 +720,12 @@
             async function onClick(r, c) {
                 if (dragging) return;
                 if (selected) {
+
+                    //New toggle logic:
+                    //If the clicked square is the exact same as the selected square, deselect it.
+                    if (selected .r === r && selected.c ===c){
+                        return deselect();
+                    }
                     if (hints.some(h => h.row === r && h.col === c))
                         return tryMove(selected.r, selected.c, r, c);
                     if (board[r][c] && pColor(board[r][c]) === turn)


### PR DESCRIPTION
## Description

Fixed a UX bug where tapping an already-selected piece on the board would not deselect it. Added a toggle check inside `onClick` in `board.js` to clear the `selected` state and remove movement hints if the clicked coordinates match the currently selected piece.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #607 
## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

N/A