### PR TITLE
UI: Increased chess piece scaling for better proportions (Fixes #601)

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -350,8 +350,8 @@ body {
 
 /* Capture ring (enemy piece) */
 .capture-ring {
-    width: 54px;
-    height: 54px;
+    width: 58px;
+    height: 58px;
     border-radius: 50%;
     border: 5px solid rgba(0, 0, 0, 0.18);
     position: absolute;
@@ -363,8 +363,8 @@ body {
    Pieces
    ============================================================ */
 .piece {
-    width: 54px;
-    height: 54px;
+    width: 58px;
+    height: 58px;
     z-index: 2;
     pointer-events: none;
     user-select: none;
@@ -675,10 +675,14 @@ body {
         width: var(--mobile-square-size);
     }
 
-    .piece,
+    .piece {
+        width: 96%;
+        height: 96%;
+    }
+
     .capture-ring {
-        width: 90%;
-        height: 90%;
+        width: 96%;
+        height: 96%;
     }
 
     .move-dot {


### PR DESCRIPTION
## Description

This PR addresses the visual UI issue where chess pieces, especially the rooks, appeared undersized compared to the board squares. The board piece sizing has been adjusted so pieces fill each square more proportionately, giving the board a more polished and professional appearance similar to standard chess platforms.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #601

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

## Screenshots (if applicable)

### Before
[Drag and drop the old screenshot with smaller pieces here]

### After
[Drag and drop the new screenshot showing the updated piece size here]

## Additional Notes

This is a scoped CSS-only change. It increases the board piece and capture-ring dimensions from `54px` to `58px` on desktop, and from `90%` to `96%` on mobile, improving proportions without changing board layout, move logic, or grid behavior.
