### PR TITLE
Fix password reset reuse validation (Fixes #686)

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django.urls import path, include
 from django.contrib.auth import views as auth_views
 from django.views.generic import TemplateView
+from game.forms import CustomSetPasswordForm
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -25,7 +26,8 @@ urlpatterns = [
 
     path('password-reset-confirm/<uidb64>/<token>/',
          auth_views.PasswordResetConfirmView.as_view(
-             template_name='game/password_reset_confirm.html'
+             template_name='game/password_reset_confirm.html',
+             form_class=CustomSetPasswordForm
          ),
          name='password_reset_confirm'),
 

--- a/game/forms.py
+++ b/game/forms.py
@@ -1,8 +1,31 @@
 from django import forms
-from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth.forms import SetPasswordForm, UserCreationForm
+
 
 class CustomUserCreationForm(UserCreationForm):
     email = forms.EmailField(required=True)
 
     class Meta(UserCreationForm.Meta):
         fields = UserCreationForm.Meta.fields + ('email',)
+
+
+class CustomSetPasswordForm(SetPasswordForm):
+    """Prevent password resets from reusing the account's current password."""
+
+    def clean(self):
+        cleaned_data = super().clean()
+        new_password = cleaned_data.get('new_password2')
+        if (
+            new_password
+            and self.user.has_usable_password()
+            and self.user.check_password(new_password)
+        ):
+            self.add_error(
+                'new_password2',
+                forms.ValidationError(
+                    'This password has been used before. '
+                    'Please choose a new password.',
+                    code='password_reused',
+                ),
+            )
+        return cleaned_data

--- a/game/templates/game/password_reset_confirm.html
+++ b/game/templates/game/password_reset_confirm.html
@@ -24,6 +24,11 @@
         {% if validlink %}
             <form method="POST">
                 {% csrf_token %}
+                {% if form.non_field_errors %}
+                    <div class="field-errors">
+                        {{ form.non_field_errors }}
+                    </div>
+                {% endif %}
                 {% for field in form %}
                     <div class="form-group">
                         <label for="{{ field.id_for_label }}">{{ field.label }}</label>

--- a/game/tests.py
+++ b/game/tests.py
@@ -10,6 +10,7 @@ from django.contrib.auth.models import User
 from django.test import SimpleTestCase, TestCase, override_settings
 
 from .engine import ChessGame
+from .forms import CustomSetPasswordForm
 
 class EnginePathResolutionTest(SimpleTestCase):
     """Engine path selection should work across local platforms."""
@@ -138,6 +139,56 @@ class RegistrationViewTest(TestCase):
         self.assertFalse(User.objects.filter(username='newplayer').exists())
         self.assertNotIn('registration_user_id', self.client.session)
         self.assertNotIn('registration_otp_hash', self.client.session)
+
+
+class CustomSetPasswordFormTest(TestCase):
+    """Password reset form should reject reusing the current password."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='resetuser',
+            password='StrongPass123!',
+        )
+
+    def test_rejects_reusing_current_password(self):
+        form = CustomSetPasswordForm(
+            self.user,
+            data={
+                'new_password1': 'StrongPass123!',
+                'new_password2': 'StrongPass123!',
+            },
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn('new_password2', form.errors)
+        self.assertIn(
+            'This password has been used before. Please choose a new password.',
+            form.errors['new_password2'],
+        )
+
+    def test_accepts_different_valid_password(self):
+        form = CustomSetPasswordForm(
+            self.user,
+            data={
+                'new_password1': 'NewStrongPass456!',
+                'new_password2': 'NewStrongPass456!',
+            },
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_unusable_password_accounts_keep_default_validation_flow(self):
+        self.user.set_unusable_password()
+        self.user.save()
+        form = CustomSetPasswordForm(
+            self.user,
+            data={
+                'new_password1': 'NewStrongPass456!',
+                'new_password2': 'NewStrongPass456!',
+            },
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
 
 class MoveValidationTest(TestCase):
     """Test move validation wrapper by mocking validate_move."""


### PR DESCRIPTION
## Description

Prevent users from reusing their current password during password reset flow.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #686

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

N/A - Backend validation change

## Additional Notes

- Added CustomSetPasswordForm to validate password reuse
- Integrated with Django's PasswordResetConfirmView
- Added comprehensive test cases for edge cases like unusable passwords
- Updated template to display validation errors to users
