### PR TITLE
Remove unnecessary scrollbar from setup dialog

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -929,8 +929,8 @@ body {
     box-shadow: 0 12px 48px rgba(0, 0, 0, 0.8);
     width: 90%;
     max-width: 480px;
-    max-height: fit-content;
-    overflow-y: visible;
+    max-height: min(90vh, fit-content);
+    overflow-y: auto;
     box-sizing: border-box;  
     position: relative;
 }

--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -929,8 +929,8 @@ body {
     box-shadow: 0 12px 48px rgba(0, 0, 0, 0.8);
     width: 90%;
     max-width: 480px;
-    max-height: calc(100vh - 40px);
-    overflow-y: auto;
+    max-height: fit-content;
+    overflow-y: visible;
     box-sizing: border-box;  
     position: relative;
 }


### PR DESCRIPTION
## Description

This PR removes the unnecessary inner scrollbar appearing inside the game setup dialog when the content already fits within the container.

Previously, the setup modal used forced overflow and height constraints, which caused an unnecessary vertical scrollbar to appear and slightly affected the overall UI polish.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)

## Related Issue

Fixes #866 

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] My changes generate no new warnings

## Screenshots 

### Before
<img width="633" height="892" alt="Screenshot 2026-05-19 233705" src="https://github.com/user-attachments/assets/2d4c63b5-9e5b-47c4-ba98-0c28648ed013" />

### After
<img width="721" height="917" alt="Screenshot 2026-05-20 143459" src="https://github.com/user-attachments/assets/f609c95e-ff8e-481c-a35c-8617b6a5cbfb" />


## Additional Notes

The modal/container sizing was updated to adapt naturally to content height instead of forcing unnecessary scrolling behavior. This improves overall UI cleanliness and provides a more polished user experience.
