### PR TITLE
fix: Update password reset message to prevent user enumeration.

### DIFF
--- a/game/templates/game/password_reset_done.html
+++ b/game/templates/game/password_reset_done.html
@@ -22,8 +22,8 @@
 
     <div class="auth-card">
         <p style="text-align:center; margin-bottom: 1.5rem;">
-            We've sent a password reset link to your email address.
-            Please check your inbox and follow the instructions.
+            We've emailed you instructions for setting your password, if an account exists with the email you entered. 
+            You should receive them shortly. If you don't receive an email, please make sure you've entered the address you registered with, and check your spam folder.
         </p>
 
         <div class="auth-footer">


### PR DESCRIPTION
## Description

Replaced misleading password reset success message with Django's recommended ambiguous wording.

Previous message explicitly claimed an email was sent even for unregistered addresses. New message is honest for both registered and unregistered emails without revealing whether an account exists, preventing user enumeration attacks.

Tested and confirmed on live site:
- Registered email   → Reset email arrives 
- Unregistered email → No email sent, but same success message was shown 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #374 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

## Screenshots (if applicable)

<img width="1854" height="844" alt="Screenshot 2026-05-16 222139" src="https://github.com/user-attachments/assets/613757af-0d1c-4faa-9f0b-db60f5b436d6" />


## Additional Notes

Previous message:
"We've sent a password reset link to your email address. Please check your inbox and follow the instructions."

Replaced with Django's recommended wording:
"We've emailed you instructions for setting your password, if an account exists with the email you entered. You should receive them shortly. If you don't receive an email, please make sure you've entered the address you registered with, and check your spam folder."