### PR TITLE
fix: align Python insufficient material status (#967)

### DIFF
--- a/game/engine/main.py
+++ b/game/engine/main.py
@@ -111,6 +111,22 @@ def path_clear(fr, fc, tr, tc):
     return True
 
 
+def is_insufficient_material():
+    total_minor = 0
+    for row in range(8):
+        for col in range(8):
+            piece = BOARD[row][col]
+            if piece == '.':
+                continue
+            piece_type = piece.lower()
+            if piece_type == 'k':
+                continue
+            if piece_type in {'p', 'r', 'q'}:
+                return False
+            total_minor += 1
+    return total_minor <= 1
+
+
 def is_square_attacked(target_row, target_col, attacker_color):
     knight_offsets = [
         (-2, -1), (-2, 1), (-1, -2), (-1, 2),
@@ -626,6 +642,10 @@ def handle_status(turn):
 
     if not has_legal_move:
         print('STATUS CHECKMATE' if in_check else 'STATUS STALEMATE')
+        return
+
+    if is_insufficient_material():
+        print('STATUS DRAW')
         return
 
     print('STATUS CHECK' if in_check else 'STATUS OK')

--- a/game/tests.py
+++ b/game/tests.py
@@ -1,6 +1,8 @@
 """Tests for the Checkora chess engine and API endpoints."""
 
+import importlib.util
 import json
+from pathlib import Path
 import sys
 from smtplib import SMTPException
 from unittest import mock
@@ -68,6 +70,40 @@ class EnginePathResolutionTest(SimpleTestCase):
                 ChessGame._build_engine_command(candidates[2]),
                 [sys.executable, candidates[2]],
             )
+
+
+class PythonFallbackStatusTest(SimpleTestCase):
+    """Python fallback engine should match C++ draw status handling."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        engine_path = Path(__file__).resolve().parent / 'engine' / 'main.py'
+        spec = importlib.util.spec_from_file_location('checkora_python_engine', engine_path)
+        cls.python_engine = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        sys.modules[spec.name] = cls.python_engine
+        spec.loader.exec_module(cls.python_engine)
+
+    def test_status_reports_draw_for_insufficient_material(self):
+        self.python_engine.load_board(
+            'k.......'
+            '........'
+            '........'
+            '........'
+            '........'
+            '........'
+            '........'
+            '.......K'
+        )
+        self.python_engine.load_castling_rights('-')
+        self.python_engine.load_en_passant(-1, -1)
+
+        with mock.patch('builtins.print') as mock_print:
+            self.python_engine.handle_status('white')
+
+        mock_print.assert_called_once_with('STATUS DRAW')
+
 
 class BoardViewTest(TestCase):
     """The board page should load and initialise a session."""


### PR DESCRIPTION
## Summary
- add insufficient-material detection to the Python fallback engine so it matches the C++ backend
- return `STATUS DRAW` for king-vs-king and similar simple insufficient-material cases in the Python `STATUS` flow
- add a focused regression test that exercises the Python fallback engine directly

Fixes #967

## Verification
- python manage.py test game.tests.PythonFallbackStatusTest
- python manage.py check
- python -m ruff check game/tests.py