### PR TITLE
feat(ux): separate about and features sections on landing page

### DIFF
--- a/game/static/game/css/landing.css
+++ b/game/static/game/css/landing.css
@@ -506,3 +506,69 @@ body {
     }
 }
 
+/* Features Capabilities Section */
+.features-capabilities {
+    padding: 4rem 5%;
+    max-width: 1200px;
+    margin: 0 auto;
+    width: 100%;
+}
+
+.capabilities-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 2rem;
+    justify-content: center;
+}
+
+.capability-card {
+    background-color: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 12px;
+    padding: 2.25rem 2rem;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    text-align: left;
+    transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+    cursor: default;
+}
+
+.capability-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
+    border-color: rgba(240, 192, 64, 0.35);
+}
+
+.capability-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 1.5rem;
+    padding: 0.75rem;
+    background: rgba(240, 192, 64, 0.05);
+    border-radius: 10px;
+    border: 1px solid rgba(240, 192, 64, 0.1);
+    transition: background-color 0.3s ease, border-color 0.3s ease;
+}
+
+.capability-card:hover .capability-icon {
+    background-color: rgba(240, 192, 64, 0.1);
+    border-color: rgba(240, 192, 64, 0.3);
+}
+
+.capability-title {
+    font-size: 1.2rem;
+    font-weight: 600;
+    color: var(--text-title);
+    margin-bottom: 0.75rem;
+    letter-spacing: 0.5px;
+}
+
+.capability-desc {
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    line-height: 1.6;
+}
+
+

--- a/game/templates/game/landing.html
+++ b/game/templates/game/landing.html
@@ -123,7 +123,7 @@
       </p>
       <div class="hero-actions">
         <a href="{% url 'index' %}" class="btn-primary">Start Game</a>
-        <a href="#about" class="btn-secondary">Learn More</a>
+        <a href="#features" class="btn-secondary">Learn More</a>
       </div>
     </main>
 
@@ -144,7 +144,7 @@
     </div>
 </section>
 
-    <section id="features" class="features">
+    <section id="about-architecture" class="features">
       <h2 class="section-title">Why Checkora</h2>
       <div class="feature-cards">
         <div class="card">
@@ -231,6 +231,103 @@
                 — connected via bindings or subprocess calls.
               </p>
             </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="features" class="features-capabilities">
+      <div class="section-container">
+        <h2 class="section-title">Platform Capabilities</h2>
+        <div class="capabilities-grid">
+          <div class="capability-card">
+            <div class="capability-icon">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M12 2a3 3 0 0 0-3 3c0 .8.3 1.5.8 2H8a3 3 0 0 0-3 3v2h14v-2a3 3 0 0 0-3-3h-1.2c.5-.5.8-1.2.8-2a3 3 0 0 0-3-3z"/>
+                <path d="M19 21H5a1 1 0 0 1-1-1v-2c0-1.7 1.3-3 3-3h10c1.7 0 3 1.3 3 3v2a1 1 0 0 1-1 1z"/>
+                <line x1="6" y1="18" x2="18" y2="18"/>
+              </svg>
+            </div>
+            <h3 class="capability-title">AI Opponent</h3>
+            <p class="capability-desc">Challenge an advanced AI opponent utilizing minimax search with alpha-beta pruning optimization.</p>
+          </div>
+
+          <div class="capability-card">
+            <div class="capability-icon">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
+              </svg>
+            </div>
+            <h3 class="capability-title">Hybrid Engine</h3>
+            <p class="capability-desc">Orchestrates high-performance C++ minimax calculations with a reliable Python fallback system.</p>
+          </div>
+
+          <div class="capability-card">
+            <div class="capability-icon">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="9"/>
+                <polyline points="12 5 12 12 16 14"/>
+                <line x1="12" y1="1" x2="12" y2="3"/>
+              </svg>
+            </div>
+            <h3 class="capability-title">Game Timer</h3>
+            <p class="capability-desc">Configure Bullet, Blitz, or Rapid game timers featuring pause, resume, and real-time synchronization.</p>
+          </div>
+
+          <div class="capability-card">
+            <div class="capability-icon">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <line x1="18" y1="20" x2="18" y2="10"/>
+                <line x1="12" y1="20" x2="12" y2="4"/>
+                <line x1="6" y1="20" x2="6" y2="14"/>
+              </svg>
+            </div>
+            <h3 class="capability-title">Live Material Score</h3>
+            <p class="capability-desc">Monitor point differentials and tracked captured pieces dynamically in a side score panel.</p>
+          </div>
+
+          <div class="capability-card">
+            <div class="capability-icon">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
+                <circle cx="9" cy="7" r="4"/>
+                <path d="M23 21v-2a4 4 0 0 0-3-3.87"/>
+                <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
+              </svg>
+            </div>
+            <h3 class="capability-title">PvP & PvE Modes</h3>
+            <p class="capability-desc">Compete locally against friends in Pass & Play mode, or test your skills against the engine.</p>
+          </div>
+
+          <div class="capability-card">
+            <div class="capability-icon">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+                <polyline points="9 11 11 13 15 9"/>
+              </svg>
+            </div>
+            <h3 class="capability-title">Full Move Validation</h3>
+            <p class="capability-desc">Rigorous real-time move validation covering castling, en passant, and pawn promotions.</p>
+          </div>
+
+          <div class="capability-card">
+            <div class="capability-icon">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="3"/>
+                <circle cx="19" cy="5" r="3"/>
+                <circle cx="5" cy="5" r="3"/>
+                <circle cx="19" cy="19" r="3"/>
+                <circle cx="5" cy="19" r="3"/>
+                <line x1="8.5" y1="5" x2="15.5" y2="5"/>
+                <line x1="8.5" y1="19" x2="15.5" y2="19"/>
+                <line x1="5" y1="8" x2="5" y2="16"/>
+                <line x1="19" y1="8" x2="19" y2="16"/>
+                <line x1="7.1" y1="7.1" x2="16.9" y2="16.9"/>
+                <line x1="7.1" y1="16.9" x2="16.9" y2="7.1"/>
+              </svg>
+            </div>
+            <h3 class="capability-title">REST API Architecture</h3>
+            <p class="capability-desc">Decoupled REST API endpoints manage clean session routing, move calculations, and game statuses.</p>
           </div>
         </div>
       </div>

--- a/game/templates/game/landing.html
+++ b/game/templates/game/landing.html
@@ -242,7 +242,7 @@
         <div class="capabilities-grid">
           <div class="capability-card">
             <div class="capability-icon">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <svg aria-hidden="true" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M12 2a3 3 0 0 0-3 3c0 .8.3 1.5.8 2H8a3 3 0 0 0-3 3v2h14v-2a3 3 0 0 0-3-3h-1.2c.5-.5.8-1.2.8-2a3 3 0 0 0-3-3z"/>
                 <path d="M19 21H5a1 1 0 0 1-1-1v-2c0-1.7 1.3-3 3-3h10c1.7 0 3 1.3 3 3v2a1 1 0 0 1-1 1z"/>
                 <line x1="6" y1="18" x2="18" y2="18"/>
@@ -254,7 +254,7 @@
 
           <div class="capability-card">
             <div class="capability-icon">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <svg aria-hidden="true" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
               </svg>
             </div>
@@ -264,7 +264,7 @@
 
           <div class="capability-card">
             <div class="capability-icon">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <svg aria-hidden="true" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <circle cx="12" cy="12" r="9"/>
                 <polyline points="12 5 12 12 16 14"/>
                 <line x1="12" y1="1" x2="12" y2="3"/>
@@ -276,7 +276,7 @@
 
           <div class="capability-card">
             <div class="capability-icon">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <svg aria-hidden="true" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <line x1="18" y1="20" x2="18" y2="10"/>
                 <line x1="12" y1="20" x2="12" y2="4"/>
                 <line x1="6" y1="20" x2="6" y2="14"/>
@@ -288,7 +288,7 @@
 
           <div class="capability-card">
             <div class="capability-icon">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <svg aria-hidden="true" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
                 <circle cx="9" cy="7" r="4"/>
                 <path d="M23 21v-2a4 4 0 0 0-3-3.87"/>
@@ -301,7 +301,7 @@
 
           <div class="capability-card">
             <div class="capability-icon">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <svg aria-hidden="true" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
                 <polyline points="9 11 11 13 15 9"/>
               </svg>
@@ -312,7 +312,7 @@
 
           <div class="capability-card">
             <div class="capability-icon">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <svg aria-hidden="true" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <circle cx="12" cy="12" r="3"/>
                 <circle cx="19" cy="5" r="3"/>
                 <circle cx="5" cy="5" r="3"/>


### PR DESCRIPTION
## 🎯 Purpose & Context
Currently, clicking both **About** and **Features** in the landing page navigation bar scrolls the user to the exact same section. This creates navigation confusion for first-time visitors who expect these items to lead to different content (About explaining the platform goals/architecture, and Features highlighting concrete application capabilities).

This PR addresses this UX issue by clearly separating platform description from platform capabilities:
1. Renaming the existing technical overview section to group it under **About**.
2. Creating a dedicated, interactive **Features** capability section.
3. Updating the navigation links and Hero CTA to point to the new section.

---

## 🛠 Proposed Changes

### Frontend Template

#### [landing.html](file:///c:/Users/Yash%20Tripathi/Desktop/New%20folder%20(3)/Checkora/game/templates/game/landing.html)
- Renamed the existing section `<section id="features" class="features">` (Why Checkora / architecture layout) to `<section id="about-architecture" class="features">`. This places the technical design under the **About** landing area.
- Added a new `<section id="features" class="features-capabilities">` containing 7 responsive cards for core capabilities:
  - ♟ **AI Opponent** (Minimax with Alpha-Beta Pruning)
  - ⚡ **Hybrid Engine** (C++ + Python fallback)
  - ⏱ **Game Timer** (Bullet/Blitz/Rapid with pause support)
  - 📊 **Live Material Score Panel**
  - 👥 **PvP & PvE Modes** (Pass & Play + Engine Challenge)
  - ✅ **Full Move Validation** (Castling, promotions, etc.)
  - 🌐 **REST API Architecture**
- Updated the Hero section's **Learn More** button from `href="#about"` to `href="#features"` to align better with a capabilities-driven CTA.

### Styling System

#### [landing.css](file:///c:/Users/Yash%20Tripathi/Desktop/New%20folder%20(3)/Checkora/game/static/game/css/landing.css)
- Added styles for the `.features-capabilities` section.
- Implemented `.capabilities-grid` using CSS Grid with auto-fitting responsive columns (`repeat(auto-fit, minmax(280px, 1fr))`) to handle automatic wrapping across desktop, tablet, and mobile screens.
- Styled `.capability-card` to match the platform's dark/gold aesthetic with smooth hover effects:
  - Slight translate-up animation (`translateY(-5px)`).
  - Transitioning gold border outline (`rgba(240, 192, 64, 0.35)`).
  - Low-opacity gold icon background glow that brightens on hover.

---

## 🧪 Verification & Testing

### Automated Test Suite
All 98 Django and Selenium integration tests were run and passed successfully:
```bash
$env:PYTHONIOENCODING="utf-8"
python manage.py test game
```
**Output:**
```text
Ran 98 tests in 29.046s
OK
```

### Manual Verification Steps
1. Navigate to `http://127.0.0.1:8000/`.
2. Click the **About** navbar item: Page smoothly scrolls to the *About Checkora* overview.
3. Click the **Features** navbar item: Page smoothly scrolls past the About overview to the new *Platform Capabilities* grid.
4. Click the **Learn More** hero CTA: Page smoothly scrolls to *Platform Capabilities*.
5. Resize viewport: Verification shows columns adaptively stack from 3-wide (desktop) to 2-wide (tablet) and 1-wide (mobile).
