### PR TITLE
Dropdown overlay hidden while resigning

### DIFF
--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -316,7 +316,7 @@
             <p id="confirmMessage" style="color: #aaa; margin-bottom: 20px; font-size: 0.9rem; letter-spacing: 0.5px;">
                 Your current progress will be lost.<br>Are you sure you want to start a new game?
             </p>
-            <div id="confirmTimerContainer" style="margin-bottom: 20px; text-align: left;">
+            <div id="confirmTimerContainer" style="display: none; margin-bottom: 20px; text-align: left;">
                 <label style="color: #ccc; display: block; margin-bottom: 5px; font-size: 0.9rem;">Game Timer</label>
                 <select id="confirmTimerSelect"
                     style="width: 100%; padding: 10px; border-radius: 5px; border: 1px solid #444; background: #1a1a2e; color: #fff; cursor: pointer;">


### PR DESCRIPTION
The dropdown has been removed, the user can simply resign 

Solves issue #678 

<img width="375" height="261" alt="image" src="https://github.com/user-attachments/assets/c9ba3f84-dc1f-4f98-b92f-77d27f98e6f7" />
