### PR TITLE
test: Add unit tests for registration OTP resend cooldown logic

### DIFF
--- a/game/tests.py
+++ b/game/tests.py
@@ -1233,7 +1233,7 @@ class ResendOTPCooldownTest(TestCase):
         session.save()
 
     def test_resend_otp_enforces_cooldown(self):
-        """Requesting a new OTP within 60 seconds should be rejected."""
+        """Requesting a new OTP within 60 seconds should be rejected and not send email."""
         import time
 
         self._seed_session(
@@ -1242,9 +1242,11 @@ class ResendOTPCooldownTest(TestCase):
             last_otp_time=time.time() - 10,  # 10 seconds ago
         )
 
-        response = self.client.get('/resend-otp/', follow=True)
+        with mock.patch('game.views.send_mail') as mock_send:
+            response = self.client.get('/resend-otp/', follow=True)
 
         self.assertRedirects(response, '/verify-otp/')
+        mock_send.assert_not_called()
         self.assertContains(response, 'Please wait')
 
     @override_settings(
@@ -1255,9 +1257,10 @@ class ResendOTPCooldownTest(TestCase):
         """Requesting a new OTP after 60 seconds should succeed."""
         import time
 
+        seeded_time = time.time() - 70
         self._seed_session(
             registration_user_id=self.user.id,
-            last_otp_time=time.time() - 70,  # 70 seconds ago
+            last_otp_time=seeded_time,  # 70 seconds ago
         )
 
         with mock.patch('game.views.send_mail') as mock_send:
@@ -1266,4 +1269,7 @@ class ResendOTPCooldownTest(TestCase):
         self.assertRedirects(response, '/verify-otp/')
         mock_send.assert_called_once()
         self.assertContains(response, 'A new OTP has been sent')
-        self.assertIn('last_otp_time', self.client.session)
+        
+        new_time = self.client.session.get('last_otp_time')
+        self.assertIsNotNone(new_time)
+        self.assertGreater(new_time, seeded_time)

--- a/game/tests.py
+++ b/game/tests.py
@@ -1205,3 +1205,65 @@ class PromotionNotationTest(TestCase):
         game = ChessGame()
         notation = game._notation(1, 0, 0, 0, 'P', None, promo_char='x')
         self.assertEqual(notation, 'a8=Q')
+
+
+class ResendOTPCooldownTest(TestCase):
+    """Resend OTP view should enforce a 60-second cooldown between requests."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='otpuser',
+            email='otpuser@example.com',
+            password='StrongPass123!',
+            is_active=False,
+        )
+        # Prime the session so Django allocates a session cookie.
+        self.client.get('/play/')
+
+    def _seed_session(self, **kwargs):
+        """Write keys into the live test-client session."""
+        from importlib import import_module
+        from django.conf import settings as django_settings
+        engine = import_module(django_settings.SESSION_ENGINE)
+        cookie_name = django_settings.SESSION_COOKIE_NAME
+        session_key = self.client.cookies[cookie_name].value
+        session = engine.SessionStore(session_key=session_key)
+        for key, value in kwargs.items():
+            session[key] = value
+        session.save()
+
+    def test_resend_otp_enforces_cooldown(self):
+        """Requesting a new OTP within 60 seconds should be rejected."""
+        import time
+
+        self._seed_session(
+            registration_user_id=self.user.id,
+            registration_otp_hash='dummy_hash',
+            last_otp_time=time.time() - 10,  # 10 seconds ago
+        )
+
+        response = self.client.get('/resend-otp/', follow=True)
+
+        self.assertRedirects(response, '/verify-otp/')
+        self.assertContains(response, 'Please wait')
+
+    @override_settings(
+        EMAIL_HOST_USER='sender@example.com',
+        EMAIL_HOST_PASSWORD='app-password',
+    )
+    def test_resend_otp_allows_after_cooldown_expires(self):
+        """Requesting a new OTP after 60 seconds should succeed."""
+        import time
+
+        self._seed_session(
+            registration_user_id=self.user.id,
+            last_otp_time=time.time() - 70,  # 70 seconds ago
+        )
+
+        with mock.patch('game.views.send_mail') as mock_send:
+            response = self.client.get('/resend-otp/', follow=True)
+
+        self.assertRedirects(response, '/verify-otp/')
+        mock_send.assert_called_once()
+        self.assertContains(response, 'A new OTP has been sent')
+        self.assertIn('last_otp_time', self.client.session)


### PR DESCRIPTION
## Description

This PR adds unit test coverage for the previously untested OTP resend cooldown logic in the registration system. 

Specifically, a new `ResendOTPCooldownTest` class has been added to `game/tests.py` containing the following tests:
- `test_resend_otp_enforces_cooldown`: Verifies that if a user requests a new OTP within the 60-second cooldown period, the view rejects the request, sets a "Please wait" error message, and redirects back to `/verify-otp/`.
- `test_resend_otp_allows_after_cooldown_expires`: Verifies that if the 60-second cooldown has passed, the view allows the OTP to be sent, triggers the email dispatch helper, updates the `last_otp_time` in the session, and redirects to `/verify-otp/`.

Additionally, the helper method `_seed_session` is implemented to properly handle Django session cookies, preventing redirection issues due to missing session states during test execution.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #945 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)
<img width="1447" height="450" alt="image" src="https://github.com/user-attachments/assets/a6509b47-7c9d-4099-89bf-6eb52e65a989" />

### Unit Tests Passing Locally
```text
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
......................................................................................
----------------------------------------------------------------------
Ran 86 tests in 19.753s

OK
Destroying test database for alias 'default'...