### PR TITLE
Feat: Implement DRY templates and auto-dismissing Toast notifications (#464)

### DIFF
--- a/game/static/game/css/auth.css
+++ b/game/static/game/css/auth.css
@@ -327,3 +327,42 @@ body.login-page .helptext {
 @keyframes fade-out {
     to { opacity: 0; height: 0; padding: 0; margin: 0; }
 }
+
+/* ── Toast Notifications ── */
+.toast-container {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    z-index: 9999;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+.toast {
+    background: #16162a;
+    color: #fff;
+    padding: 16px 20px;
+    border-radius: 8px;
+    border-left: 4px solid #f0c040;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.5);
+    font-size: 0.95rem;
+    animation: toast-enter 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
+    display: flex;
+    align-items: center;
+    max-width: calc(100vw - 40px);
+}
+.toast-success { border-left-color: #4caf50; }
+.toast-error { border-left-color: #ff6b6b; }
+.toast-warning { border-left-color: #f0c040; }
+
+@keyframes toast-enter {
+    from { transform: translateX(100%); opacity: 0; }
+    to { transform: translateX(0); opacity: 1; }
+}
+.toast-exit {
+    animation: toast-exit-anim 0.4s ease forwards !important;
+}
+@keyframes toast-exit-anim {
+    from { transform: translateX(0); opacity: 1; }
+    to { transform: translateX(100%); opacity: 0; }
+}

--- a/game/static/game/js/auth.js
+++ b/game/static/game/js/auth.js
@@ -126,4 +126,16 @@ document.addEventListener("DOMContentLoaded", () => {
     passwordInput.addEventListener("input", validatePassword);
     validatePassword(); // Run on initial load (handles autofill/form restoration)
   }
+
+  /* ── Auto-dismiss Toast Notifications ── */
+  const toasts = document.querySelectorAll('.toast');
+  toasts.forEach(toast => {
+    // Critical auth errors should stay visible
+    if (!toast.classList.contains('toast-error')) {
+      setTimeout(() => {
+        toast.classList.add('toast-exit');
+        setTimeout(() => toast.remove(), 400); // Wait for animation to finish
+      }, 5000);
+    }
+  });
 });

--- a/game/templates/game/includes/messages.html
+++ b/game/templates/game/includes/messages.html
@@ -1,0 +1,9 @@
+{% if messages %}
+<div class="toast-container" aria-live="polite" aria-atomic="true">
+    {% for message in messages %}
+        <div class="toast toast-{{ message.tags }}" role="{% if message.tags == 'error' %}alert{% else %}status{% endif %}">
+            <div class="toast-content">{{ message }}</div>
+        </div>
+    {% endfor %}
+</div>
+{% endif %}

--- a/game/templates/game/login.html
+++ b/game/templates/game/login.html
@@ -25,6 +25,8 @@
         <form method="POST">
             {% csrf_token %}
             
+            {% include 'game/includes/messages.html' %}
+            
             {% if form.non_field_errors %}
                 {{ form.non_field_errors }}
             {% endif %}

--- a/game/templates/game/register.html
+++ b/game/templates/game/register.html
@@ -29,13 +29,7 @@
         <form method="POST">
             {% csrf_token %}
 
-            {% if messages %}
-                <div class="message-list" role="alert">
-                    {% for message in messages %}
-                        <div class="message message-{{ message.tags }}">{{ message }}</div>
-                    {% endfor %}
-                </div>
-            {% endif %}
+            {% include 'game/includes/messages.html' %}
 
             {% if form.non_field_errors %}
                 {{ form.non_field_errors }}

--- a/game/templates/game/verify_otp.html
+++ b/game/templates/game/verify_otp.html
@@ -55,13 +55,7 @@
         <form method="POST">
             {% csrf_token %}
             
-            {% if messages %}
-                <div class="message-list" role="alert">
-                    {% for message in messages %}
-                        <div class="message message-{{ message.tags }}">{{ message }}</div>
-                    {% endfor %}
-                </div>
-            {% endif %}
+            {% include 'game/includes/messages.html' %}
             
             <div class="form-group">
                 <label for="otp">Enter 6-Digit OTP</label>


### PR DESCRIPTION
## Description
While setting up the project locally for the first time, I forgot to configure the **`EMAIL_HOST_USER`** in my **`.env`** file. Whenever I tried to register, the page silently refreshed without any feedback.

Upon investigating, I realized that while **`views.py`** correctly catches **SMTP exceptions** and generates a **`messages.error**` payload, the **`login.html`** template entirely lacked a Django **`{% if messages %}`** block, and the other templates had rigid inline loops. This caused critical authentication feedback to be "swallowed" by the frontend, leading to a silent reload.

**Chnages made :**
Instead of just copying and pasting the standard `{% if messages %}` block across all files,  I implemented a cleaner architectural and UX approach:

**1. DRY Templates:** 
Created a centralized `game/templates/game/includes/messages.html` component. I updated `register.html`, `login.html`, and `verify_otp.html` to leverage the `{% include %}` tag, significantly reducing code duplication.

**2. Enhanced UX (Toast Notifications):** 
Instead of static red text that permanently clutters the auth cards, I upgraded the UI to use floating "Toast" notifications. 
- Added `.toast-container` and `.toast` styling (with slide-in animations) to `auth.css`.
- Added a highly lightweight listener in `auth.js` that automatically applies an exit animation and dismisses the toast from the DOM after 5 seconds.

This ensures new contributors won't get silently stuck setting up their environments, and provides a much more premium UX for end users.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #464 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

<img width="2878" height="516" alt="image" src="https://github.com/user-attachments/assets/3ceaecb0-4f5d-4585-be87-41404b22421c" />

