### PR TITLE
fix: wrap header logo in anchor tag for home navigation

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -33,6 +33,15 @@ body {
     gap: 8px;
 }
 
+/* Logo home link */
+.logo-link {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    text-decoration: none;
+    color: inherit;
+}
+
 /* Logo image - FIXED: Single rule with animation */
 .logo-icon-img {
     height: 40px;

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -159,7 +159,7 @@
         
         <div class="logo-container">
             <a href="{% url 'landing' %}" class="logo-link">
-                <img src="{% static 'game/checkora_icon_only.png' %}" class="logo-icon-img" alt="Checkora">
+                <img src="{% static 'game/checkora_icon_only.png' %}" class="logo-icon-img" alt="">
                 <span class="logo-text">Checkora</span>
             </a>
             <span class="badge" id="modeBadge">PVP</span>

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -158,8 +158,10 @@
     <div class="header">
         
         <div class="logo-container">
-            <img src="{% static 'game/checkora_icon_only.png' %}" class="logo-icon-img" alt="Checkora">
-            <span class="logo-text">Checkora</span>
+            <a href="{% url 'landing' %}" class="logo-link">
+                <img src="{% static 'game/checkora_icon_only.png' %}" class="logo-icon-img" alt="Checkora">
+                <span class="logo-text">Checkora</span>
+            </a>
             <span class="badge" id="modeBadge">PVP</span>
         </div>
         


### PR DESCRIPTION
## Summary
Fixes #687

Resolved the issue where the header logo was not wrapped in an anchor tag. Clicking the logo now correctly navigates the user back to the homepage (/) instead of triggering a "refused to connect" error.

## Changes
- **`game/templates/game/board.html`**: Wrapped the logo `<img>` and `<span class="logo-text">` inside `<a href="{% url 'landing' %}" class="logo-link">` so clicking the logo correctly navigates users to `/`.
- **`game/static/game/css/board.css`**: Added `.logo-link` rule (`display: flex; align-items: center; gap: 8px; text-decoration: none; color: inherit;`) to preserve the visual layout and strip default link styling.

## Verification
- Logo is clickable and redirects to the home path.
- UI layout remains visually unchanged.
- No unrelated files modified.
