### PR TITLE
fix: Use EMAIL_BACKEND env var to enable SMTP in production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,7 @@ DATABASE_URL=sqlite:///db.sqlite3
 # Email Configuration for OTP (Optional)
 EMAIL_HOST_USER=
 EMAIL_HOST_PASSWORD=
+
+# Email Backend (Optional, defaults to console for local dev)
+# For production, set to: django.core.mail.backends.smtp.EmailBackend
+EMAIL_BACKEND=

--- a/core/settings.py
+++ b/core/settings.py
@@ -144,7 +144,7 @@ SECURE_SSL_REDIRECT = not DEBUG
 
 
 # Email Configuration for OTP
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+EMAIL_BACKEND = os.getenv('EMAIL_BACKEND', 'django.core.mail.backends.console.EmailBackend')
 EMAIL_HOST = 'smtp.gmail.com'
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True


### PR DESCRIPTION
## Description

`EMAIL_BACKEND` was hardcoded to `console.EmailBackend`, which only prints emails to the terminal and never delivers them. 
This fix reads the backend from an environment variable, defaulting to console for local development. 

**Production deployments can set `EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend` to enable real email delivery.**

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issue

Fixes #965

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

Add screenshots to demonstrate visual changes.

## Additional Notes

`test_04_game_timers_visible` was already failing on upstream main before this change — it is an unrelated UI/Selenium test failure.
