### PR TITLE
Fix OTP email delivery configuration

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -144,7 +144,11 @@ SECURE_SSL_REDIRECT = not DEBUG
 
 
 # Email Configuration for OTP
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_BACKEND = (
+    'django.core.mail.backends.smtp.EmailBackend'
+    if not DEBUG
+    else 'django.core.mail.backends.console.EmailBackend'
+)
 EMAIL_HOST = 'smtp.gmail.com'
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True

--- a/core/settings.py
+++ b/core/settings.py
@@ -144,7 +144,7 @@ SECURE_SSL_REDIRECT = not DEBUG
 
 
 # Email Configuration for OTP
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = 'smtp.gmail.com'
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True


### PR DESCRIPTION
## Description

This PR fixes the OTP/verification email delivery issue by updating the Django email backend configuration from the console backend to the SMTP backend..

---

### Changes Made
- Updated the email backend configuration in `core/settings.py`
- Replaced the console email backend with SMTP backend for actual email delivery

---

### Files Changed
- `core/settings.py`

---

### What This PR Does

Previously, verification and OTP emails were not being delivered because the project was using:

```python
EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
```

This backend only prints emails to the console and is intended mainly for development/testing purposes.

This PR updates it to:

```python
EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
```

which enables real email delivery using SMTP configuration and environment variables.

---

### Result
- OTP/verification emails are now delivered correctly

---

## Type of Change

- [✔] Bug fix (non-breaking change that fixes an issue)
- [  ] New feature (non-breaking change that adds functionality)
- [  ] Breaking change (fix or feature that would cause existing functionality to change)
- [  ] Documentation update

## Related Issue

Fixes #909 

## Checklist

- [✔] My code follows the project's style guidelines
- [✔] I have performed a self-review of my code
- [✔] I have commented my code where necessary
- [✔] I have updated the documentation if needed
- [✔] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
