### PR TITLE
Add development OTP terminal fallback

### DIFF
--- a/game/tests.py
+++ b/game/tests.py
@@ -88,12 +88,14 @@ class LandingViewTest(TestCase):
         self.assertContains(response, '/play/')
 
 class RegistrationViewTest(TestCase):
-    """Registration should send OTP by email only and show failures."""
+    """Registration should support local OTP fallback and email failures."""
 
     @override_settings(
-        EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend'
+        DEBUG=True,
+        EMAIL_HOST_USER='',
+        EMAIL_HOST_PASSWORD=''
     )
-    def test_successful_registration_redirects_without_showing_otp(self):
+    def test_missing_email_credentials_prints_otp_in_debug(self):
         payload = {
             'username': 'devplayer',
             'email': 'devplayer@example.com',
@@ -101,12 +103,24 @@ class RegistrationViewTest(TestCase):
             'password2': 'StrongPass123!',
         }
 
-        response = self.client.post('/register/', data=payload, follow=True)
+        with mock.patch('builtins.print') as mock_print:
+            response = self.client.post('/register/', data=payload, follow=True)
 
         self.assertRedirects(response, '/verify-otp/')
         self.assertNotContains(response, 'Development mode OTP')
         self.assertTrue(User.objects.filter(username='devplayer').exists())
+        printed_messages = ' '.join(
+            str(arg)
+            for call in mock_print.call_args_list
+            for arg in call.args
+        )
+        self.assertIn('Development registration OTP', printed_messages)
+        self.assertIn('devplayer@example.com', printed_messages)
 
+    @override_settings(
+        EMAIL_HOST_USER='sender@example.com',
+        EMAIL_HOST_PASSWORD='app-password'
+    )
     def test_email_failure_renders_error_and_removes_pending_user(self):
         payload = {
             'username': 'newplayer',

--- a/game/views.py
+++ b/game/views.py
@@ -480,6 +480,15 @@ def register_view(request):
             otp_hash = hashlib.sha256(f"{otp}:{settings.SECRET_KEY}".encode()).hexdigest()
             request.session['registration_otp_hash'] = otp_hash
 
+            missing_email_credentials = (
+                not settings.EMAIL_HOST_USER or
+                not settings.EMAIL_HOST_PASSWORD
+            )
+
+            if settings.DEBUG and missing_email_credentials:
+                print(f"[Checkora] Development registration OTP for {user.email}: {otp}")
+                return redirect('verify_otp')
+
             # Send Email
             try:
                 msg_plain = (


### PR DESCRIPTION
## Description

This PR adds a development-only fallback for the registration OTP flow.

Previously, registration always attempted to send the OTP through the configured SMTP email backend. In local development, when `EMAIL_HOST_USER` and `EMAIL_HOST_PASSWORD` were not configured, OTP sending failed and the registration flow stopped with an error.

With this change, if the app is running in `DEBUG=True` and email credentials are missing, the generated OTP is printed to the terminal instead. This allows developers to test the registration and OTP verification flow locally without requiring Gmail SMTP setup.

## Changes Made

- Added a debug-only fallback in the registration view.
- Prints the generated OTP to the terminal when SMTP credentials are missing.
- Keeps production behavior unchanged.
- Updated registration tests to cover the local OTP fallback.
- Preserved the existing failure behavior when SMTP credentials are configured but email sending fails.

## Testing

Ran the focused registration tests:

```bash
python manage.py test game.tests.RegistrationViewTest
```
Result:
```
OK
```
Notes
-----

The OTP is not shown in the browser UI. It is only printed in the terminal during local development when email credentials are missing.
Fixes #665