### PR TITLE
Fix infinite AI reconnect loop during checkmate situations

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -904,6 +904,11 @@
                     }
 
                         if (data.valid) {
+                            if (!data.ai_move) {
+                                gameOver = true;
+                                handleGameStatus(data.game_status, data.draw_reason);
+                                return;
+                            }
                             playSound(data);
                             const mv = data.ai_move;
                             await animateMove(mv.from_row, mv.from_col, mv.to_row, mv.to_col);
@@ -945,7 +950,7 @@
                         // 503 from backend — engine is down, stop retrying completely
                         showStatus('AI unavailable. Please start a new game.', true);
                         gameOver = true;
-                        
+
                     } else {
                         showStatus(data.message, true);
                     }

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -250,14 +250,17 @@
             }
 
             async function post(url, body) {
-                return (await fetch(url, {
+                const res = await fetch(url, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
                         'X-CSRFToken': csrf()
                     },
                     body: JSON.stringify(body)
-                })).json();
+                });
+                const data = await res.json();
+                data._status = res.status;
+                return data;
             }
 
             function isAITurn() {
@@ -946,7 +949,7 @@
                             }
                             if (a11yMsg) announceMove(a11yMsg);
                         }
-                    } else if (data.message === 'AI engine unavailable.') {
+                    } else if (data._status === 503 || data.message === 'AI engine unavailable.') {
                         // 503 from backend — engine is down, stop retrying completely
                         showStatus('AI unavailable. Please start a new game.', true);
                         gameOver = true;

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -941,12 +941,22 @@
                             }
                             if (a11yMsg) announceMove(a11yMsg);
                         }
+                    } else if (data.message === 'AI engine unavailable.') {
+                        // 503 from backend — engine is down, stop retrying completely
+                        showStatus('AI unavailable. Please start a new game.', true);
+                        gameOver = true;
+                        
                     } else {
                         showStatus(data.message, true);
                     }
                 } catch (e) {
                     clearInterval(thinkingInterval);
-                    await handleReconnect();
+                    // Only reconnect for real network errors, not engine failures
+                    if (e instanceof TypeError || e instanceof SyntaxError) {
+                        await handleReconnect();
+                    } else {
+                        showStatus('AI error. Please start a new game.', true);
+                    }
                 } finally {
                     if (seq === aiRequestSeq) {
                         aiThinking = false;

--- a/game/views.py
+++ b/game/views.py
@@ -339,16 +339,37 @@ def ai_move(request):
     depth_map = {'easy': 1, 'medium': 2, 'hard': 3}
     depth = depth_map.get(difficulty, 2)
 
-    best = game.get_ai_move(depth=depth)  # called once only
-    
+
+    # Prevent unhandled AI engine exceptions from crashing the endpoint with a 500 error
+    try:
+        best = game.get_ai_move(depth=depth)
+    except Exception as exc:
+        logger.error("get_ai_move raised unexpectedly: %s", exc)
+        best = None
+
     if not best:
-        if game.game_status == 'checkmate':
+        # Re-check actual board state instead of relying on stale cached game_status
+        game_status = game.check_game_status()
+
+        if game_status == 'ok':
+            game_status = game.game_status
+
+        if game_status == 'checkmate':
             winner = 'black' if game.current_turn == 'white' else 'white'
             record_game_result(request, game.mode, winner, 'checkmate', game.player_color)
-            game_status = 'checkmate'
+        elif game_status in ('stalemate', 'draw'):
+            record_game_result(
+                request, game.mode, 'draw',
+                game.draw_reason or 'stalemate', game.player_color
+            )
         else:
-            record_game_result(request, game.mode, 'draw', 'stalemate', game.player_color)
-            game_status = 'stalemate'
+            logger.error("ai_move: engine unavailable, game_status=%s", game_status)
+
+            # Prevent frontend reconnect/retry loop when AI engine fails unexpectedly
+            return JsonResponse(
+                {'valid': False, 'message': 'AI engine unavailable.'},
+                status=503
+            )
 
         game.game_status = game_status
         request.session['game'] = game.to_dict()
@@ -365,7 +386,7 @@ def ai_move(request):
             'captured_pieces': game.captured,
             'message': '',
         })
-
+    
     success, message, captured, game_status = game.make_move(
         best['from_row'], best['from_col'],
         best['to_row'],   best['to_col'],

--- a/game/views.py
+++ b/game/views.py
@@ -343,8 +343,11 @@ def ai_move(request):
     # Prevent unhandled AI engine exceptions from crashing the endpoint with a 500 error
     try:
         best = game.get_ai_move(depth=depth)
+    except ValueError as exc:
+        logger.exception("get_ai_move returned malformed output")
+        best = None
     except Exception as exc:
-        logger.error("get_ai_move raised unexpectedly: %s", exc)
+        logger.exception("get_ai_move raised unexpectedly")
         best = None
 
     if not best:
@@ -363,7 +366,7 @@ def ai_move(request):
                 game.draw_reason or 'stalemate', game.player_color
             )
         else:
-            logger.error("ai_move: engine unavailable, game_status=%s", game_status)
+            logger.exception("ai_move: engine unavailable, game_status=%s", game_status)
 
             # Prevent frontend reconnect/retry loop when AI engine fails unexpectedly
             return JsonResponse(

--- a/game/views.py
+++ b/game/views.py
@@ -366,7 +366,7 @@ def ai_move(request):
                 game.draw_reason or 'stalemate', game.player_color
             )
         else:
-            logger.exception("ai_move: engine unavailable, game_status=%s", game_status)
+            logger.error("ai_move: engine unavailable, game_status=%s", game_status)
 
             # Prevent frontend reconnect/retry loop when AI engine fails unexpectedly
             return JsonResponse(


### PR DESCRIPTION
## Description

This PR fixes an issue where the AI game could enter an infinite "AI is thinking..." and reconnect loop during checkmate or repeated check situations.
The issue was caused by improper handling of failed AI move generation and stale game status checks in the backend. The frontend was also retrying reconnects for backend engine failures, which created an infinite retry loop.


## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issue

Fixes #900 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally

## Screenshots 

### Issue on deployed/live server

The deployed version previously entered an infinite AI reconnect/thinking loop during checkmate situations and produced backend API errors.

<img width="1867" height="941" alt="Screenshot 2026-05-21 005345" src="https://github.com/user-attachments/assets/ed74e9c2-9b6f-4528-9872-f67779665120" />

### Local testing after fix

After applying the changes locally, the AI successfully completed checkmate scenarios without entering the reconnect loop.

<img width="1500" height="917" alt="Screenshot 2026-05-21 005648" src="https://github.com/user-attachments/assets/d428037a-822e-41f6-8a88-4d52fa588c8e" />

## Additional Notes

### Backend (`views.py`)

- Added exception handling around `get_ai_move()`
- Re-checked actual board state using `check_game_status()`
- Added proper `503` response handling for AI engine failures
- Prevented incorrect stale state handling during checkmate/stalemate situations

### Frontend (`board.js`)

- Prevented infinite reconnect retries for backend engine failures
- Added handling for `"AI engine unavailable."`
- Stopped repeated AI retry loops by setting `gameOver = true`

### Testing

Tested locally with:

- White and Black sides
- Easy, Medium, and Hard AI modes
- Checkmate scenarios
- Repeated check situations
- Resign scenarios

The infinite reconnect/thinking loop could no longer be reproduced locally after these changes.