### PR TITLE
Enhancement: Add game duration display in post-game modal

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -33,6 +33,8 @@
             let timerInterval = null;
             let pendingPromo = null;
 
+            let gameStartTime = null;
+    
             let gameMode = 'pvp';
             let currentDifficulty = 'medium';
             let currentWhiteName = 'White';
@@ -1126,9 +1128,23 @@
                 if (resignBtn) resignBtn.style.display = 'none';
                 if (drawBtn) drawBtn.style.display = 'none';
                 if (pauseBtn) pauseBtn.style.display = 'none';
+
+                let durationText = '';
+
+                if (gameStartTime) {
+                    const duration = Date.now() - gameStartTime;
+                    durationText = `\nGame duration: ${formatGameDuration(duration)}.`;
+                }
+
                 gameOverTitle.textContent = title;
-                gameOverMessage.textContent = message;
+                gameOverMessage.textContent = message + durationText;
+
+                const durationElement = document.getElementById('gameDurationText');
                 
+                if (durationElement) {
+                    durationElement.textContent = durationText;
+                }
+
                 // Delay the overlay and celebration effects by 1 second
                 setTimeout(() => {
                     // Add celebration effects for wins
@@ -1248,7 +1264,14 @@
             ========================================================== */
             const fmt = t => `${Math.floor(t / 60)}:${String(t % 60).padStart(2, '0')}`;
             function formatTime(t) { return fmt(t); }
-
+            
+            function formatGameDuration(ms) {
+                const totalSeconds = Math.floor(ms / 1000);
+                const mins = Math.floor(totalSeconds / 60);
+                const secs = totalSeconds % 60;
+                return `${mins}m ${secs}s`;
+            }
+    
             function renderClocks() {
                 const wTime = document.getElementById('whiteTime');
                 const bTime = document.getElementById('blackTime');
@@ -1507,6 +1530,9 @@
                 turn = d.current_turn;
                 paused = false;
                 gameOver = false;
+                
+                gameStartTime = Date.now();
+                
                 gameMode = d.mode;
                 playerColor = d.player_color || 'white';
                 currentDifficulty = d.difficulty || difficulty;

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -433,6 +433,7 @@
             <div class="promo-title" id="gameOverTitle" style="font-size: 1.5rem; color: #f0c040; margin-bottom: 10px;">
                 Game Over</div>
             <p id="gameOverMessage" style="color: #ccc; margin-bottom: 25px; font-size: 1rem;"></p>
+            <p id="gameDurationText" style="color: #aaa; margin-bottom: 20px; font-size: 0.9rem;"></p>
             <div style="margin-bottom: 20px;">
                 <label style="color: #ccc; display: block; margin-bottom: 8px; font-size: 0.9rem;">Game Mode</label>
                 <div style="display: flex; gap: 10px; margin-bottom: 15px;">


### PR DESCRIPTION
## Summary

Added game duration display in the post-game result modal.

Players can now see how long the match lasted after game completion (checkmate, resignation, timeout, draw, etc.).

Example:

* Game Duration: 2m 14s

## Changes Made

* Added game start time tracking
* Calculated elapsed game duration on game end
* Displayed formatted duration in the game over modal

## Files Changed

* game/static/game/js/board.js
* game/templates/game/board.html

## Benefits

* Improves gameplay insights
* Enhances post-game UX
* Small focused frontend enhancement

## Testing

* Tested locally using 'python manage.py runserver'
* Verified duration display after game end
