### PR TITLE
Fix material score UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Join our Discord community for updates, support, and games: https://discord.gg/D
 | Hybrid Engine        | C++ binary for maximum speed with an automatic Python fallback                                      |
 | Full Move Validation | Legal moves enforced for all pieces including castling and promotion (en passant pending — see #88) |
 | Game Timer           | Per-player countdown clocks with pause support                                                      |
+| Material Score Panel | Live material advantage tracking that updates dynamically during gameplay                           |
 | REST API             | Clean JSON endpoints powering a decoupled frontend                                                  |
 | PvP & PvE Modes      | Play against a friend or challenge the AI                                                           |
 

--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -1266,3 +1266,50 @@ body {
         transform: translateY(-100px) scale(1);
     }
 }
+
+.score-panel {
+    display: flex;
+    justify-content: center;
+    gap: 12px;
+
+    margin-top: 10px;
+    flex-wrap: wrap;
+}
+
+.score-box {
+    background: #141638;
+
+    border: 1px solid #d4af37;
+
+    border-radius: 10px;
+
+    padding: 8px 16px;
+
+    min-width: 80px;
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.score-label {
+    font-size: 0.8rem;
+    opacity: 0.7;
+}
+
+.score-box span:last-child {
+    font-size: 1.1rem;
+    font-weight: bold;
+    color: #f5d76e;
+}
+
+@media (max-width: 600px) {
+    .score-panel {
+        gap: 8px;
+    }
+
+    .score-box {
+        min-width: 65px;
+        padding: 6px 10px;
+    }
+}

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -4,6 +4,15 @@
             /* ==========================================================
             CONSTANTS & STATE
             ========================================================== */
+             const MATERIAL_VALUES = {
+                  p: 1,
+                  n: 3,
+                  b: 3,
+                  r: 5,
+                  q: 9,
+                  k: 0
+             };
+
             const PIECE_IMG = {};
             for (const c of ['w', 'b'])
                 for (const t of ['k', 'q', 'r', 'b', 'n', 'p'])
@@ -193,6 +202,39 @@
             /* ==========================================================
             CSRF & API HELPERS
             ========================================================== */
+            function calculateMaterial(board) {
+                let white = 0;
+                let black = 0;
+            
+                for (let r = 0; r < 8; r++) {
+                    for (let c = 0; c < 8; c++) {
+                        const piece = board[r][c];
+                        if (!piece) continue;
+            
+                        const value = MATERIAL_VALUES[piece.toLowerCase()] || 0;
+                       if (piece === piece.toUpperCase()) {
+                     white += value;
+                    } 
+                     else {
+                      black += value;
+                     }
+                 }
+                } 
+            
+                return {
+                    white,
+                    black
+                            };
+            }
+
+            function updateMaterialUI(board) {
+                const { white, black } = calculateMaterial(board);
+
+              document.getElementById("whiteScore").innerText = white;
+
+              document.getElementById("blackScore").innerText = black;
+            }
+            
             function csrf() {
                 const m = document.cookie.match(/csrftoken=([^;]+)/);
                 return m ? decodeURIComponent(m[1]) : '';
@@ -536,6 +578,7 @@
                 }
                 refreshHighlights();
                 markPlayable();
+                updateMaterialUI(board);
             }
 
             function markPlayable() {
@@ -764,7 +807,7 @@
                             syncPieces();
                             renderClocks();
                             startTimer();
-
+                            updateMaterialUI(board);
                         let a11yMsg = '';
                         if (data.move_history && data.move_history.length > 0) {
                             const lastMove = data.move_history[data.move_history.length - 1].notation;
@@ -823,7 +866,7 @@
                             syncPieces();
                             renderClocks();
                             startTimer();
-
+                            updateMaterialUI(board);
                         let a11yMsg = '';
                         if (data.move_history && data.move_history.length > 0) {
                             const lastMove = data.move_history[data.move_history.length - 1].notation;
@@ -957,8 +1000,13 @@
             }
 
             function showStatus(msg, err) {
-                statusEl.textContent = msg;
-                statusEl.className = 'status-bar' + (err ? ' error' : '');
+                const gameStatusEl = document.getElementById("game-status");
+
+                   if (gameStatusEl) {
+                       gameStatusEl.textContent = msg;
+                   }
+               
+                   statusEl.className = 'status-bar' + (err ? ' error' : '');
             }
 
             function handleGameStatus(status, drawReason) {

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -254,7 +254,22 @@
                 </div>
             </div>
 
-            <div class="status-bar" id="statusBar" style="height: 22px; box-sizing: border-box;"></div>
+            <div class="status-bar" id="statusBar" style="height: 22px; box-sizing: border-box;">
+                <!--Score bar-->
+                  <div id="game-status">Game started</div>
+                   <div class="score-panel">
+                   <div class="score-box">
+                       <span class="score-label">White</span>
+                       <span id="whiteScore">0</span>
+                   </div>
+           
+                   <div class="score-box">
+                       <span class="score-label">Black</span>
+                       <span id="blackScore">0</span>
+                   </div>
+               </div>
+                
+            </div>
         </div>
         
 <!-- Right Panel: Controls -->


### PR DESCRIPTION
## Description

Added a live material score panel to the chess board UI that tracks and displays the material advantage for both players during gameplay.

The scoreboard updates dynamically after moves and remains visible throughout the game.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #75 

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [X] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [X] New and existing tests pass locally

## Screenshots (if applicable)

<img width="620" height="272" alt="Screenshot 2026-05-15 210251" src="https://github.com/user-attachments/assets/dd2e32bc-9823-44cb-b5aa-b256e55f1cd2" />



## Additional Notes

Changes made
Added a material score panel to the board UI
Implemented dynamic score updates after moves
Improved status bar layout and visibility
Updated README documentation for the new feature
Local Testing
Tested in browser during PvP gameplay
Verified score updates after captures
Verified panel remains visible during gameplay

