### PR TITLE
Fix: Update move history display logic for correct indexing

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -920,9 +920,9 @@
                 }
                 movesEl.innerHTML = '';
                 const totalPairs = Math.ceil(history.length / 2);
-                for (let i = history.length - 1; i >= 0; i -= 2) {
-                    const whiteIdx = i % 2 === 0 ? i : i - 1;
-                    const blackIdx = whiteIdx + 1;
+                for (let i = 0; i < history.length; i += 2) {
+                    const whiteIdx = i;
+                    const blackIdx = i + 1;
                     const moveNum = Math.floor(whiteIdx / 2) + 1;
                     const row = document.createElement('div');
                     row.className = 'move-row';


### PR DESCRIPTION
## Description

Fixed move history ordering in the chess UI.

The move history rendering logic was iterating through the move list in reverse order, causing newly played moves to appear above older moves.

Updated the rendering loop to iterate forward so moves now display in proper chronological order.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #699 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

<img width="240" height="152" alt="move" src="https://github.com/user-attachments/assets/6e43c4c7-64fc-4769-b4f4-16ae3ed156b6" />


## Additional Notes

This change only affects the UI rendering order of move history and does not modify game logic or stored move data.

under gssoc