### PR TITLE
fix: align rulebook step indicators beside chess board

### DIFF
--- a/game/templates/game/rules.html
+++ b/game/templates/game/rules.html
@@ -219,7 +219,6 @@
             border: 1px solid var(--border);
             border-radius: 10px;
             padding: 1.5rem;
-            width: 100%;
 
              
         }
@@ -262,7 +261,7 @@
         .mini-board-container {
             display: flex;
             gap: 2rem;
-            align-items: flex-center;
+            align-items: center;
             flex-wrap: nowrap;
         }
 

--- a/game/templates/game/rules.html
+++ b/game/templates/game/rules.html
@@ -362,7 +362,6 @@
         /* ── Steps ── */
         .steps {
             display: flex;
-             justify-content: center;
             flex-direction: column;
             gap: 0.6rem;
             margin-top: 0.5rem;

--- a/game/templates/game/rules.html
+++ b/game/templates/game/rules.html
@@ -258,12 +258,18 @@
         }
 
         /* ── Mini Chess Board ── */
-        .mini-board-container {
-            display: flex;
-            gap: 2rem;
-            align-items: center;
-            flex-wrap: nowrap;
-        }
+       .mini-board-container {
+    display: flex;
+    gap: 2rem;
+    align-items: center;
+    flex-wrap: nowrap;
+}
+
+@media (max-width: 1100px) {
+    .mini-board-container {
+        flex-wrap: wrap;
+    }
+}
 
         .mini-board {
     display: grid;

--- a/game/templates/game/rules.html
+++ b/game/templates/game/rules.html
@@ -151,6 +151,7 @@
         main {
             padding: 3rem 4rem;
             max-width: 900px;
+            width: 100%;
         }
 
         .page-title {
@@ -172,6 +173,8 @@
             background: var(--surface);
             border: 1px solid var(--border);
             border-radius: 12px;
+            width: 100%;
+
             padding: 2rem;
             margin-bottom: 2rem;
             display: none;
@@ -216,6 +219,9 @@
             border: 1px solid var(--border);
             border-radius: 10px;
             padding: 1.5rem;
+            width: 100%;
+
+             
         }
 
         .demo-label {
@@ -256,8 +262,8 @@
         .mini-board-container {
             display: flex;
             gap: 2rem;
-            align-items: flex-start;
-            flex-wrap: wrap;
+            align-items: flex-center;
+            flex-wrap: nowrap;
         }
 
         .mini-board {
@@ -351,6 +357,7 @@
         /* ── Steps ── */
         .steps {
             display: flex;
+             justify-content: center;
             flex-direction: column;
             gap: 0.6rem;
             margin-top: 0.5rem;


### PR DESCRIPTION
## Description

On the Chess Rulebook page, the step indicators (King in Check, Block the check, Checkmate) were wrapping below the chess board instead of appearing beside it, leaving a large empty space to the right of the board.
Changed `flex-wrap: wrap` to `flex-wrap: nowrap` on `.mini-board-container` in `game/templates/game/rules.html` so the steps now sit in a two-column layout  board on the left, steps on the right  making full use of the card width.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #942 


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

## Screenshots (if applicable)

Before:
<img width="1920" height="936" alt="Screenshot 2026-05-21 173827" src="https://github.com/user-attachments/assets/91fadf90-62a0-4d9f-ae2f-9486d386e463" />
After:
<img width="1920" height="938" alt="Screenshot 2026-05-21 182602" src="https://github.com/user-attachments/assets/736a196e-0787-4f9a-bed8-67b01477a004" />

## Additional Notes

Fixed the rulebook demo layout where the step indicators were wrapping below the chess board instead of appearing beside it. 
