### PR TITLE
Fix: Delete unverified ghost accounts to prevent registration lockout 

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -467,20 +467,36 @@ def register_view(request):
         return redirect('index')
 
     if request.method == 'POST':
-        username = request.POST.get('username')
-        email = request.POST.get('email')
-        
-        # Ghost Account Cleanup: Delete unverified users blocking this registration
-        if username and email:
-            ghost_user = User.objects.filter(
-                Q(username=username) | Q(email=email),
-                is_active=False
-            ).first()
-            if ghost_user:
-                ghost_user.delete()
-
         form = CustomUserCreationForm(request.POST)
-        if form.is_valid():
+        is_valid = form.is_valid()
+        
+        # Ghost Account Cleanup: Only run if form is perfectly valid except for username/email conflicts
+        if not is_valid and set(form.errors.keys()).issubset({'username', 'email'}):
+            username = request.POST.get('username')
+            email = request.POST.get('email')
+            
+            if username and email:
+                deleted = False
+                # 1. Exact match (User retrying with the exact same details)
+                if User.objects.filter(username=username, email=email, is_active=False).exists():
+                    User.objects.filter(username=username, email=email, is_active=False).delete()
+                    deleted = True
+                else:
+                    # 2. Username conflict (Free up unverified, abandoned usernames)
+                    if User.objects.filter(username=username, is_active=False).exists():
+                        User.objects.filter(username=username, is_active=False).delete()
+                        deleted = True
+                    # 3. Email conflict (Free up unverified, abandoned emails)
+                    if User.objects.filter(email=email, is_active=False).exists():
+                        User.objects.filter(email=email, is_active=False).delete()
+                        deleted = True
+                
+                if deleted:
+                    # Re-validate the form now that conflicts are cleared
+                    form = CustomUserCreationForm(request.POST)
+                    is_valid = form.is_valid()
+
+        if is_valid:
             user = form.save(commit=False)
             user.is_active = False  # Deactivate account till OTP is verified
             user.save()

--- a/game/views.py
+++ b/game/views.py
@@ -467,6 +467,18 @@ def register_view(request):
         return redirect('index')
 
     if request.method == 'POST':
+        username = request.POST.get('username')
+        email = request.POST.get('email')
+        
+        # Ghost Account Cleanup: Delete unverified users blocking this registration
+        if username and email:
+            ghost_user = User.objects.filter(
+                Q(username=username) | Q(email=email),
+                is_active=False
+            ).first()
+            if ghost_user:
+                ghost_user.delete()
+
         form = CustomUserCreationForm(request.POST)
         if form.is_valid():
             user = form.save(commit=False)


### PR DESCRIPTION
## Description
When a new user registers, Checkora immediately creates their `User` model with `is_active = False` while waiting for OTP verification. 
If the user's session expires or they close the tab, they lose the `registration_user_id` cookie. 

If they try to register again, `CustomUserCreationForm.is_valid()` throws a `Username already exists` or `Email already exists` validation error because their unverified ghost account still permanently occupies the database row. The user becomes permanently locked out of their own username and email.

## The Solution

I implemented a "Ghost Account Cleanup" intercept directly inside `register_view`. Before the form validates, we scan the database to see if the requested username or email is currently occupied by an unverified (`is_active=False`) account. If it is, we delete the ghost account, allowing the user's new registration attempt to pass `is_valid()` and succeed flawlessly.

### Code Changes (game/views.py)
```python
    if request.method == 'POST':
        username = request.POST.get('username')
        email = request.POST.get('email')
        
        # Ghost Account Cleanup: Delete unverified users blocking this registration
        if username and email:
            ghost_user = User.objects.filter(
                Q(username=username) | Q(email=email),
                is_active=False
            ).first()
            if ghost_user:
                ghost_user.delete()
        form = CustomUserCreationForm(request.POST)
        if form.is_valid():

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #706 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
