### PR TITLE
fix: comment out unused piece variables in isSquareAttacked

### DIFF
--- a/game/engine/main.cpp
+++ b/game/engine/main.cpp
@@ -138,9 +138,9 @@ bool pathClear(int fr, int fc, int tr, int tc) {
  */
 bool isSquareAttacked(int tr, int tc, string attackerColor) {
     char pKnight = (attackerColor == "white") ? 'N' : 'n';
-    char pRook   = (attackerColor == "white") ? 'R' : 'r';
-    char pBishop = (attackerColor == "white") ? 'B' : 'b';
-    char pQueen  = (attackerColor == "white") ? 'Q' : 'q';
+    // char pRook   = (attackerColor == "white") ? 'R' : 'r';
+    // char pBishop = (attackerColor == "white") ? 'B' : 'b';
+    // char pQueen  = (attackerColor == "white") ? 'Q' : 'q';
     char pPawn   = (attackerColor == "white") ? 'P' : 'p';
     char pKing   = (attackerColor == "white") ? 'K' : 'k';
 


### PR DESCRIPTION
## Description
Commented out unused variables for rook, bishop, and queen. The traces of the warnings caused by this were appearing in CI/CD checks.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #810 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots
<img width="2010" height="279" alt="image" src="https://github.com/user-attachments/assets/b62480a4-8fd1-4c9c-8c0e-4bc76515f60d" />
The warnings are gone. There is no breaking in logic.
