### PR TITLE
Fix: Remove duplicated AI execution call (Performance)

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -340,7 +340,6 @@ def ai_move(request):
     depth = depth_map.get(difficulty, 3)
 
     best = game.get_ai_move(depth=depth)
-    best = game.get_ai_move(depth=depth)
     
     if not best:
         if game.game_status == 'checkmate':


### PR DESCRIPTION
## Description

Brief description of the changes in this PR.
This PR resolves a critical performance degradation in the AI move generation view.
Previously, `ai_move()` was mistakenly executing the expensive C++ Minimax engine twice per turn:
```
    best = game.get_ai_move(depth=depth)
    best = game.get_ai_move(depth=depth) # Duplicated
```
This threw away the first calculation and re-calculated the exact same board, effectively cutting the Checkora engine's speed in half and unnecessarily doubling the CPU load on the server.

**Changes Made**
Removed the duplicated **game.get_ai_move()** call in game/views.py.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #830 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

