### PR TITLE
feat: send welcome email after otp verification (#966)

### DIFF
--- a/game/tests.py
+++ b/game/tests.py
@@ -1,5 +1,6 @@
 """Tests for the Checkora chess engine and API endpoints."""
 
+import hashlib
 import json
 import sys
 from smtplib import SMTPException
@@ -152,6 +153,66 @@ class RegistrationViewTest(TestCase):
         self.assertFalse(User.objects.filter(username='newplayer').exists())
         self.assertNotIn('registration_user_id', self.client.session)
         self.assertNotIn('registration_otp_hash', self.client.session)
+
+    @override_settings(
+        EMAIL_HOST_USER='sender@example.com',
+        EMAIL_HOST_PASSWORD='app-password'
+    )
+    def test_successful_otp_verification_sends_welcome_email(self):
+        user = User.objects.create_user(
+            username='otpplayer',
+            email='otpplayer@example.com',
+            password='StrongPass123!',
+            is_active=False,
+        )
+        otp = '123456'
+        session = self.client.session
+        session['registration_user_id'] = user.id
+        session['registration_otp_hash'] = hashlib.sha256(
+            f'{otp}:{settings.SECRET_KEY}'.encode()
+        ).hexdigest()
+        session.save()
+
+        with mock.patch('game.views.send_mail') as mock_send_mail:
+            response = self.client.post('/verify-otp/', data={'otp': otp})
+
+        self.assertRedirects(response, '/play/')
+        user.refresh_from_db()
+        self.assertTrue(user.is_active)
+        self.assertEqual(str(self.client.session.get('_auth_user_id')), str(user.id))
+        mock_send_mail.assert_called_once()
+        self.assertEqual(mock_send_mail.call_args.args[0], 'Welcome to Checkora')
+        self.assertEqual(mock_send_mail.call_args.args[3], [user.email])
+
+    @override_settings(
+        EMAIL_HOST_USER='sender@example.com',
+        EMAIL_HOST_PASSWORD='app-password'
+    )
+    def test_welcome_email_failure_does_not_block_login(self):
+        user = User.objects.create_user(
+            username='mailfallback',
+            email='mailfallback@example.com',
+            password='StrongPass123!',
+            is_active=False,
+        )
+        otp = '654321'
+        session = self.client.session
+        session['registration_user_id'] = user.id
+        session['registration_otp_hash'] = hashlib.sha256(
+            f'{otp}:{settings.SECRET_KEY}'.encode()
+        ).hexdigest()
+        session.save()
+
+        with mock.patch(
+            'game.views.send_mail',
+            side_effect=SMTPException('SMTP unavailable'),
+        ):
+            response = self.client.post('/verify-otp/', data={'otp': otp})
+
+        self.assertRedirects(response, '/play/')
+        user.refresh_from_db()
+        self.assertTrue(user.is_active)
+        self.assertEqual(str(self.client.session.get('_auth_user_id')), str(user.id))
 
 
 class CustomSetPasswordFormTest(TestCase):

--- a/game/views.py
+++ b/game/views.py
@@ -47,6 +47,54 @@ def record_game_result(request, mode, winner, reason, player_color='white'):
     GameResult.objects.create(user=user, mode=mode, winner=winner, end_reason=reason, player_color=player_color)
 
 
+def send_welcome_email(user):
+    """Send a best-effort welcome email after registration completes."""
+    missing_email_credentials = (
+        not settings.EMAIL_HOST_USER or
+        not settings.EMAIL_HOST_PASSWORD
+    )
+    if missing_email_credentials:
+        return False
+
+    send_mail(
+        'Welcome to Checkora',
+        (
+            f'Hi {user.username},\n\n'
+            'Welcome to Checkora. Your account is now active and ready for play.\n'
+            'You can sign in anytime to challenge the AI, explore the rulebook, '
+            'and track your progress.\n\n'
+            'See you on the board,\n'
+            'Team Checkora'
+        ),
+        None,
+        [user.email],
+        fail_silently=False,
+        html_message=(
+            "<div style=\"font-family: 'Segoe UI', Arial, sans-serif; "
+            "background-color: #0f0f1a; color: #d0d0d0; padding: 40px 20px; "
+            "text-align: center;\"><div style=\"background-color: #16162a; "
+            "border: 1px solid #252545; border-radius: 12px; padding: 40px "
+            "30px; max-width: 480px; margin: 0 auto; box-shadow: 0 10px 30px "
+            "rgba(0,0,0,0.5);\"><h1 style=\"color: #ffffff; margin-top: 0; "
+            "margin-bottom: 15px; font-size: 28px; letter-spacing: 2px;\">CHECK"
+            "<span style=\"color: #f0c040;\">ORA</span></h1><hr style=\"border: "
+            "none; border-top: 1px solid #252545; margin: 20px 0;\"><p style=\""
+            "color: #e0e0e0; font-size: 16px; line-height: 1.6; margin-bottom: "
+            "20px;\">Hi {username}, your account is now active and ready for "
+            "play.</p><p style=\"color: #b8b8c8; font-size: 15px; line-height: "
+            "1.6; margin-bottom: 30px;\">You can now sign in to challenge the AI, "
+            "explore the rulebook, and track your progress on Checkora.</p>"
+            "<a href=\"https://checkora.vercel.app/play/\" style=\"display: "
+            "inline-block; background: linear-gradient(135deg, #f0c040, #d4a020); "
+            "color: #1a1a2e; text-decoration: none; padding: 12px 24px; "
+            "border-radius: 8px; font-weight: 600;\">Start Playing</a><p style=\""
+            "color: #5a5a7a; font-size: 12px; margin-top: 40px;\">Thanks for "
+            "joining Checkora.</p></div></div>"
+        ).format(username=user.username),
+    )
+    return True
+
+
 @require_POST
 def make_move(request):
     """Validate and execute a chess move via the C++ engine."""
@@ -611,6 +659,14 @@ def verify_otp(request):
                 del request.session['registration_otp_hash']
 
                 login(request, user)
+                try:
+                    send_welcome_email(user)
+                except (SMTPException, BadHeaderError, OSError):
+                    logger.warning(
+                        'Failed to send welcome email to %s after registration.',
+                        user.email,
+                        exc_info=True,
+                    )
                 messages.success(request, 'Registration successful! Welcome to Checkora.')
                 request.session.cycle_key()
                 return redirect('index')

--- a/game/views.py
+++ b/game/views.py
@@ -663,8 +663,8 @@ def verify_otp(request):
                     send_welcome_email(user)
                 except (SMTPException, BadHeaderError, OSError):
                     logger.warning(
-                        'Failed to send welcome email to %s after registration.',
-                        user.email,
+                        'Failed to send welcome email after registration for user_id=%s.',
+                        user.id,
                         exc_info=True,
                     )
                 messages.success(request, 'Registration successful! Welcome to Checkora.')


### PR DESCRIPTION
## Summary
- send a welcome email after successful OTP verification activates the account
- keep registration/login flow non-blocking if the welcome email fails
- add regression coverage for both successful send and best-effort fallback behavior

Fixes #966

## Testing
- python manage.py test game.tests.RegistrationViewTest
- python manage.py check