### PR TITLE
fix: restore working rulebook back navigation (#977)

### DIFF
--- a/game/templates/game/rules.html
+++ b/game/templates/game/rules.html
@@ -543,7 +543,7 @@
     <!-- Sidebar -->
     <nav class="sidebar">
         <div style="margin-bottom: 20px; margin-top: 10px; text-align: center; width: 50%;">
-            <a href="#" class="back-btn" style="color:#f0c040; display: inline-block;" onclick="try { var modal = window.parent.document.getElementById('rulebookModal'); if (modal) modal.style.display='none'; } catch(e) { console.error('Cannot close modal:', e); } return false;">← Back to Game</a>
+            <a href="{% url 'index' %}" class="back-btn" style="color:#f0c040; display: inline-block;" onclick="return handleBackToGame(event);">← Back to Game</a>
         </div>
         <div class="sidebar-title">Rulebook</div>
         <div class="rule-nav-item active" onclick="showRule('basics')" id="nav-basics">
@@ -912,6 +912,23 @@ function highlightCapture(id, r, c) {
    NAVIGATION
 ══════════════════════════════════════════════ */
 const rules = ['basics','pieces','pawn','castling','enpassant','check','stalemate','promotion'];
+
+function handleBackToGame(event) {
+    try {
+        if (window.parent && window.parent !== window) {
+            const modal = window.parent.document.getElementById('rulebookModal');
+            if (modal) {
+                modal.style.display = 'none';
+                event.preventDefault();
+                return false;
+            }
+        }
+    } catch (error) {
+        console.error('Cannot close modal:', error);
+    }
+
+    return true;
+}
 
 function showRule(name) {
     rules.forEach(r => {

--- a/game/tests.py
+++ b/game/tests.py
@@ -101,6 +101,17 @@ class NotFoundPageTest(TestCase):
         self.assertContains(response, 'Return to Main Menu', status_code=404)
         self.assertContains(response, reverse('landing'), status_code=404)
 
+
+class RulesViewTest(TestCase):
+    """The rules page should keep a working back-to-game fallback."""
+
+    def test_rules_page_back_link_falls_back_to_play_route(self):
+        response = self.client.get('/rules/')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'href="/play/"')
+        self.assertContains(response, 'onclick="return handleBackToGame(event);"')
+
 class RegistrationViewTest(TestCase):
     """Registration should support local OTP fallback and email failures."""
 


### PR DESCRIPTION
## Summary
- keep the existing in-modal rulebook close behavior when the page is embedded in the board iframe
- add a real /play/ fallback so the back link still works when the rulebook is opened directly
- add a regression test covering the rendered fallback link and handler

Fixes #977

## Verification
- python manage.py test game.tests.RulesViewTest
- python manage.py check