### PR TITLE
feat: implement custom themed 500 error page

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -45,4 +45,10 @@ def custom_page_not_found(request, exception):
     return render(request, '404.html', status=404)
 
 
+def custom_server_error(request):
+    """Render the themed 500 page for unexpected server errors."""
+    return render(request, '500.html', status=500)
+
+
 handler404 = 'core.urls.custom_page_not_found'
+handler500 = 'core.urls.custom_server_error'

--- a/game/static/game/css/500.css
+++ b/game/static/game/css/500.css
@@ -1,0 +1,156 @@
+:root {
+    --bg-dark: #0f0f1a;
+    --card-bg: #16162a;
+    --card-border: #252545;
+    --text-primary: #d0d0d0;
+    --text-secondary: #aaaaaa;
+    --text-title: #ffffff;
+    --accent-gold: #f0c040;
+    --danger-red: #ff6b6b;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    min-height: 100vh;
+    font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+    color: var(--text-primary);
+    background:
+        radial-gradient(circle at 18% 18%, rgba(255, 107, 107, 0.09), transparent 40%),
+        radial-gradient(circle at 82% 72%, rgba(240, 192, 64, 0.08), transparent 42%),
+        var(--bg-dark);
+    position: relative;
+    overflow: hidden;
+}
+
+body::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    background:
+        repeating-conic-gradient(
+            #bdbdbd 0% 25%,
+            #0b0b0b 0% 50%
+        ) 0 0 / 140px 140px;
+    opacity: 0.14;
+    filter: saturate(0.2) brightness(0.42) contrast(1.18);
+    z-index: -2;
+    pointer-events: none;
+}
+
+body::after {
+    content: "";
+    position: fixed;
+    inset: 0;
+    background: linear-gradient(
+        to bottom,
+        rgba(10, 10, 18, 0.72),
+        rgba(8, 8, 14, 0.92)
+    );
+    z-index: -1;
+    pointer-events: none;
+}
+
+.error-stage {
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    padding: 2rem 1rem;
+}
+
+.error-card {
+    width: min(92vw, 640px);
+    background: linear-gradient(160deg, rgba(22, 22, 42, 0.96), rgba(15, 15, 26, 0.96));
+    border: 1px solid var(--card-border);
+    border-radius: 16px;
+    text-align: center;
+    padding: clamp(2rem, 6vw, 3rem) clamp(1.25rem, 5vw, 2rem);
+    box-shadow: 0 22px 50px rgba(0, 0, 0, 0.38);
+    position: relative;
+    overflow: hidden;
+}
+
+.error-card::before {
+    content: "\2654";
+    position: absolute;
+    top: -0.3rem;
+    right: 1rem;
+    font-size: clamp(4rem, 16vw, 7rem);
+    line-height: 1;
+    color: rgba(240, 192, 64, 0.08);
+    pointer-events: none;
+}
+
+.server-error {
+    border-color: rgba(240, 192, 64, 0.22);
+}
+
+.crest {
+    width: 72px;
+    height: auto;
+    margin-bottom: 0.85rem;
+    filter: brightness(1.5) contrast(1.2) drop-shadow(0 0 8px rgba(240, 192, 64, 0.28));
+}
+
+.code {
+    font-family: 'Cinzel', serif;
+    letter-spacing: 1.8px;
+    font-size: 0.85rem;
+    color: var(--danger-red);
+    margin-bottom: 0.7rem;
+    text-transform: uppercase;
+}
+
+h1 {
+    font-family: 'Cinzel', serif;
+    font-size: clamp(1.9rem, 5vw, 3rem);
+    color: var(--text-title);
+    line-height: 1.15;
+    margin-bottom: 0.9rem;
+}
+
+.message {
+    max-width: 50ch;
+    margin: 0 auto 1.8rem;
+    color: var(--text-secondary);
+    line-height: 1.6;
+}
+
+.home-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 44px;
+    text-decoration: none;
+    font-weight: 700;
+    color: #1a1a2e;
+    background: linear-gradient(135deg, #f0c040, #d4a020);
+    padding: 0.75rem 1.35rem;
+    border-radius: 8px;
+    border: none;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.home-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 20px rgba(240, 192, 64, 0.22);
+}
+
+.home-btn:focus-visible {
+    outline: 2px solid var(--accent-gold);
+    outline-offset: 3px;
+}
+
+@media (max-width: 480px) {
+    .crest {
+        width: 60px;
+    }
+
+    .message {
+        font-size: 0.95rem;
+    }
+}

--- a/game/static/game/css/500.css
+++ b/game/static/game/css/500.css
@@ -97,7 +97,7 @@ body::after {
 }
 
 .code {
-    font-family: 'Cinzel', serif;
+    font-family: Cinzel, serif;
     letter-spacing: 1.8px;
     font-size: 0.85rem;
     color: var(--danger-red);
@@ -106,7 +106,7 @@ body::after {
 }
 
 h1 {
-    font-family: 'Cinzel', serif;
+    font-family: Cinzel, serif;
     font-size: clamp(1.9rem, 5vw, 3rem);
     color: var(--text-title);
     line-height: 1.15;

--- a/game/templates/500.html
+++ b/game/templates/500.html
@@ -1,0 +1,26 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>500 | Checkora</title>
+    <link rel="icon" type="image/jpeg" href="{% static 'game/favicon.jpeg' %}">
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{% static 'game/css/500.css' %}">
+</head>
+<body>
+    <main class="error-stage">
+        <section class="error-card server-error" role="alert" aria-live="assertive">
+            <img src="{% static 'game/checkora_icon_only.png' %}" class="crest" alt="Checkora crest">
+            <p class="code">Error 500</p>
+            <h1>The King has fallen!</h1>
+            <p class="message">
+                An unexpected move disrupted the board. Our team has been notified,
+                and you can safely return to the main menu.
+            </p>
+            <a class="home-btn" href="{% url 'landing' %}">Return to Main Menu</a>
+        </section>
+    </main>
+</body>
+</html>

--- a/game/tests.py
+++ b/game/tests.py
@@ -8,7 +8,12 @@ from unittest import mock
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.urls import reverse
-from django.test import SimpleTestCase, TestCase, override_settings
+from django.test import (
+    RequestFactory,
+    SimpleTestCase,
+    TestCase,
+    override_settings,
+)
 
 from .engine import ChessGame
 from .forms import CustomSetPasswordForm
@@ -100,6 +105,30 @@ class NotFoundPageTest(TestCase):
         self.assertContains(response, 'This move is illegal!', status_code=404)
         self.assertContains(response, 'Return to Main Menu', status_code=404)
         self.assertContains(response, reverse('landing'), status_code=404)
+
+
+class ServerErrorPageTest(SimpleTestCase):
+    """Custom 500 page should match the product theme and recovery flow."""
+
+    def test_custom_500_handler_renders_themed_page(self):
+        from core.urls import custom_server_error
+
+        request = RequestFactory().get('/server-error/')
+        response = custom_server_error(request)
+
+        self.assertEqual(response.status_code, 500)
+        self.assertContains(
+            response,
+            'The King has fallen!',
+            status_code=500,
+        )
+        self.assertContains(
+            response,
+            'Return to Main Menu',
+            status_code=500,
+        )
+        self.assertContains(response, reverse('landing'), status_code=500)
+
 
 class RegistrationViewTest(TestCase):
     """Registration should support local OTP fallback and email failures."""


### PR DESCRIPTION
## Description

This PR implements a custom, responsive `500 Internal Server Error` page for Checkora. The page follows the existing dark-and-gold chess-themed design, provides clear server-error messaging, and includes a recovery button to return users to the main menu.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #858

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [x] No documentation update was required
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

### Desktop View
<img width="1366" height="768" alt="custom-500-desktop" src="https://github.com/user-attachments/assets/9c059d15-de2b-48ef-adaf-7ea69e38c052" />

### Mobile View
<img width="390" height="844" alt="custom-500-mobile" src="https://github.com/user-attachments/assets/ac8b786d-80e4-4b17-acb0-1bca7a7588ef" />


## Additional Notes

Added `game/templates/500.html`, `game/static/game/css/500.css`, and configured Django `handler500` in `core/urls.py`.

The implementation follows the existing Checkora UI patterns and reuses shared theme styling principles for consistency.

Tested with:
- `python manage.py test game.tests.ServerErrorPageTest`
- `python manage.py test game.tests`
- `python manage.py check`

Direct deployment/merge is left for maintainers.