### PR TITLE
fix: FEN Enter key now starts game & remove duplicate board.js script

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1485,7 +1485,7 @@
                     time_limit: timeLimit
                 };
 
-                const fenValue = fen ? fen.trim() : null;
+                const fenValue = (fen && fen.trim()) ? fen.trim() : null;
                 if (fenValue) payload.fen = fenValue;
 
                 if (fenError) fenError.textContent = '';
@@ -1574,9 +1574,29 @@
                 if (errorDiv) errorDiv.style.display = 'none';
             }
 
-            if (welcomePvPBtn) welcomePvPBtn.onclick = async () => {
+            if (welcomeFenInput) {
+                welcomeFenInput.addEventListener('keydown', async (e) => {
+                    if (e.key !== 'Enter') return;
+                    e.preventDefault();
+                    const fenValue = welcomeFenInput.value?.trim();
+                    if (!fenValue) return;
+                    const isAIMode = pveOptions.style.display !== 'none';
+                    const mode = isAIMode ? 'ai' : 'pvp';
+                    const pColor = isAIMode ? selectedPveColor : 'white';
+                    const diff = isAIMode
+                        ? (document.getElementById('welcomeDifficultySelect')?.value || 'medium')
+                        : 'medium';
+                    if (welcomeFenError) welcomeFenError.textContent = '';
+                    const started = await startNewGame(mode, pColor, diff, fenValue);
+                    if (!started) return;
+                    welcomeOverlay.classList.remove('active');
+                    gameLayout.style.visibility = 'visible';
+                });
+            }
+            
+            if (welcomePvPBtn) welcomePvPBtn.onclick = async () => {            
                 if (!validatePlayerNames()) return;
-                const fen = welcomeFenInput?.value || null;
+                const fen = welcomeFenInput?.value?.trim() || null;
                 const started = await startNewGame('pvp', 'white', 'medium', fen);
                 if (!started) return;
                 welcomeOverlay.classList.remove('active');
@@ -1671,7 +1691,7 @@
                 }
 
                 const diff = document.getElementById('welcomeDifficultySelect').value;
-                const fen = welcomeFenInput?.value || null;
+                const fen = welcomeFenInput?.value?.trim() || null;
                 const started = await startNewGame('ai', selectedPveColor, diff, fen);
                 if (!started) return;
                 welcomeOverlay.classList.remove('active');
@@ -1820,6 +1840,13 @@
             if (fenCancelBtn) fenCancelBtn.onclick = () => {
                 fenOverlay.classList.remove('active');
             };
+            if (fenInput) {
+                fenInput.addEventListener('keydown', async (e) => {
+                    if (e.key !== 'Enter') return;
+                    e.preventDefault();
+                    fenStartBtn?.click();
+                });
+            }
 
             if (pauseBtn) pauseBtn.onclick = () => paused ? resumeGame() : pauseGame();
             if (muteBtn) muteBtn.onclick = toggleMute;

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -25,7 +25,6 @@
         window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
     </script>
     <script defer src="/_vercel/insights/script.js"></script>
-
     <script>
         (function () {
             const VALID_THEMES = ['classic', 'dark', 'green', 'blue', 'pastel'];
@@ -537,7 +536,6 @@
     <script>
         window.SOUND_BASE_URL = "{% static 'game/sounds/' %}";
     </script>
-    <script src="{% static 'game/js/board.js' %}" defer></script>
     <script src="{% static 'game/js/board.js' %}"></script>
 
     <script>


### PR DESCRIPTION
## Changes
- Moved `welcomeFenInput` keydown (Enter) listener to top level in 
  `board.js` — was incorrectly nested inside `welcomeAIBtn.onclick`
- Removed duplicate `<script src="board.js" defer>` tag in `board.html`

## Testing
- [ ] Paste FEN in welcome screen → press Enter → game loads from position
- [ ] Paste FEN → click Pass & Play → game loads from position  
- [ ] Paste FEN → click Play vs AI → game loads from position
- [ ] Open DevTools Network tab → board.js loads only once

Fixes #927 
