### PR TITLE
Fix duplicate account creation with same email

### DIFF
--- a/game/forms.py
+++ b/game/forms.py
@@ -1,8 +1,18 @@
 from django import forms
 from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth.models import User
+
 
 class CustomUserCreationForm(UserCreationForm):
     email = forms.EmailField(required=True)
 
     class Meta(UserCreationForm.Meta):
         fields = UserCreationForm.Meta.fields + ('email',)
+
+    def clean_email(self):
+        email = self.cleaned_data.get('email')
+        if email and User.objects.filter(email__iexact=email).exists():
+            raise forms.ValidationError(
+                'An account with this email already exists. Please log in instead.'
+            )
+        return email

--- a/game/migrations/0005_unique_email_ci.py
+++ b/game/migrations/0005_unique_email_ci.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('game', '0004_gameresult_player_color'),
+        ('auth', '0012_alter_user_first_name_max_length'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="CREATE UNIQUE INDEX auth_user_email_ci_uniq ON auth_user (LOWER(email)) WHERE email != '';",
+            reverse_sql="DROP INDEX IF EXISTS auth_user_email_ci_uniq;"
+        )
+    ]

--- a/game/tests.py
+++ b/game/tests.py
@@ -139,6 +139,97 @@ class RegistrationViewTest(TestCase):
         self.assertNotIn('registration_user_id', self.client.session)
         self.assertNotIn('registration_otp_hash', self.client.session)
 
+    @override_settings(
+        DEBUG=True,
+        EMAIL_HOST_USER='',
+        EMAIL_HOST_PASSWORD=''
+    )
+    def test_duplicate_email_rejected(self):
+        """Registration must fail when email is already taken."""
+        User.objects.create_user(
+            username='existing', email='taken@example.com', password='Pass123!'
+        )
+        payload = {
+            'username': 'newuser',
+            'email': 'taken@example.com',
+            'password1': 'StrongPass123!',
+            'password2': 'StrongPass123!',
+        }
+        response = self.client.post('/register/', data=payload)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            'An account with this email already exists. Please log in instead.'
+        )
+        self.assertFalse(User.objects.filter(username='newuser').exists())
+
+    @override_settings(
+        DEBUG=True,
+        EMAIL_HOST_USER='',
+        EMAIL_HOST_PASSWORD=''
+    )
+    def test_duplicate_email_case_insensitive(self):
+        """Email uniqueness check must be case-insensitive."""
+        User.objects.create_user(
+            username='existing', email='Player@Example.com', password='Pass123!'
+        )
+        payload = {
+            'username': 'newuser',
+            'email': 'player@example.com',
+            'password1': 'StrongPass123!',
+            'password2': 'StrongPass123!',
+        }
+        response = self.client.post('/register/', data=payload)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            'An account with this email already exists. Please log in instead.'
+        )
+        self.assertFalse(User.objects.filter(username='newuser').exists())
+
+    @override_settings(
+        DEBUG=True,
+        EMAIL_HOST_USER='',
+        EMAIL_HOST_PASSWORD=''
+    )
+    def test_unique_email_succeeds(self):
+        """Registration with a fresh email must still work normally."""
+        User.objects.create_user(
+            username='existing', email='old@example.com', password='Pass123!'
+        )
+        payload = {
+            'username': 'brandnew',
+            'email': 'fresh@example.com',
+            'password1': 'StrongPass123!',
+            'password2': 'StrongPass123!',
+        }
+        with mock.patch('builtins.print'):
+            response = self.client.post('/register/', data=payload, follow=True)
+        self.assertRedirects(response, '/verify-otp/')
+        self.assertTrue(User.objects.filter(username='brandnew').exists())
+
+    @override_settings(
+        DEBUG=True,
+        EMAIL_HOST_USER='',
+        EMAIL_HOST_PASSWORD=''
+    )
+    def test_duplicate_email_does_not_create_user(self):
+        """No new User row should be created when email is duplicate."""
+        User.objects.create_user(
+            username='first', email='dup@example.com', password='Pass123!'
+        )
+        initial_count = User.objects.count()
+        payload = {
+            'username': 'second',
+            'email': 'dup@example.com',
+            'password1': 'StrongPass123!',
+            'password2': 'StrongPass123!',
+        }
+        self.client.post('/register/', data=payload)
+        self.assertEqual(User.objects.count(), initial_count)
+
+
+
 class MoveValidationTest(TestCase):
     """Test move validation wrapper by mocking validate_move."""
 

--- a/game/views.py
+++ b/game/views.py
@@ -15,6 +15,7 @@ from smtplib import SMTPException
 from django.core.mail import BadHeaderError, send_mail
 from django.contrib import messages
 from django.db.models import F, Q
+from django.db import IntegrityError
 
 from .forms import CustomUserCreationForm
 from django.views.decorators.csrf import ensure_csrf_cookie, csrf_exempt
@@ -471,7 +472,11 @@ def register_view(request):
         if form.is_valid():
             user = form.save(commit=False)
             user.is_active = False  # Deactivate account till OTP is verified
-            user.save()
+            try:
+                user.save()
+            except IntegrityError:
+                form.add_error('email', 'An account with this email already exists. Please log in instead.')
+                return render(request, 'game/register.html', {'form': form})
 
             # Generate 6-digit OTP
             otp = str(secrets.randbelow(900000) + 100000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django>=6.0,<7.0
+django>=5.0,<6.0
 dj-database-url>=2.1.0
 psycopg2-binary>=2.9.9
 python-dotenv>=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django>=5.0,<6.0
+django>=6.0,<7.0
 dj-database-url>=2.1.0
 psycopg2-binary>=2.9.9
 python-dotenv>=1.0.0


### PR DESCRIPTION
## Description

This PR fixes the issue where users could register multiple accounts using the same email address.

## Changes Made

* Added email uniqueness validation in `CustomUserCreationForm`
* Prevented case-insensitive duplicate emails using `email__iexact`
* Added test cases for duplicate email registration

## Result

* Registration now fails gracefully if the email already exists
* Users see a clear validation message:
  "An account with this email already exists. Please log in instead."

## Testing

Tested manually by:

1. Registering with a new email
2. Attempting registration again with the same email
3. Verifying case-insensitive duplicate prevention (`Test@gmail.com`)