### PR TITLE
Improve classic theme visibility and accessibility

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -317,13 +317,16 @@ body {
 
 :root {
     --page-bg: #0f0f1a;
+
     /* Classic */
-    --sq-light: #f0c040;
-    --sq-dark: #2f2f2f;
-    --sq-selected-light: #f6f669;
-    --sq-selected-dark: #baca2b;
-    --sq-last-light: #f5f682;
-    --sq-last-dark: #b8cc36;
+    --sq-light: #FFF6D5;
+    --sq-dark: #E1B12C;
+
+    --sq-selected-light: #FFE27A;
+    --sq-selected-dark: #FFD84D;
+
+    --sq-last-light: #FFEAA0;
+    --sq-last-dark: #F4D35E;
 }
 
 /* Dark Theme */
@@ -385,13 +388,17 @@ body {
     width: 17px;
     height: 17px;
     border-radius: 50%;
-    background: rgba(0, 0, 0, 0.18);
+    background: rgba(209, 213, 219, 0.78);
+    border: 1px solid rgba(255, 255, 255, 0.45);
+    box-shadow: 0 0 8px rgba(255, 255, 255, 0.28);
     position: absolute;
     pointer-events: none;
+    transition: all 0.2s ease;
 }
 
 .square:hover .move-dot {
-    background: rgba(0, 0, 0, 0.3);
+    background: rgba(229, 231, 235, 0.92);
+    box-shadow: 0 0 10px rgba(255, 255, 255, 0.45);
 }
 
 /* Capture ring */

--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -327,6 +327,12 @@ body {
 
     --sq-last-light: #FFEAA0;
     --sq-last-dark: #F4D35E;
+
+    --move-dot: rgba(209, 213, 219, 0.78);
+    --move-dot-hover: rgba(229, 231, 235, 0.92);
+    --move-dot-border: rgba(255, 255, 255, 0.45);
+    --move-dot-glow: rgba(255, 255, 255, 0.28);
+    --move-dot-hover-glow: rgba(255, 255, 255, 0.45);
 }
 
 /* Dark Theme */
@@ -388,17 +394,17 @@ body {
     width: 17px;
     height: 17px;
     border-radius: 50%;
-    background: rgba(209, 213, 219, 0.78);
-    border: 1px solid rgba(255, 255, 255, 0.45);
-    box-shadow: 0 0 8px rgba(255, 255, 255, 0.28);
+    background: var(--move-dot);
+    border: 1px solid var(--move-dot-border);
+    box-shadow: 0 0 8px var(--move-dot-glow);
     position: absolute;
     pointer-events: none;
     transition: all 0.2s ease;
 }
 
 .square:hover .move-dot {
-    background: rgba(229, 231, 235, 0.92);
-    box-shadow: 0 0 10px rgba(255, 255, 255, 0.45);
+    background: var(--move-dot-hover);
+    box-shadow: 0 0 10px var(--move-dot-hover-glow);
 }
 
 /* Capture ring */


### PR DESCRIPTION
## Description

This PR improves the visibility and accessibility of move indicators in the classic chess theme.

Previously, move dots had very low contrast on dark squares, making it difficult for users to clearly trace valid moves during gameplay, especially while using black pieces.

## Changes Made

* Improved classic theme color palette while preserving the yellow aesthetic of the platform
* Enhanced square contrast for better readability
* Redesigned move indicators for improved visibility on both light and dark squares
* Added subtle glow and border styling to move dots
* Added smoother hover transitions for a cleaner UI experience

## Updated Theme Colors

* Light Square: `#FFF6D5`
* Dark Square: `#E1B12C`
* Selected Light Square: `#FFE27A`
* Selected Dark Square: `#FFD84D`
* Move Indicator: `rgba(209, 213, 219, 0.78)`

## Benefits

* Better accessibility and usability
* Improved move traceability
* Cleaner and more modern visual appearance
* Better visibility under black pieces

## Screenshots

### Before

<img width="608" height="607" alt="Screenshot 2026-05-17 225300" src="https://github.com/user-attachments/assets/782d82c2-71b7-4039-ba97-5ae372df7216" />


### After

<img width="652" height="642" alt="Screenshot 2026-05-18 195434" src="https://github.com/user-attachments/assets/c1a1371a-de4f-4010-99a6-e9e57ec702c6" />


Fixes #785
