### PR TITLE
Added P shortcut for pause and resume

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1911,6 +1911,9 @@
                 } else if (key === 'd' && drawBtn && drawBtn.style.display !== 'none' && !drawBtn.disabled) {
                     e.preventDefault();
                     drawBtn.click();
+                } else if (key === 'p' && pauseBtn && pauseBtn.style.display !== 'none' && !pauseBtn.disabled) {
+                    e.preventDefault();
+                    pauseBtn.click();
                 }
             });
             // Emote Logic


### PR DESCRIPTION
## Summary

Added a keyboard shortcut for Pause/Resume in the chess board UI.

Fixes #736

## Changes Made

- Updated `game/static/game/js/board.js`.
- Extended the existing `document.addEventListener('keydown', ...)` shortcut handler.
- Added support for the `P` key.
- Reused the existing `pauseBtn.click()` behavior, so it works for both pausing and resuming.
- Followed the same guard logic as the existing `F`, `R`, and `D` shortcuts.

## Behavior

The `P` shortcut:

- Does not run on repeated key events.
- Does not run while an input, textarea, or select is focused.
- Does not run while a modal/dialog/promotion overlay is active.
- Only runs when the pause button exists, is visible, and is not disabled.

## Testing

- Ran `npm test` successfully.
  - Result: 1 test suite passed, 9 tests passed.
- Ran Django migrations successfully using `python3`.
- Started the Django development server successfully at `http://127.0.0.1:8000/`.
