### PR TITLE
fix: validate player_color parameter in new_game endpoint

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -129,6 +129,8 @@ def new_game(request):
     if mode not in ('pvp', 'ai'):
         mode = 'pvp'
     player_color = data.get('player_color', 'white')
+    if player_color not in ('white', 'black'):
+        player_color = 'white'
 
     def _clean_name(raw, fallback):
         name = (raw or '').strip()


### PR DESCRIPTION
## Description

Fixes #646

This PR adds validation for the `player_color` parameter in the `new_game` endpoint to ensure it's either 'white' or 'black'. Invalid values now default to 'white' instead of being stored in the session.

## Changes

- Added validation in `game/views.py` in the `new_game()` function
- Invalid `player_color` values now default to 'white'
- Follows the same defensive programming pattern as the existing `mode` parameter validation

## Testing

The fix has been tested with:
- Valid values: 'white', 'black'
- Invalid values: 'red', 'blue', empty strings, etc.
- All invalid values correctly default to 'white'

## Related Issue

Closes #646