### PR TITLE
fix: resolve drag-and-drop by shifting pointer events to square div

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -424,6 +424,31 @@
                         d.ondragover = e => e.preventDefault();
                         d.ondrop = e => onDrop(e, r, c);
 
+                        // ADD THESE:
+                        d.draggable = true;
+                        d.ondragstart = e => {
+                            const piece = board[r][c];
+                            if (!piece || pColor(piece) !== turn || paused || gameOver) return e.preventDefault();
+                            if (gameMode === 'ai' && turn !== playerColor) return e.preventDefault();
+                            
+                            if (e.dataTransfer) {
+                                e.dataTransfer.setData('text/plain', 'piece-move');
+                                e.dataTransfer.effectAllowed = 'move';
+                            }
+                            
+                            const pieceImg = d.querySelector('.piece');
+                            if (pieceImg) e.dataTransfer.setDragImage(pieceImg, pieceImg.offsetWidth / 2, pieceImg.offsetHeight / 2);
+                            
+                            dragging = true;
+                            dragSrc = { r, c };
+                            setTimeout(() => selectPiece(r, c), 10);
+                        };
+
+                        d.ondragend = () => {
+                            dragging = false;
+                            dragSrc = null;
+                        };
+
                         d.setAttribute('tabindex', '0');
                         d.setAttribute('role', 'gridcell');
                         d.setAttribute('data-row', r);
@@ -461,9 +486,10 @@
                     const img = document.createElement('img');
                     img.src = PIECE_IMG[pKey(p)];
                     img.className = 'piece';
-                    img.draggable = true;
-                    img.ondragstart = e => onDragStart(e, r, c);
-                    img.ondragend = () => dragging = false;
+                    //Set to false, as the parent div now handles dragging
+                    img.draggable = false;
+                    // Keep this so drops work smoothly on occupied squares
+                    img.ondragover = e => e.preventDefault();
                     el.appendChild(img);
                 }
                 refreshHighlights();


### PR DESCRIPTION
## Description

Fixed a UX bug where drag-and-drop functionality failed to initialize. The `.piece` images had CSS suppressing pointer events, causing the `ondragstart` listener on the image to never fire. 

**Changes made:**
- Shifted the drag responsibility (`draggable=true` and `ondragstart`) from the `img` to the parent `.square` `div`, which reliably receives pointer events.
- Utilized `e.dataTransfer.setDragImage()` to maintain the visual effect of the piece being dragged.
- Set `draggable=false` on the `img` to prevent conflicts.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #684 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally