### PR TITLE
fix: AI no legal moves now correctly ends game as checkmate or stalemate

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -296,24 +296,29 @@ def ai_move(request):
 
     best = game.get_ai_move(depth=depth)
     if not best:
-        if game.game_status == 'checkmate':
-            record_game_result(request, game.mode, game.current_turn, 'checkmate', game.player_color)
-            game_status = 'checkmate'
-        else:
-            record_game_result(request, game.mode, 'draw', 'stalemate', game.player_color)
-            game_status = 'stalemate'
-        return JsonResponse({
-            'valid': True,
-            'game_status': game_status,
-            'board': game.board,
-            'current_turn': game.current_turn,
-            'white_time': game.white_time,
-            'black_time': game.black_time,
-            'move_history': game.move_history,
-            'captured_pieces': game.captured,
-            'message': '',
-        })
+    if game.game_status == 'checkmate':
+        winner = 'black' if game.current_turn == 'white' else 'white'
+        record_game_result(request, game.mode, winner, 'checkmate', game.player_color)
+        game_status = 'checkmate'
+    else:
+        record_game_result(request, game.mode, 'draw', 'stalemate', game.player_color)
+        game_status = 'stalemate'
 
+    game.game_status = game_status
+    request.session['game'] = game.to_dict()
+    request.session.modified = True
+
+    return JsonResponse({
+        'valid': True,
+        'game_status': game_status,
+        'board': game.board,
+        'current_turn': game.current_turn,
+        'white_time': game.white_time,
+        'black_time': game.black_time,
+        'move_history': game.move_history,
+        'captured_pieces': game.captured,
+        'message': '',
+    })
     if game.game_status == 'checkmate':
         winner = 'black' if game.current_turn == 'white' else 'white'
         record_game_result(request, game.mode, winner, 'checkmate', game.player_color)

--- a/game/views.py
+++ b/game/views.py
@@ -314,6 +314,31 @@ def ai_move(request):
             'message': '',
         })
 
+    if game.game_status == 'checkmate':
+        winner = 'black' if game.current_turn == 'white' else 'white'
+        record_game_result(request, game.mode, winner, 'checkmate', game.player_color)
+        game_status = 'checkmate'
+    else:
+        record_game_result(request, game.mode, 'draw', 'stalemate', game.player_color)
+        game_status = 'stalemate'
+
+    game.game_status = game_status
+    request.session['game'] = game.to_dict()
+    request.session.modified = True
+
+    return JsonResponse({
+        'valid': True,
+        'game_status': game_status,
+        'board': game.board,
+        'current_turn': game.current_turn,
+        'white_time': game.white_time,
+        'black_time': game.black_time,
+        'move_history': game.move_history,
+        'captured_pieces': game.captured,
+        'message': '',
+    })
+>>>>>>> 33c21c2 (fix: correct winner on AI checkmate and persist session state)
+
     success, message, captured, game_status = game.make_move(
         best['from_row'], best['from_col'],
         best['to_row'],   best['to_col'],

--- a/game/views.py
+++ b/game/views.py
@@ -296,11 +296,22 @@ def ai_move(request):
 
     best = game.get_ai_move(depth=depth)
     if not best:
+        if game.game_status == 'checkmate':
+            record_game_result(request, game.mode, game.current_turn, 'checkmate', game.player_color)
+            game_status = 'checkmate'
+        else:
+            record_game_result(request, game.mode, 'draw', 'stalemate', game.player_color)
+            game_status = 'stalemate'
         return JsonResponse({
-            'valid': False,
-            'message': 'No legal moves available.',
+            'valid': True,
+            'game_status': game_status,
             'board': game.board,
             'current_turn': game.current_turn,
+            'white_time': game.white_time,
+            'black_time': game.black_time,
+            'move_history': game.move_history,
+            'captured_pieces': game.captured,
+            'message': '',
         })
 
     success, message, captured, game_status = game.make_move(

--- a/game/views.py
+++ b/game/views.py
@@ -295,54 +295,32 @@ def ai_move(request):
     depth = depth_map.get(difficulty, 3)
 
     best = game.get_ai_move(depth=depth)
+    best = game.get_ai_move(depth=depth)
+    
     if not best:
-    if game.game_status == 'checkmate':
-        winner = 'black' if game.current_turn == 'white' else 'white'
-        record_game_result(request, game.mode, winner, 'checkmate', game.player_color)
-        game_status = 'checkmate'
-    else:
-        record_game_result(request, game.mode, 'draw', 'stalemate', game.player_color)
-        game_status = 'stalemate'
+        if game.game_status == 'checkmate':
+            winner = 'black' if game.current_turn == 'white' else 'white'
+            record_game_result(request, game.mode, winner, 'checkmate', game.player_color)
+            game_status = 'checkmate'
+        else:
+            record_game_result(request, game.mode, 'draw', 'stalemate', game.player_color)
+            game_status = 'stalemate'
 
-    game.game_status = game_status
-    request.session['game'] = game.to_dict()
-    request.session.modified = True
+        game.game_status = game_status
+        request.session['game'] = game.to_dict()
+        request.session.modified = True
 
-    return JsonResponse({
-        'valid': True,
-        'game_status': game_status,
-        'board': game.board,
-        'current_turn': game.current_turn,
-        'white_time': game.white_time,
-        'black_time': game.black_time,
-        'move_history': game.move_history,
-        'captured_pieces': game.captured,
-        'message': '',
-    })
-    if game.game_status == 'checkmate':
-        winner = 'black' if game.current_turn == 'white' else 'white'
-        record_game_result(request, game.mode, winner, 'checkmate', game.player_color)
-        game_status = 'checkmate'
-    else:
-        record_game_result(request, game.mode, 'draw', 'stalemate', game.player_color)
-        game_status = 'stalemate'
-
-    game.game_status = game_status
-    request.session['game'] = game.to_dict()
-    request.session.modified = True
-
-    return JsonResponse({
-        'valid': True,
-        'game_status': game_status,
-        'board': game.board,
-        'current_turn': game.current_turn,
-        'white_time': game.white_time,
-        'black_time': game.black_time,
-        'move_history': game.move_history,
-        'captured_pieces': game.captured,
-        'message': '',
-    })
->>>>>>> 33c21c2 (fix: correct winner on AI checkmate and persist session state)
+        return JsonResponse({
+            'valid': True,
+            'game_status': game_status,
+            'board': game.board,
+            'current_turn': game.current_turn,
+            'white_time': game.white_time,
+            'black_time': game.black_time,
+            'move_history': game.move_history,
+            'captured_pieces': game.captured,
+            'message': '',
+        })
 
     success, message, captured, game_status = game.make_move(
         best['from_row'], best['from_col'],


### PR DESCRIPTION
## Description
fix: AI no legal moves triggers correct game end

When AI had no legal moves the game showed No legal moves available error and got stuck. Fixed by checking game.game_status when get_ai_move() returns None and returning correct checkmate or stalemate status with full game state so frontend handles it correctly.

Fixes #559 
## Files changed: game/views.py
