### PR TITLE
feat: add random color assignment option for Play vs AI setup (#723)

### DIFF
--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -133,6 +133,8 @@
                         style="padding: 12px; flex: 1; border: 2px solid #f0c040; background: #fff; color: #000; transition: all 0.2s;">White</button>
                     <button class="btn color-choice" id="pveBlackBtn" data-color="black"
                         style="padding: 12px; flex: 1; border: 2px solid #444; background: #000; color: #fff; transition: all 0.2s;">Black</button>
+                        <button class="btn color-choice" id="pveRandomBtn" data-color="random"
+                        style="border: 1px solid #444; background: linear-gradient(to right, #fff 50%, #000 50%); color: #888; transition: all 0.2s;">🎲 Random</button>
                 </div>
 
                 <div id="aiDifficultyContainer" style="margin-bottom: 10px;">

--- a/game/views.py
+++ b/game/views.py
@@ -134,8 +134,13 @@ def new_game(request):
 
     if mode not in ('pvp', 'ai'):
         mode = 'pvp'
+    
     player_color = data.get('player_color', 'white')
-    if player_color not in ('white', 'black'):
+
+    if player_color == 'random':
+        import random
+        player_color = random.choice(['white', 'black'])
+    elif player_color not in ('white', 'black'):
         player_color = 'white'
 
     def _clean_name(raw, fallback):


### PR DESCRIPTION
## Description
Adds a "Random" color option to the Play vs AI game setup screen, alongside the existing White and Black buttons. When selected, the backend randomly assigns either white or black using `random.choice()`.

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Changes Made
- `game/templates/game/board.html`: Added a third "🎲 Random" button in the color selection UI
- `game/views.py`: Added logic to handle `player_color == 'random'` using `random.choice(['white', 'black'])`

## Related Issue
Closes #723

## Testing
- Tested in VS AI mode — board correctly orients based on randomly assigned color
- Existing White/Black flow unchanged