### PR TITLE
feat: auto-swap player colors when starting new game from post-game s…

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -455,10 +455,10 @@
             }
 
             function updatePlayerNames(data) {
-                let wName = data.white_name || 'White';
-                let bName = data.black_name || 'Black';
                 currentWhiteName = data.white_name || currentWhiteName || 'White';
                 currentBlackName = data.black_name || currentBlackName || 'Black';
+                let wName = currentWhiteName;
+                let bName = currentBlackName;
                 
                 if (gameMode === 'ai'){
                     const diffLabel = (currentDifficulty || 'medium').toUpperCase();

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -35,6 +35,8 @@
 
             let gameMode = 'pvp';
             let currentDifficulty = 'medium';
+            let currentWhiteName = 'White';
+            let currentBlackName = 'Black';
             // Updates UI to highlight selected game mode button
             function updateModeButtonsUI(mode) {
                 const pvpBtn = document.getElementById("newPvPBtn");
@@ -455,6 +457,8 @@
             function updatePlayerNames(data) {
                 let wName = data.white_name || 'White';
                 let bName = data.black_name || 'Black';
+                currentWhiteName = data.white_name || 'White';
+                currentBlackName = data.black_name || 'Black';
                 
                 if (gameMode === 'ai'){
                     const diffLabel = (currentDifficulty || 'medium').toUpperCase();
@@ -1437,7 +1441,7 @@
                 );
             }
 
-            async function startNewGame(mode, pColor = 'white', difficulty = 'medium', fen = null, timeLimitMins = null) {
+            async function startNewGame(mode, pColor = 'white', difficulty = 'medium', fen = null, timeLimitMins = null, overrideNames = null) {
                 // Reset AI request sequence and thinking state on new game
                 aiRequestSeq = 0;
                 aiThinking = false;
@@ -1460,8 +1464,12 @@
                     confettiContainer.remove();
                 }
 
-                const wName = (document.getElementById('whiteNameInput')?.value || 'White').trim().slice(0, 17);
-                const bName = (document.getElementById('blackNameInput')?.value || 'Black').trim().slice(0, 17);
+                const wName = overrideNames
+                    ? overrideNames.white
+                    : (document.getElementById('whiteNameInput')?.value || 'White').trim().slice(0, 17);
+                const bName = overrideNames
+                    ? overrideNames.black
+                    : (document.getElementById('blackNameInput')?.value || 'Black').trim().slice(0, 17);
                 const defaultTimeLimitMins = parseInt(document.getElementById('timeLimitInput')?.value || 10, 10);
                 const timeLimit = (timeLimitMins !== null ? timeLimitMins : defaultTimeLimitMins) * 60;
 
@@ -1852,17 +1860,18 @@
                 const timeLimitMins = parseInt(document.getElementById('goTimerSelect').value, 10);
                 gameOverOverlay.classList.remove('active');
                 gameOverOverlay.classList.remove('game-over-celebration');
-                
-                // Add this: Clear confetti container
+
                 const confettiContainer = gameOverOverlay.querySelector('.confetti-container');
                 if (confettiContainer) {
                     confettiContainer.remove();
                 }
-                
+
+                const swappedColor = playerColor === 'white' ? 'black' : 'white';
                 if (mode === 'ai') {
                     showSideSelectionModal(side => startNewGame(mode, side, diff, null, timeLimitMins));
                 } else {
-                    startNewGame(mode, 'white', diff, null, timeLimitMins);
+                    startNewGame(mode, swappedColor, diff, null, timeLimitMins,
+                        { white: currentBlackName, black: currentWhiteName });
                 }
             };
 

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -457,8 +457,8 @@
             function updatePlayerNames(data) {
                 let wName = data.white_name || 'White';
                 let bName = data.black_name || 'Black';
-                currentWhiteName = data.white_name || 'White';
-                currentBlackName = data.black_name || 'Black';
+                currentWhiteName = data.white_name || currentWhiteName || 'White';
+                currentBlackName = data.black_name || currentBlackName || 'Black';
                 
                 if (gameMode === 'ai'){
                     const diffLabel = (currentDifficulty || 'medium').toUpperCase();
@@ -1464,12 +1464,15 @@
                     confettiContainer.remove();
                 }
 
-                const wName = overrideNames
-                    ? overrideNames.white
-                    : (document.getElementById('whiteNameInput')?.value || 'White').trim().slice(0, 17);
-                const bName = overrideNames
-                    ? overrideNames.black
-                    : (document.getElementById('blackNameInput')?.value || 'Black').trim().slice(0, 17);
+                const normalizeName = (name, fallback) => (name || fallback).trim().slice(0, 17);
+                const wName = normalizeName(
+                    overrideNames ? overrideNames.white : document.getElementById('whiteNameInput')?.value,
+                    'White'
+                );
+                const bName = normalizeName(
+                    overrideNames ? overrideNames.black : document.getElementById('blackNameInput')?.value,
+                    'Black'
+                );
                 const defaultTimeLimitMins = parseInt(document.getElementById('timeLimitInput')?.value || 10, 10);
                 const timeLimit = (timeLimitMins !== null ? timeLimitMins : defaultTimeLimitMins) * 60;
 


### PR DESCRIPTION
## Description

When a game ends, clicking "Start New Game" now automatically swaps player colors — White becomes Black and vice versa. Same mode, timer, and player names are preserved.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #894

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)
During Match:  
<img width="945" height="639" alt="Screenshot 2026-05-20 at 6 56 38 PM" src="https://github.com/user-attachments/assets/53412ae9-d6ce-46fd-a3eb-bd2fc8f28561" />

After Match finished and Starting new game Players changed White and Black :

<img width="1026" height="644" alt="Screenshot 2026-05-20 at 6 58 02 PM" src="https://github.com/user-attachments/assets/09ef0c3b-4f73-4c4f-889f-3b7b9b50890e" />


## Additional Notes

Change is limited to `board.js` — no backend or template changes required.