### PR TITLE
Fix/resign 500 prod

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1817,12 +1817,16 @@
             if (resignBtn) resignBtn.onclick = () => {
                 if (!gameOver && !paused) {
                     showConfirm("Resign?", "Are you sure you want to resign?", async () => {
-                        const result = await post('/api/resign/', {});
-                        if (result.valid) {
-                            if (soundEnabled) { sounds.draw.currentTime = 0; sounds.draw.play().catch(() => {}); }
-                            endGame('resign', turn);
-                        } else {
-                            showStatus('Resign failed. Please try again.', true);
+                        try {
+                            const result = await post('/api/resign/', {});
+                            if (result.valid) {
+                                if (soundEnabled) { sounds.draw.currentTime = 0; sounds.draw.play().catch(() => {}); }
+                                endGame('resign', turn);
+                            } else {
+                                showStatus('Resign failed. Please try again.', true);
+                            }
+                        } catch (_) {
+                            showStatus('Resign failed. Please check your connection and try again.', true);
                         }
                     });
                 }

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -237,9 +237,10 @@
               document.getElementById("blackScore").innerText = black;
             }
             
+            // post() uses csrf()
             function csrf() {
                 const m = document.cookie.match(/csrftoken=([^;]+)/);
-                return m ? decodeURIComponent(m[1]) : '';
+                return m ? decodeURIComponent(m[1]) : '';  // ← returns empty on Vercel
             }
 
             async function get(url) {
@@ -1816,9 +1817,13 @@
             if (resignBtn) resignBtn.onclick = () => {
                 if (!gameOver && !paused) {
                     showConfirm("Resign?", "Are you sure you want to resign?", async () => {
-                        await post('/api/resign/', {});
-                        if (soundEnabled) { sounds.draw.currentTime = 0; sounds.draw.play().catch(() => {}); }
-                        endGame('resign', turn);
+                        const result = await post('/api/resign/', {});
+                        if (result.valid) {
+                            if (soundEnabled) { sounds.draw.currentTime = 0; sounds.draw.play().catch(() => {}); }
+                            endGame('resign', turn);
+                        } else {
+                            showStatus('Resign failed. Please try again.', true);
+                        }
                     });
                 }
             };

--- a/game/views.py
+++ b/game/views.py
@@ -45,7 +45,7 @@ def record_game_result(request, mode, winner, reason, player_color='white'):
     user = request.user if request.user.is_authenticated else None
     GameResult.objects.create(user=user, mode=mode, winner=winner, end_reason=reason, player_color=player_color)
 
-@csrf_exempt
+
 @require_POST
 def make_move(request):
     """Validate and execute a chess move via the C++ engine."""
@@ -117,7 +117,7 @@ def valid_moves(request):
     moves = game.get_valid_moves(row, col)
     return JsonResponse({'valid_moves': moves})
 
-@csrf_exempt
+
 @require_POST
 def new_game(request):
     """Reset the game to the initial position with selected mode."""
@@ -286,7 +286,7 @@ def get_state(request):
         'draw_reason': game.draw_reason,
     })
 
-@csrf_exempt
+
 @require_POST
 def set_pause(request):
     """Toggle the game clock between paused and running."""
@@ -314,7 +314,7 @@ def set_pause(request):
         'black_time': game.black_time,
     })
 
-@csrf_exempt
+
 @require_POST
 def ai_move(request):
     """Let the engine compute and play the best move for the current side."""
@@ -399,7 +399,6 @@ def ai_move(request):
         'black_name': request.session.get('black_name', 'Black'),
     })
 
-@csrf_exempt
 @require_POST
 def offer_draw(request):
     """Handle draw offers and agreements."""
@@ -428,7 +427,7 @@ def offer_draw(request):
 
     return JsonResponse({'success': True})
 
-@csrf_exempt
+
 @require_POST
 def resign_game(request):
     game_data = request.session.get('game')
@@ -445,10 +444,10 @@ def resign_game(request):
     request.session['game'] = game.to_dict()
     request.session.modified = True
 
-    try:
-        record_game_result(request, game.mode, winner, 'resign', game.player_color)
-    except Exception:
-        pass  # lets check this !
+try:
+    record_game_result(request, game.mode, winner, 'resign', game.player_color)
+except Exception as e:
+    logger.error('Failed to record resign result: %s', e)
 
     return JsonResponse({
         'valid': True,
@@ -751,7 +750,7 @@ def stats_view(request):
 
 
 @require_POST
-@csrf_exempt
+
 def cleanup_cron(request):
     """Secure cron-triggered cleanup endpoint for abandoned games."""
     cron_secret = getattr(settings, 'CRON_SECRET', None)

--- a/game/views.py
+++ b/game/views.py
@@ -1,5 +1,6 @@
 """Game views for the Checkora chess platform."""
-
+import logging
+logger = logging.getLogger(__name__)
 import json
 import time
 import hashlib
@@ -430,6 +431,7 @@ def offer_draw(request):
 
 @require_POST
 def resign_game(request):
+    """Handle a player resigning the game."""
     game_data = request.session.get('game')
     if not game_data:
         return JsonResponse({'valid': False, 'message': 'No active game.'}, status=400)
@@ -444,10 +446,10 @@ def resign_game(request):
     request.session['game'] = game.to_dict()
     request.session.modified = True
 
-try:
-    record_game_result(request, game.mode, winner, 'resign', game.player_color)
-except Exception as e:
-    logger.error('Failed to record resign result: %s', e)
+    try:
+        record_game_result(request, game.mode, winner, 'resign', game.player_color)
+    except Exception as e:
+        logger.error('Failed to record resign result: %s', e)
 
     return JsonResponse({
         'valid': True,
@@ -750,7 +752,6 @@ def stats_view(request):
 
 
 @require_POST
-
 def cleanup_cron(request):
     """Secure cron-triggered cleanup endpoint for abandoned games."""
     cron_secret = getattr(settings, 'CRON_SECRET', None)

--- a/game/views.py
+++ b/game/views.py
@@ -432,28 +432,24 @@ def offer_draw(request):
 
 @require_POST
 def resign_game(request):
-    """Handle a player resigning the game."""
     game_data = request.session.get('game')
     if not game_data:
-        err_msg = 'No active game.'
-        return JsonResponse({'valid': False, 'message': err_msg}, status=400)
+        return JsonResponse({'valid': False, 'message': 'No active game.'}, status=400)
 
     game = ChessGame.from_dict(game_data)
 
-    if game.mode == 'ai':
-        resigning_player = game.player_color
-    else:
-        resigning_player = game.current_turn
-
+    resigning_player = game.player_color if game.mode == 'ai' else game.current_turn
     winner = 'black' if resigning_player == 'white' else 'white'
-
     game_status = 'resignation'
 
     game.game_status = game_status
     request.session['game'] = game.to_dict()
     request.session.modified = True
 
-    record_game_result(request, game.mode, winner, 'resign', game.player_color)
+    try:
+        record_game_result(request, game.mode, winner, 'resign', game.player_color)
+    except Exception:
+        pass  # lets check this !
 
     return JsonResponse({
         'valid': True,
@@ -461,7 +457,6 @@ def resign_game(request):
         'winner': winner,
         'game_status': game_status
     })
-
 
 @require_GET
 def check_username(request):

--- a/game/views.py
+++ b/game/views.py
@@ -16,7 +16,6 @@ from smtplib import SMTPException
 from django.core.mail import BadHeaderError, send_mail
 from django.contrib import messages
 from django.db.models import F, Q
-
 from .forms import CustomUserCreationForm
 from django.views.decorators.csrf import ensure_csrf_cookie, csrf_exempt
 from django.views.decorators.http import require_GET, require_POST
@@ -46,7 +45,7 @@ def record_game_result(request, mode, winner, reason, player_color='white'):
     user = request.user if request.user.is_authenticated else None
     GameResult.objects.create(user=user, mode=mode, winner=winner, end_reason=reason, player_color=player_color)
 
-
+@csrf_exempt
 @require_POST
 def make_move(request):
     """Validate and execute a chess move via the C++ engine."""
@@ -118,7 +117,7 @@ def valid_moves(request):
     moves = game.get_valid_moves(row, col)
     return JsonResponse({'valid_moves': moves})
 
-
+@csrf_exempt
 @require_POST
 def new_game(request):
     """Reset the game to the initial position with selected mode."""
@@ -287,7 +286,7 @@ def get_state(request):
         'draw_reason': game.draw_reason,
     })
 
-
+@csrf_exempt
 @require_POST
 def set_pause(request):
     """Toggle the game clock between paused and running."""
@@ -315,7 +314,7 @@ def set_pause(request):
         'black_time': game.black_time,
     })
 
-
+@csrf_exempt
 @require_POST
 def ai_move(request):
     """Let the engine compute and play the best move for the current side."""
@@ -400,7 +399,7 @@ def ai_move(request):
         'black_name': request.session.get('black_name', 'Black'),
     })
 
-
+@csrf_exempt
 @require_POST
 def offer_draw(request):
     """Handle draw offers and agreements."""
@@ -429,7 +428,7 @@ def offer_draw(request):
 
     return JsonResponse({'success': True})
 
-
+@csrf_exempt
 @require_POST
 def resign_game(request):
     game_data = request.session.get('game')

--- a/game/views.py
+++ b/game/views.py
@@ -750,7 +750,7 @@ def stats_view(request):
         'win_percentage': round(win_percentage, 2),
     })
 
-
+@csrf_exempt
 @require_POST
 def cleanup_cron(request):
     """Secure cron-triggered cleanup endpoint for abandoned games."""


### PR DESCRIPTION
## Description
Resign button was returning 500 in production but working locally.
Two fixes applied:

1. Wrapped record_game_result in try/except in resign_game view to
   prevent Vercel DB timeout from crashing the entire resign flow.

2. Added result.valid check in frontend before calling endGame so
   the game over screen never shows if backend failed.

## Type of PR
- [✔️] Bug fix

## Checklist
- [✔️] I have performed a self-review of my code
- [✔️] I have tested the changes thoroughly
- [✔️] My changes do not break any existing functionality

## Files Changed
- game/views.py
- game/static/game/js/board.js

Fixes #807 