### PR TITLE
auth: Add resend OTP functionality with cooldown and rate limiting.

### DIFF
--- a/game/templates/game/verify_otp.html
+++ b/game/templates/game/verify_otp.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Verify your Email | Checkora</title>
-    <link rel="stylesheet" href="{% static 'game/css/auth.css' %}">
+    <link rel="stylesheet" href="{% static 'game/css/auth.css' %}?v=7">
     <link rel="icon" type="image/jpeg" href="{% static 'game/favicon.jpeg' %}">
     <style>
         .otp-container {
@@ -34,17 +34,131 @@
             box-shadow: 0 0 0 2px rgba(240, 192, 64, 0.2);
         }
         /* Hide number arrows */
-        input[type=number]::-webkit-inner-spin-button, 
-        input[type=number]::-webkit-outer-spin-button { 
-            -webkit-appearance: none; 
-            margin: 0; 
+        input[type=number]::-webkit-inner-spin-button,
+        input[type=number]::-webkit-outer-spin-button {
+            -webkit-appearance: none;
+            margin: 0;
         }
         input[type=number] {
             -moz-appearance: textfield;
         }
+
+        /* ── Resend OTP section ── */
+        .resend-section {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            margin-top: 20px;
+            min-height: 38px;
+        }
+        .resend-btn {
+            background: none;
+            border: 1px solid #f0c040;
+            color: #f0c040;
+            padding: 8px 18px;
+            border-radius: 6px;
+            font-size: 0.88rem;
+            font-weight: 600;
+            cursor: pointer;
+            letter-spacing: 0.3px;
+            transition: all 0.25s ease;
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+        }
+        .resend-btn:hover:not(:disabled) {
+            background: rgba(240, 192, 64, 0.12);
+            transform: translateY(-1px);
+            box-shadow: 0 2px 10px rgba(240, 192, 64, 0.15);
+        }
+        .resend-btn:disabled {
+            opacity: 0.4;
+            cursor: not-allowed;
+            border-color: #555;
+            color: #777;
+        }
+
+        /* Spinner inside button */
+        .resend-spinner {
+            display: none;
+            width: 14px;
+            height: 14px;
+            border: 2px solid transparent;
+            border-top-color: currentColor;
+            border-radius: 50%;
+            animation: spin 0.7s linear infinite;
+        }
+        .resend-btn.loading .resend-spinner {
+            display: inline-block;
+        }
+        .resend-btn.loading .resend-label {
+            opacity: 0.7;
+        }
+
+        @keyframes spin {
+            to { transform: rotate(360deg); }
+        }
+
+        /* Cooldown text */
+        .cooldown-text {
+            font-size: 0.82rem;
+            color: #8a8aaa;
+            letter-spacing: 0.3px;
+        }
+        .cooldown-text .cooldown-seconds {
+            color: #f0c040;
+            font-weight: 700;
+            font-variant-numeric: tabular-nums;
+        }
+
+        /* ── Toast notification ── */
+        .toast-container {
+            position: fixed;
+            top: 24px;
+            right: 24px;
+            z-index: 9999;
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+            pointer-events: none;
+        }
+        .toast {
+            pointer-events: auto;
+            padding: 12px 20px;
+            border-radius: 8px;
+            font-size: 0.88rem;
+            font-weight: 500;
+            color: #fff;
+            box-shadow: 0 6px 24px rgba(0, 0, 0, 0.45);
+            transform: translateX(120%);
+            opacity: 0;
+            transition: all 0.35s cubic-bezier(0.22, 1, 0.36, 1);
+            max-width: 340px;
+            line-height: 1.4;
+        }
+        .toast.show {
+            transform: translateX(0);
+            opacity: 1;
+        }
+        .toast-success {
+            background: linear-gradient(135deg, #1b5e20, #2e7d32);
+            border-left: 4px solid #66bb6a;
+        }
+        .toast-error {
+            background: linear-gradient(135deg, #b71c1c, #c62828);
+            border-left: 4px solid #ef5350;
+        }
+        .toast-warning {
+            background: linear-gradient(135deg, #e65100, #ef6c00);
+            border-left: 4px solid #ffa726;
+        }
     </style>
 </head>
 <body>
+
+    <!-- Toast container for notifications -->
+    <div class="toast-container" id="toast-container"></div>
 
     <div class="header">
         <h1>Verify your Email</h1>
@@ -52,9 +166,9 @@
     </div>
 
     <div class="auth-card">
-        <form method="POST">
+        <form method="POST" id="otp-form">
             {% csrf_token %}
-            
+
             {% if messages %}
                 <div class="message-list" role="alert">
                     {% for message in messages %}
@@ -62,21 +176,164 @@
                     {% endfor %}
                 </div>
             {% endif %}
-            
+
             <div class="form-group">
                 <label for="otp">Enter 6-Digit OTP</label>
                 <div class="otp-container">
                     <input type="text" id="otp" name="otp" class="otp-input" maxlength="6" pattern="\d{6}" placeholder="000000" autocomplete="off" required>
                 </div>
             </div>
-            
-            <button type="submit" class="btn btn-gold">Verify & Activate</button>
+
+            <button type="submit" class="btn btn-gold" id="verify-btn">Verify &amp; Activate</button>
         </form>
-        
+
+        <!-- Resend OTP section -->
+        <div class="resend-section" id="resend-section">
+            <button type="button" class="resend-btn" id="resend-btn" aria-label="Resend OTP">
+                <span class="resend-spinner"></span>
+                <span class="resend-label">Resend OTP</span>
+            </button>
+            <span class="cooldown-text" id="cooldown-text" style="display: none;">
+                Resend OTP in <span class="cooldown-seconds" id="cooldown-seconds">0</span>s
+            </span>
+        </div>
+
         <div class="auth-footer">
-            Didn't receive the code? <a href="{% url 'register' %}">Try again</a>
+            Need to change your email? <a href="{% url 'register' %}">Go back</a>
         </div>
     </div>
+
+    <script>
+    (function () {
+        "use strict";
+
+        /* ── DOM refs ── */
+        const resendBtn     = document.getElementById("resend-btn");
+        const cooldownText  = document.getElementById("cooldown-text");
+        const cooldownSecs  = document.getElementById("cooldown-seconds");
+        const toastBox      = document.getElementById("toast-container");
+
+        /* ── State ── */
+        let cooldownTimer   = null;
+        let isRequesting    = false;
+
+        /* CSRF token from the form */
+        const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]').value;
+
+        /* Initial cooldown from Django template (server-rendered) */
+        const initialCooldown = {{ cooldown_remaining|default:"0" }};
+
+        /* ────────────────────────────────────────────
+           Toast notifications
+           ──────────────────────────────────────────── */
+        function showToast(message, type) {
+            const toast = document.createElement("div");
+            toast.className = "toast toast-" + type;
+            toast.textContent = message;
+            toastBox.appendChild(toast);
+
+            /* Trigger slide-in on next frame */
+            requestAnimationFrame(function () {
+                requestAnimationFrame(function () {
+                    toast.classList.add("show");
+                });
+            });
+
+            /* Auto-dismiss after 4s */
+            setTimeout(function () {
+                toast.classList.remove("show");
+                setTimeout(function () { toast.remove(); }, 400);
+            }, 4000);
+        }
+
+        /* ────────────────────────────────────────────
+           Cooldown timer
+           ──────────────────────────────────────────── */
+        function startCooldown(seconds) {
+            if (cooldownTimer) clearInterval(cooldownTimer);
+
+            let remaining = Math.max(0, Math.ceil(seconds));
+            resendBtn.disabled = true;
+            resendBtn.style.display = "none";
+            cooldownText.style.display = "inline";
+            cooldownSecs.textContent = remaining;
+
+            cooldownTimer = setInterval(function () {
+                remaining -= 1;
+                if (remaining <= 0) {
+                    clearInterval(cooldownTimer);
+                    cooldownTimer = null;
+                    resendBtn.disabled = false;
+                    resendBtn.style.display = "inline-flex";
+                    cooldownText.style.display = "none";
+                } else {
+                    cooldownSecs.textContent = remaining;
+                }
+            }, 1000);
+        }
+
+        /* ────────────────────────────────────────────
+           Resend OTP handler
+           ──────────────────────────────────────────── */
+        resendBtn.addEventListener("click", function () {
+            if (isRequesting || resendBtn.disabled) return;
+            isRequesting = true;
+
+            /* Loading state */
+            resendBtn.classList.add("loading");
+            resendBtn.disabled = true;
+
+            fetch("{% url 'resend_otp' %}", {
+                method: "POST",
+                headers: {
+                    "X-CSRFToken": csrfToken,
+                    "Content-Type": "application/json",
+                },
+                credentials: "same-origin",
+            })
+            .then(function (res) {
+                return res.json().then(function (data) {
+                    return { status: res.status, data: data };
+                });
+            })
+            .then(function (result) {
+                var data   = result.data;
+                var status = result.status;
+
+                if (data.success) {
+                    showToast(data.message || "OTP resent successfully!", "success");
+                    startCooldown(data.cooldown || 60);
+                } else if (status === 429) {
+                    showToast(data.message || "Too many attempts. Please wait.", "warning");
+                    if (data.cooldown_remaining) {
+                        startCooldown(data.cooldown_remaining);
+                    }
+                } else if (status === 404) {
+                    showToast(data.message || "Session not found. Please register again.", "error");
+                    setTimeout(function () {
+                        window.location.href = "{% url 'register' %}";
+                    }, 2000);
+                } else {
+                    showToast(data.message || "Something went wrong. Please try again.", "error");
+                    resendBtn.disabled = false;
+                }
+            })
+            .catch(function () {
+                showToast("Network error. Please check your connection and try again.", "error");
+                resendBtn.disabled = false;
+            })
+            .finally(function () {
+                isRequesting = false;
+                resendBtn.classList.remove("loading");
+            });
+        });
+
+        /* ── Kick off initial cooldown if server says so ── */
+        if (initialCooldown > 0) {
+            startCooldown(initialCooldown);
+        }
+    })();
+    </script>
 
 </body>
 </html>

--- a/game/urls.py
+++ b/game/urls.py
@@ -21,6 +21,7 @@ urlpatterns = [
     # Authentication
     path('register/', views.register_view, name='register'),
     path('verify-otp/', views.verify_otp, name='verify_otp'),
+    path('api/auth/resend-otp/', views.resend_otp, name='resend_otp'),
     path('login/', views.login_view, name='login'),
     path('rules/', views.rules, name='rules'),
     path('logout/', views.logout_view, name='logout'),

--- a/game/views.py
+++ b/game/views.py
@@ -462,6 +462,43 @@ def resign_game(request):
     })
 
 
+def _build_otp_email_html(otp):
+    """Build the branded HTML email body for OTP verification."""
+    return (
+        "<div style=\"font-family: 'Segoe UI', Arial, sans-serif; "
+        "background-color: #0f0f1a; color: #d0d0d0; padding: 40px "
+        "20px; text-align: center;\"><div style=\"background-"
+        "color: #16162a; border: 1px solid #252545; border-radius"
+        ": 12px; padding: 40px 30px; max-width: 450px; margin: 0 "
+        "auto; box-shadow: 0 10px 30px rgba(0,0,0,0.5);\">"
+        "<h1 style=\"color: #ffffff; margin-top: 0; margin-bottom"
+        ": 15px; font-size: 28px; letter-spacing: 2px;\">CHECK"
+        "<span style=\"color: #f0c040;\">ORA</span></h1>"
+        "<hr style=\"border: none; border-top: 1px solid #252545; "
+        "margin: 20px 0;\"><p style=\"color: #e0e0e0; font-size: "
+        "16px; line-height: 1.5; margin-bottom: 30px;\">Welcome "
+        "to the elite chess platform. To activate your account "
+        "and start playing, please use the verification code "
+        "below:</p><div style=\"margin: 35px 0;\"><span style=\""
+        "font-family: 'Consolas', monospace; font-size: 36px; "
+        "font-weight: bold; color: #f0c040; letter-spacing: 8px; "
+        "background: #0f0f1a; padding: 15px 25px; border-radius: "
+        "8px; border: 1px solid #3d3222; display: inline-block;"
+        "\">{otp}</span></div><p style=\"color: #8a8aaa; font-"
+        "size: 14px; margin-top: 30px;\">Enter this code on the "
+        "verification page to complete your registration.</p>"
+        "<p style=\"color: #5a5a7a; font-size: 12px; margin-top: "
+        "40px;\">If you didn't attempt to register on Checkora, "
+        "please safely ignore this email.</p></div></div>"
+    ).format(otp=otp)
+
+
+# OTP configuration constants
+OTP_EXPIRY_SECONDS = 300       # 5 minutes
+OTP_COOLDOWN_SECONDS = 60      # 1 minute between resends
+OTP_MAX_RESEND_ATTEMPTS = 5    # Maximum resend attempts per session
+
+
 def register_view(request):
     if request.user.is_authenticated:
         return redirect('index')
@@ -476,9 +513,13 @@ def register_view(request):
             # Generate 6-digit OTP
             otp = str(secrets.randbelow(900000) + 100000)
             request.session['registration_user_id'] = user.id
+            request.session['registration_email'] = user.email
             # Hash OTP with SECRET_KEY as salt to prevent reading from signed cookies
             otp_hash = hashlib.sha256(f"{otp}:{settings.SECRET_KEY}".encode()).hexdigest()
             request.session['registration_otp_hash'] = otp_hash
+            request.session['registration_otp_created_at'] = time.time()
+            request.session['registration_resend_count'] = 0
+            request.session['registration_last_resend_at'] = 0.0
 
             # Send Email
             try:
@@ -486,33 +527,7 @@ def register_view(request):
                     f'Your OTP for registration is: {otp}\n\n'
                     'Please enter this code to activate your account.'
                 )
-                html_message = (
-                    "<div style=\"font-family: 'Segoe UI', Arial, sans-serif; "
-                    "background-color: #0f0f1a; color: #d0d0d0; padding: 40px "
-                    "20px; text-align: center;\"><div style=\"background-"
-                    "color: #16162a; border: 1px solid #252545; border-radius"
-                    ": 12px; padding: 40px 30px; max-width: 450px; margin: 0 "
-                    "auto; box-shadow: 0 10px 30px rgba(0,0,0,0.5);\">"
-                    "<h1 style=\"color: #ffffff; margin-top: 0; margin-bottom"
-                    ": 15px; font-size: 28px; letter-spacing: 2px;\">CHECK"
-                    "<span style=\"color: #f0c040;\">ORA</span></h1>"
-                    "<hr style=\"border: none; border-top: 1px solid #252545; "
-                    "margin: 20px 0;\"><p style=\"color: #e0e0e0; font-size: "
-                    "16px; line-height: 1.5; margin-bottom: 30px;\">Welcome "
-                    "to the elite chess platform. To activate your account "
-                    "and start playing, please use the verification code "
-                    "below:</p><div style=\"margin: 35px 0;\"><span style=\""
-                    "font-family: 'Consolas', monospace; font-size: 36px; "
-                    "font-weight: bold; color: #f0c040; letter-spacing: 8px; "
-                    "background: #0f0f1a; padding: 15px 25px; border-radius: "
-                    "8px; border: 1px solid #3d3222; display: inline-block;"
-                    "\">{otp}</span></div><p style=\"color: #8a8aaa; font-"
-                    "size: 14px; margin-top: 30px;\">Enter this code on the "
-                    "verification page to complete your registration.</p>"
-                    "<p style=\"color: #5a5a7a; font-size: 12px; margin-top: "
-                    "40px;\">If you didn't attempt to register on Checkora, "
-                    "please safely ignore this email.</p></div></div>"
-                ).format(otp=otp)
+                html_message = _build_otp_email_html(otp)
                 send_mail(
                     'Your Checkora Verification Code',
                     msg_plain,
@@ -527,6 +542,10 @@ def register_view(request):
                 user.delete()
                 request.session.pop('registration_user_id', None)
                 request.session.pop('registration_otp_hash', None)
+                request.session.pop('registration_email', None)
+                request.session.pop('registration_otp_created_at', None)
+                request.session.pop('registration_resend_count', None)
+                request.session.pop('registration_last_resend_at', None)
                 err_msg = (
                     'Failed to send OTP email. '
                     'Please check your email address and try again.'
@@ -549,10 +568,29 @@ def verify_otp(request):
         messages.error(request, 'Session expired. Please register again.')
         return redirect('register')
 
+    # Calculate remaining cooldown seconds for the template
+    last_resend = request.session.get('registration_last_resend_at', 0.0)
+    elapsed_since_resend = time.time() - last_resend
+    cooldown_remaining = max(0, int(OTP_COOLDOWN_SECONDS - elapsed_since_resend))
+
     if request.method == 'POST':
         entered_otp = request.POST.get('otp', '').strip()
+
+        # Check OTP expiry before verifying
+        otp_created_at = request.session.get('registration_otp_created_at', 0)
+        if time.time() - otp_created_at > OTP_EXPIRY_SECONDS:
+            messages.error(
+                request,
+                'OTP has expired. Please click "Resend OTP" to get a new code.'
+            )
+            return render(request, 'game/verify_otp.html', {
+                'cooldown_remaining': cooldown_remaining,
+            })
+
         # Verify hash
-        entered_otp_hash = hashlib.sha256(f"{entered_otp}:{settings.SECRET_KEY}".encode()).hexdigest()
+        entered_otp_hash = hashlib.sha256(
+            f"{entered_otp}:{settings.SECRET_KEY}".encode()
+        ).hexdigest()
 
         if entered_otp_hash == stored_otp_hash:
             try:
@@ -560,9 +598,14 @@ def verify_otp(request):
                 user.is_active = True
                 user.save()
 
-                # Clear session data
-                del request.session['registration_user_id']
-                del request.session['registration_otp_hash']
+                # Clear all registration session data
+                for key in (
+                    'registration_user_id', 'registration_otp_hash',
+                    'registration_email', 'registration_otp_created_at',
+                    'registration_resend_count',
+                    'registration_last_resend_at',
+                ):
+                    request.session.pop(key, None)
 
                 login(request, user)
                 request.session.cycle_key()
@@ -576,7 +619,126 @@ def verify_otp(request):
         else:
             messages.error(request, 'Invalid OTP. Please try again.')
 
-    return render(request, 'game/verify_otp.html')
+    return render(request, 'game/verify_otp.html', {
+        'cooldown_remaining': cooldown_remaining,
+    })
+
+
+@require_POST
+def resend_otp(request):
+    """Resend a fresh OTP to the user's registered email.
+
+    Returns JSON responses:
+        200 - OTP resent successfully
+        400 - Invalid request (missing session data)
+        404 - User/session not found
+        429 - Resend limit exceeded or cooldown active
+        500 - Internal server error
+    """
+    try:
+        user_id = request.session.get('registration_user_id')
+        stored_email = request.session.get('registration_email')
+
+        # 400 – missing registration session
+        if not user_id or not stored_email:
+            return JsonResponse(
+                {'success': False, 'message': 'No active registration session. Please register again.'},
+                status=400,
+            )
+
+        # 404 – user record not found
+        try:
+            user = User.objects.get(id=user_id)
+        except User.DoesNotExist:
+            # Clean up orphan session keys
+            for key in (
+                'registration_user_id', 'registration_otp_hash',
+                'registration_email', 'registration_otp_created_at',
+                'registration_resend_count',
+                'registration_last_resend_at',
+            ):
+                request.session.pop(key, None)
+            return JsonResponse(
+                {'success': False, 'message': 'User not found. Please register again.'},
+                status=404,
+            )
+
+        # Reject if user is already active (already verified)
+        if user.is_active:
+            return JsonResponse(
+                {'success': False, 'message': 'Account already verified. Please sign in.'},
+                status=400,
+            )
+
+        # 429 – cooldown check
+        last_resend = request.session.get('registration_last_resend_at', 0.0)
+        elapsed = time.time() - last_resend
+        if elapsed < OTP_COOLDOWN_SECONDS:
+            remaining = int(OTP_COOLDOWN_SECONDS - elapsed)
+            return JsonResponse(
+                {
+                    'success': False,
+                    'message': f'Please wait {remaining} seconds before requesting a new OTP.',
+                    'cooldown_remaining': remaining,
+                },
+                status=429,
+            )
+
+        # 429 – resend limit check
+        resend_count = request.session.get('registration_resend_count', 0)
+        if resend_count >= OTP_MAX_RESEND_ATTEMPTS:
+            return JsonResponse(
+                {
+                    'success': False,
+                    'message': 'Maximum resend attempts exceeded. Please register again.',
+                },
+                status=429,
+            )
+
+        # Generate a fresh OTP and invalidate the old one
+        otp = str(secrets.randbelow(900000) + 100000)
+        otp_hash = hashlib.sha256(
+            f"{otp}:{settings.SECRET_KEY}".encode()
+        ).hexdigest()
+
+        request.session['registration_otp_hash'] = otp_hash
+        request.session['registration_otp_created_at'] = time.time()
+        request.session['registration_resend_count'] = resend_count + 1
+        request.session['registration_last_resend_at'] = time.time()
+        request.session.modified = True
+
+        # Send the new OTP email
+        msg_plain = (
+            f'Your new OTP for registration is: {otp}\n\n'
+            'Please enter this code to activate your account.'
+        )
+        html_message = _build_otp_email_html(otp)
+        send_mail(
+            'Your Checkora Verification Code',
+            msg_plain,
+            None,
+            [stored_email],
+            fail_silently=False,
+            html_message=html_message,
+        )
+
+        return JsonResponse({
+            'success': True,
+            'message': 'OTP resent successfully.',
+            'cooldown': OTP_COOLDOWN_SECONDS,
+        })
+
+    except (SMTPException, BadHeaderError, OSError):
+        return JsonResponse(
+            {'success': False, 'message': 'Failed to send OTP email. Please try again.'},
+            status=500,
+        )
+    except Exception:
+        logging.getLogger(__name__).exception('resend_otp: Unexpected error.')
+        return JsonResponse(
+            {'success': False, 'message': 'Internal server error.'},
+            status=500,
+        )
 
 
 def login_view(request):


### PR DESCRIPTION
## Description

Implemented a secure Resend OTP feature with a 60s cooldown, 5-minute expiry, and attempt limits to prevent abuse. The UI now features a dynamic countdown timer, loading states, and toast notifications for a smoother, frustration-free registration experience.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #673 

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

<img width="2354" height="1342" alt="Screenshot 2026-05-15 204616" src="https://github.com/user-attachments/assets/760977d8-778e-49af-a0f7-f3fd5bc1bfdd" />

