### PR TITLE
feat: Add opening book JSON for AI engine

### DIFF
--- a/game/engine/opening_book.json
+++ b/game/engine/opening_book.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "Opening book: keys are FEN positions (no move count), values are lists of [from_row, from_col, to_row, to_col].",
 
   "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq": [
     [6, 4, 4, 4],


### PR DESCRIPTION
Adds opening positions for Sicilian Defence, Ruy Lopez,  Queen's Gambit, Italian Game and Caro-Kann. Closes #721

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #721 

## Checklist

- [x ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

## Screenshots (if applicable)

Add screenshots to demonstrate visual changes.

## Additional Notes

Any additional information reviewers should know.
