### PR TITLE
feat: add keyboard shortcuts for chess board actions

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -2051,7 +2051,7 @@
                 const tag = document.activeElement && document.activeElement.tagName;
                 if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
 
-                if (document.querySelector('.modal.show, [role="dialog"]:not([hidden]), .promo-overlay.active')) return;
+                const hasOpenModal = document.querySelector('.modal.show, [role="dialog"]:not([hidden]), .promo-overlay.active');
 
                 const key = e.key.toLowerCase();
                 if (key === 'f' && flipBtn) {
@@ -2066,7 +2066,20 @@
                 } else if (key === 'p' && pauseBtn && pauseBtn.style.display !== 'none') {
                     e.preventDefault();
                     pauseBtn.click();
-                }// added pause/resume button shortcut
+                } else if (key === 'n' && !hasOpenModal) {
+                    e.preventDefault();
+                    const newAiBtn = document.getElementById('newAIBtn');
+                    if (newAiBtn) newAiBtn.click();
+                } else if (key === 'a' && !hasOpenModal && typeof requestAIMove === 'function') {
+                    e.preventDefault();
+                    requestAIMove();
+                } else if (e.key === 'Escape' && hasOpenModal) {
+                    e.preventDefault();
+                    document.querySelectorAll('.modal.show, [role="dialog"]:not([hidden]), .promo-overlay.active').forEach(el => {
+                        el.style.display = 'none';
+                        el.classList.remove('show', 'active');
+                    });
+                }
             });
             // Emote Logic
             let emoteCooldown = false;

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -319,7 +319,7 @@
                         onclick="document.getElementById('rulebookModal').style.display='flex'">📖 Rulebook</button>
                 </div>
                 <div class="keyboard-hints" style="font-size: 0.8rem; color: #888; margin-top: 8px;">
-                    ⌨️ Shortcuts: <kbd>F</kbd> Flip &nbsp; <kbd>R</kbd> Resign &nbsp; <kbd>D</kbd> Draw &nbsp; <kbd>P</kbd> Pause
+                    ⌨️ Shortcuts: <kbd>F</kbd> Flip &nbsp; <kbd>R</kbd> Resign &nbsp; <kbd>D</kbd> Draw &nbsp; <kbd>P</kbd> Pause &nbsp; <kbd>N</kbd> New Game &nbsp; <kbd>A</kbd> AI Move &nbsp; <kbd>Esc</kbd> Close
                 </div>
                 <a href="/" class="btn" 
    style="background: #2a1414; color: #ff6b6b;margin-top: 1rem;margin-bottom: 1.5rem; border: 1px solid #632424; text-decoration: none; text-align: center; display: block; line-height: 2.5;">


### PR DESCRIPTION
Closes #991

Adds keyboard shortcuts:
- N → Start new game (clicks Play vs AI button)
- A → Trigger AI move
- Esc → Close active modals/popups
- Updates keyboard hints in the UI

F, R, D, P shortcuts were already implemented.