### PR TITLE
game: Add dynamic player names, result, and date to PGN export.

### DIFF
--- a/game/engine.py
+++ b/game/engine.py
@@ -22,7 +22,7 @@ import subprocess
 import json
 import sys
 import time
-
+from datetime import date
 
 class ChessGame:
     """Manage a single chess game: state, validation,
@@ -96,10 +96,19 @@ class ChessGame:
         """Flatten the 2-D board into a 64-char string for the C++ engine."""
         return ''.join(c if c else '.' for row in self.board for c in row)
 
-    def generate_pgn(self):
+    def generate_pgn(self, white_name='White', black_name='Black'):
         """Generate a PGN string from move history."""
         if not self.move_history:
             return ""
+        
+        # Compute result based on game status
+        result = '*'
+        if self.game_status == 'checkmate':
+            result = '0-1' if self.current_turn == 'white' else '1-0'
+        elif self.game_status in ('draw', 'stalemate'):
+            result = '1/2-1/2'
+        elif self.game_status == 'resignation':
+            result = '0-1' if self.current_turn == 'black' else '1-0'
 
         pgn_moves = []
         for i in range(0, len(self.move_history), 2):
@@ -110,11 +119,14 @@ class ChessGame:
                 pgn_moves.append(f"{move_number}. {white_move} {black_move}")
             else:
                 pgn_moves.append(f"{move_number}. {white_move}")
+        
+        today = date.today().strftime('%Y.%m.%d')
         headers = [
             '[Event "Checkora Match"]',
-            '[White "White"]',
-            '[Black "Black"]',
-            '[Result "*"]',
+            f'[White "{white_name}"]',
+            f'[Black "{black_name}"]',
+            f'[Date "{today}"]',
+            f'[Result "{result}"]',
         ]
         moves = " ".join(pgn_moves)
         return "\n".join(headers) + "\n\n" + moves

--- a/game/engine.py
+++ b/game/engine.py
@@ -108,7 +108,7 @@ class ChessGame:
         elif self.game_status in ('draw', 'stalemate'):
             result = '1/2-1/2'
         elif self.game_status == 'resignation':
-            result = '0-1' if self.current_turn == 'black' else '1-0'
+            result = '1-0' if self.current_turn == 'black' else '0-1'
 
         pgn_moves = []
         for i in range(0, len(self.move_history), 2):

--- a/game/views.py
+++ b/game/views.py
@@ -92,7 +92,7 @@ def make_move(request):
         'game_status': game_status,
         'draw_reason': game.draw_reason,
         'fen': game.generate_fen_key(),
-        'pgn': game.generate_pgn(),
+        'pgn': game.generate_pgn(request.session.get('white_name', 'White'), request.session.get('black_name', 'Black')),
         'white_name': request.session.get('white_name', 'White'),
         'black_name': request.session.get('black_name', 'Black'),
     })
@@ -185,7 +185,7 @@ def new_game(request):
         'black_name': request.session['black_name'],
         'difficulty': difficulty,
         'fen': game.generate_fen_key(),
-        'pgn': game.generate_pgn(),
+        'pgn': game.generate_pgn(request.session.get('white_name', 'White'), request.session.get('black_name', 'Black')),
         'game_status': game.game_status,
         'draw_reason': game.draw_reason,
     })
@@ -222,7 +222,7 @@ def resume_game(request):
         'game_status': game.game_status,
         'draw_reason': game.draw_reason,
         'fen': game.generate_fen_key(),
-        'pgn': game.generate_pgn(),
+        'pgn': game.generate_pgn(request.session.get('white_name', 'White'), request.session.get('black_name', 'Black')),
         'difficulty': request.session.get('difficulty', 'medium'),
     })
 
@@ -282,7 +282,7 @@ def get_state(request):
         'white_name': request.session.get('white_name', 'White'),
         'black_name': request.session.get('black_name', 'Black'),
         'fen': game.generate_fen_key(),
-        'pgn': game.generate_pgn(),
+        'pgn': game.generate_pgn(request.session.get('white_name', 'White'), request.session.get('black_name', 'Black')),
         'game_status': game.game_status,
         'draw_reason': game.draw_reason,
     })
@@ -396,7 +396,7 @@ def ai_move(request):
         'game_status': game_status,
         'draw_reason': game.draw_reason,
         'fen': game.generate_fen_key(),
-        'pgn': game.generate_pgn(),
+        'pgn': game.generate_pgn(request.session.get('white_name', 'White'), request.session.get('black_name', 'Black')),
         'white_name': request.session.get('white_name', 'White'),
         'black_name': request.session.get('black_name', 'Black'),
     })


### PR DESCRIPTION
## Description

Updated `generate_pgn()` to include actual player names, computed game result, and current date in PGN headers instead of hardcoded placeholders. Previously the PGN always exported `[White "White"]`, `[Black "Black"]`, and `[Result "*"]` regardless of the actual game context.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #871 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

N/A — backend-only change affecting PGN string output.

## Additional Notes

### Changes made:

**`game/engine.py`**
- Added `from datetime import date` import
- Updated `generate_pgn()` to accept `white_name` and `black_name` parameters (defaults to `'White'`/`'Black'` for backward compatibility)
- Added dynamic `[Result]` computation based on `game_status` (checkmate → `1-0`/`0-1`, draw/stalemate → `1/2-1/2`, resignation, active → `*`)
- Added `[Date]` tag using PGN standard format (`YYYY.MM.DD`)

**`game/views.py`**
- Updated all 5 call sites (`make_move`, `new_game`, `resume_game`, `get_state`, `ai_move`) to pass session player names to `generate_pgn()`
