### PR TITLE
feat: implement asset blocker detection and auto-resume flow

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1951,7 +1951,58 @@
                     }
                 });
             }
-            
+            function showAssetWarning() {
+                const t = document.getElementById('confirmTimerContainer');
+                const d = document.getElementById('confirmDifficultyContainer');
+                if (t) t.style.display = 'none';
+                if (d) d.style.display = 'none';
+
+                // 1. Pause the timer while the alert is open
+                if (!paused && typeof pauseGame === 'function') {
+                    pauseGame().catch(() => {}); // Catch prevents crash if backend hasn't initialized
+                }
+
+                showConfirm( //the message on alert
+                    "⚠️ Assets Blocked",
+                    "<div style='line-height: 1.5; font-size: 0.95rem;'>The chess pieces failed to load.<br><br>Please check your browser permissions (allow images) or disable any ad-blockers on this site.</div>",
+                    () => { 
+                        // 2. Set a memory flag to bypass the main menu on reload
+                        sessionStorage.setItem('checkoraAutoResume', 'true');
+                        window.location.reload(); 
+                    },
+                    '#f0c040'
+                );
+                
+                const yesBtn = document.getElementById('confirmYesBtn');
+                const noBtn = document.getElementById('confirmNoBtn');
+                if (yesBtn) yesBtn.textContent = 'Reload Page';
+                
+                // 3. Resume the timer if they click Close
+                if (noBtn) {
+                    noBtn.textContent = 'Close';
+                    const defaultClose = noBtn.onclick; 
+                    noBtn.onclick = () => {
+                        if (defaultClose) defaultClose();
+                        if (paused && typeof resumeGame === 'function') {
+                            resumeGame().catch(() => {});
+                        }
+                    };
+                }
+            }            function checkAssets() {
+                const img = document.querySelector('.piece');
+                
+                // If a piece exists in the HTML but still has 0 width after 2 seconds, Chrome blocked it.
+                if (img && img.naturalWidth === 0) {
+                    if (!window.assetWarningShown) {
+                        window.assetWarningShown = true;
+                        showAssetWarning();
+                    }
+                }
+            }
+
+            // Wait exactly 2 seconds after the script loads to check the assets
+            // This gives normal connections plenty of time to load, while catching strict blockers.
+            setInterval(checkAssets, 5000);
 
           if (typeof module !== "undefined" && module.exports) {
           module.exports = { pColor, getSquareLabel, formatTime };


### PR DESCRIPTION
## Description
This PR adds a safety check for when chess piece images fail to load (which usually happens if a user has strict browser permissions or an aggressive ad-blocker).

Instead of showing an empty board or broken image icons, the game now detects the failure and shows a friendly warning modal. While this alert modal is open, the game timer is automatically paused. It asks the user to check their permissions and gives them a button to reload.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #634 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)
<img width="1073" height="425" alt="image" src="https://github.com/user-attachments/assets/77cfb9a9-96de-4b1f-b2c7-39e92aa84e81" />

## Additional Notes
I'm GSSOC Contributor.
