### PR TITLE
Fix OTP resend flow and add resend cooldown timer

### DIFF
--- a/game/templates/game/verify_otp.html
+++ b/game/templates/game/verify_otp.html
@@ -68,9 +68,32 @@
         </form>
         
         <div class="auth-footer">
-            Didn't receive the code? <a href="{% url 'register' %}">Try again</a>
+            Didn't receive the code? 
+            <a href="{% url 'resend_otp' %}" id = "resend-link">Try again</a>
+            <span id="timer"></span>
         </div>
     </div>
+<script>
+    let remainingTime = {{ remaining_time|default:0 }};
+    const resendLink = document.getElementById("resend-link");
+    const timer = document.getElementById("timer");
 
+    function updateTimer() {
+        if (remainingTime > 0) {
+            resendLink.style.pointerEvents = "none";
+            resendLink.style.opacity = "0.5";
+            timer.textContent = ` (${remainingTime}s)`;
+
+            remainingTime--;
+
+            setTimeout(updateTimer, 1000);
+        } else {
+            resendLink.style.pointerEvents = "auto";
+            resendLink.style.opacity = "1";
+            timer.textContent = "";
+        }
+    }
+    updateTimer();
+</script>
 </body>
 </html>

--- a/game/urls.py
+++ b/game/urls.py
@@ -23,6 +23,7 @@ urlpatterns = [
     path('api/check-username/', views.check_username, name='check_username'),
     path('register/', views.register_view, name='register'),
     path('verify-otp/', views.verify_otp, name='verify_otp'),
+    path('resend-otp/', views.resend_otp, name='resend_otp'),
     path('login/', views.login_view, name='login'),
     path('rules/', views.rules, name='rules'),
     path('logout/', views.logout_view, name='logout'),

--- a/game/views.py
+++ b/game/views.py
@@ -624,8 +624,61 @@ def verify_otp(request):
         else:
             messages.error(request, 'Invalid OTP. Please try again.')
 
-    return render(request, 'game/verify_otp.html')
+    remaining_time=0
+    last_otp_time=request.session.get('last_otp_time')
+    if last_otp_time:
+        elapsed = int(time.time() - last_otp_time)
+        remaining_time = max(0, 60 - elapsed)  
+    return render(request, 'game/verify_otp.html', {'remaining_time': remaining_time})
 
+def resend_otp(request):
+    user_id = request.session.get('registration_user_id')
+
+    if not user_id:
+        messages.error(request, 'Session expired. Please register again.')
+        return redirect('register')
+
+    try:
+        user = User.objects.get(id=user_id, is_active=False)
+    except User.DoesNotExist:
+        messages.error(request, 'User not found. Please register again.')
+        return redirect('register')
+    last_otp_time = request.session.get('last_otp_time')
+    if last_otp_time and time.time() - last_otp_time < 60:
+        remaining = int(60 - (time.time() - last_otp_time))
+        messages.error(request, f'Please wait {remaining} seconds before requesting a new OTP.')
+        return redirect('verify_otp')
+
+    otp = str(secrets.randbelow(900000) + 100000)
+
+    otp_hash = hashlib.sha256(
+        f"{otp}:{settings.SECRET_KEY}".encode()
+    ).hexdigest()
+
+    request.session['registration_otp_hash'] = otp_hash
+
+    try:
+        send_mail(
+            'Your Checkora Verification Code',
+            f'Your new OTP is: {otp}',
+            None,
+            [user.email],
+            fail_silently=False,
+        )
+
+        messages.success(
+            request,
+            'A new OTP has been sent to your email.'
+        )
+        request.session['last_otp_time'] = time.time()
+
+    except (SMTPException, BadHeaderError, OSError):
+        messages.error(
+            request,
+            'Failed to resend OTP. Please try again.'
+        )
+
+    return redirect('verify_otp')
 
 def login_view(request):
     if request.user.is_authenticated:

--- a/game/views.py
+++ b/game/views.py
@@ -4,6 +4,7 @@ import json
 import time
 import hashlib
 import secrets
+import secrets as secrets_module
 from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.conf import settings
 from django.http import JsonResponse
@@ -23,6 +24,7 @@ from django.contrib.auth.decorators import login_required
 
 from .engine import ChessGame
 from .models import GameResult
+from game.services import cleanup_stale_games
 
 
 def landing(request):
@@ -624,11 +626,11 @@ def verify_otp(request):
         else:
             messages.error(request, 'Invalid OTP. Please try again.')
 
-    remaining_time=0
-    last_otp_time=request.session.get('last_otp_time')
+    remaining_time = 0
+    last_otp_time = request.session.get('last_otp_time')
     if last_otp_time:
         elapsed = int(time.time() - last_otp_time)
-        remaining_time = max(0, 60 - elapsed)  
+        remaining_time = max(0, 60 - elapsed)
     return render(request, 'game/verify_otp.html', {'remaining_time': remaining_time})
 
 def resend_otp(request):
@@ -746,10 +748,6 @@ def stats_view(request):
         'win_percentage': round(win_percentage, 2),
     })
 
-
-import secrets as secrets_module
-from django.views.decorators.http import require_POST
-from game.services import cleanup_stale_games
 
 @require_POST
 @csrf_exempt


### PR DESCRIPTION
## Description
Improved the OTP verification flow by implementing proper resend OTP functionality and adding a resend cooldown timer.

## Changes Made
- Added dedicated resend OTP endpoint
- Prevented redirect back to registration page
- Implemented OTP resend cooldown logic
- Added 60-second resend timer UI
- Disabled resend link during cooldown
- Improved verification flow user experience

## Features
- Resend OTP without restarting registration
- Prevent OTP spam requests
- Live countdown timer for resend action
- Keeps user on verification page

## Testing
- `python manage.py check` passed
- `python manage.py test` passed
- Selenium/UI tests passed
- Manual OTP resend flow tested locally

## Type of Change
- [x] Bug fix
- [x] Enhancement

Fixes #857