### PR TITLE
fix: Username field partially hidden and not scrollable on registrati…

### DIFF
--- a/game/static/game/css/auth.css
+++ b/game/static/game/css/auth.css
@@ -1,4 +1,4 @@
-/* auth.css - Shared styles for Checkora Authentication Pages */
+/* auth.css - Shared styles for Checkora Authentication Pages*/
 
 *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
 html, body {
@@ -107,6 +107,7 @@ body {
     color: #fff;
     font-size: 1.1rem;
     transition: all 0.2s ease;
+    box-sizing: border-box;
 }
 .form-group input:focus {
     outline: none;
@@ -389,5 +390,11 @@ body.login-page .helptext {
 @media (max-width: 600px) {
     .auth-card {
         padding: 30px 20px;
+    }
+}
+
+@media (max-width: 768px) {
+    .auth-card {
+        padding: 30px 16px;
     }
 }

--- a/game/static/game/css/auth.css
+++ b/game/static/game/css/auth.css
@@ -1,4 +1,4 @@
-/* auth.css - Shared styles for Checkora Authentication Pages*/
+/* auth.css - Shared styles for Checkora Authentication Pages */
 
 *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
 html, body {


### PR DESCRIPTION
## Description
The username field on the registration form was partially hidden 
and not scrollable on smaller screens due to missing box-sizing 
and excessive padding on the auth card.

## Type of Change
- [x] Bug fix 

## Related Issue
Fixes #722

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

## Screenshots (if applicable)
The fix is a CSS change (box-sizing and responsive padding).

## Additional Notes
- Added `box-sizing: border-box` to `.form-group input` in auth.css
- Added responsive padding rule for screens under 768px