### PR TITLE
Pause and Resign buttons fixed

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -591,6 +591,17 @@ body {
     transform: translateY(-1px);
 }
 .btn-danger:active { transform: translateY(0); }
+.btn-pause {
+    background: linear-gradient(135deg, #b8860b, #8b6508);
+    color: #fff;
+    border: 1px solid #a07808;
+}
+.btn-pause:hover {
+    background: linear-gradient(135deg, #cc9a10, #a07808);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 16px rgba(184, 134, 11, 0.3);
+}
+.btn-pause:active { transform: translateY(0); }
 .back-btn {
     font-size: small;
     background: var(--bg);
@@ -1208,9 +1219,11 @@ body {
 }
 
 #pauseBtn.paused {
-    background: linear-gradient(135deg, #ff4444, #cc0000);
+    background: linear-gradient(135deg, #27ae60, #1e8449);
     color: #fff;
+    border-color: #1a7a3c;
 }
+
 /* ================= INPUT ERROR STATE ================= */
 .input-error {
     border-color: #ff6b6b !important;

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -422,6 +422,8 @@
                 }
 
                 if (drawBtn) drawBtn.style.display = gameMode === 'pvp' ? 'block' : 'none';
+                if (pauseBtn)  pauseBtn.style.display  = 'block';  
+                if (resignBtn) resignBtn.style.display = 'block'; 
 
                 updatePlayerNames(data);
                 updateTurn();

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -306,8 +306,8 @@
                         <button class="btn btn-gold" id="autoFlipBtn">Auto-Flip: OFF</button>
                     </div>
                     <button class="btn btn-gold" id="drawBtn" style="display: none;">Offer Draw</button>
-                    <button class="btn btn-pause" id="pauseBtn">Pause</button>
-                    <button class="btn btn-danger" id="resignBtn">Resign</button>
+                    <button type="button" class="btn btn-pause" id="pauseBtn">Pause</button>
+                    <button type="button" class="btn btn-danger" id="resignBtn">Resign</button>
                     <button class="btn btn-gold" style="width: 100%;"
                         onclick="document.getElementById('rulebookModal').style.display='flex'">📖 Rulebook</button>
                 </div>

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -306,8 +306,8 @@
                         <button class="btn btn-gold" id="autoFlipBtn">Auto-Flip: OFF</button>
                     </div>
                     <button class="btn btn-gold" id="drawBtn" style="display: none;">Offer Draw</button>
-                    <button class="btn btn-gold" id="pauseBtn">Pause</button>
-                    <button class="btn" id="resignBtn" style="background: #333; color: #fff;">Resign</button>
+                    <button class="btn btn-pause" id="pauseBtn">Pause</button>
+                    <button class="btn btn-danger" id="resignBtn">Resign</button>
                     <button class="btn btn-gold" style="width: 100%;"
                         onclick="document.getElementById('rulebookModal').style.display='flex'">📖 Rulebook</button>
                 </div>


### PR DESCRIPTION
1. Pause and Resign buttons were disappearing after the first game ended and never coming back in new games
2. Resign button had no hover effect or proper styling — it was using a raw inline style
3. Pause button looked identical to every other control button with no visual distinction

<img width="1557" height="878" alt="image" src="https://github.com/user-attachments/assets/435ab4e7-dfaa-4acd-a356-13c7ee1f668b" />