### PR TITLE
feat: add keyboard shortcuts for game controls

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -2061,7 +2061,12 @@
                         '.modal.show, [role="dialog"]:not([hidden]), .promo-overlay.active'
                     ) ||
                     (shareModal?.style.display && shareModal.style.display !== 'none') ||
-                    (rulebookModal?.style.display && rulebookModal.style.display !== 'none');
+                    (rulebookModal?.style.display && rulebookModal.style.display !== 'none') ||
+                    fenOverlay?.classList.contains('active') ||
+                    confirmOverlay?.classList.contains('active') ||
+                    drawOverlay?.classList.contains('active') ||
+                    gameOverOverlay?.classList.contains('active') ||
+                    welcomeOverlay?.classList.contains('active');
 
             // Allow Escape to close overlays
             if (hasBlockingOverlay && key !== 'escape') {

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -2060,8 +2060,8 @@
                     document.querySelector(
                         '.modal.show, [role="dialog"]:not([hidden]), .promo-overlay.active'
                     ) ||
-                    shareModal?.style.display === 'flex' ||
-                    rulebookModal?.style.display === 'flex';
+                    (shareModal?.style.display && shareModal.style.display !== 'none') ||
+                    (rulebookModal?.style.display && rulebookModal.style.display !== 'none');
 
             // Allow Escape to close overlays
             if (hasBlockingOverlay && key !== 'escape') {

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -2053,9 +2053,18 @@
                 const tag = document.activeElement && document.activeElement.tagName;
                 if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
 
-                if (document.querySelector('.modal.show, [role="dialog"]:not([hidden]), .promo-overlay.active')) return;
+                
 
                 const key = e.key.toLowerCase();
+                const hasBlockingOverlay = document.querySelector(
+                    '.modal.show, [role="dialog"]:not([hidden]), .promo-overlay.active'
+            );
+
+            // Allow Escape to close overlays
+            if (hasBlockingOverlay && key !== 'escape') {
+                return;
+            }
+
                 if (key === 'f' && flipBtn) {
                     e.preventDefault();
                     flipBtn.click();

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -2056,9 +2056,12 @@
                 
 
                 const key = e.key.toLowerCase();
-                const hasBlockingOverlay = document.querySelector(
-                    '.modal.show, [role="dialog"]:not([hidden]), .promo-overlay.active'
-            );
+                const hasBlockingOverlay =
+                    document.querySelector(
+                        '.modal.show, [role="dialog"]:not([hidden]), .promo-overlay.active'
+                    ) ||
+                    shareModal?.style.display === 'flex' ||
+                    rulebookModal?.style.display === 'flex';
 
             // Allow Escape to close overlays
             if (hasBlockingOverlay && key !== 'escape') {

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -122,6 +122,8 @@
             /* ==========================================================
             DOM REFERENCES
             ========================================================== */
+            const shareModal = document.getElementById('shareModal');
+            const rulebookModal = document.getElementById('rulebookModal');
             const boardEl = document.getElementById('board');
             const turnEl = document.getElementById('turnBadge');
             const statusEl = document.getElementById('statusBar');
@@ -1799,7 +1801,7 @@
                 confirmOverlay.classList.remove('active');
                 confirmCallback = null;
             };
-                //added new line here
+
             if (newPvPBtn) newPvPBtn.onclick = () => {
                 // Clear any lingering celebration effects
                 const overlay = document.getElementById('gameOverOverlay');
@@ -1877,6 +1879,62 @@
             if (pauseBtn) pauseBtn.onclick = () => paused ? resumeGame() : pauseGame();
             if (muteBtn) muteBtn.onclick = toggleMute;
             if (flipBtn) flipBtn.onclick = toggleBoardOrientation;
+            document.addEventListener('keydown', (e) => {
+                const tag = e.target.tagName;
+                if (
+                    tag === 'INPUT' ||
+                    tag === 'TEXTAREA' ||
+                    e.target.isContentEditable ||
+                    e.repeat
+                ) {
+                    return;
+                }
+
+                const key = e.key.toLowerCase();
+
+
+                switch (key) {
+                    case 'f':
+                        e.preventDefault();
+                        flipBtn?.click();
+                        break;
+
+                    case 'p':
+                        e.preventDefault();
+                        pauseBtn?.click();
+                        break;
+
+                    case 'r':
+                        e.preventDefault();
+                        resignBtn?.click();
+                        break;
+
+                    case 'd':
+                        e.preventDefault();
+                        if (gameMode === 'pvp') {
+                            drawBtn?.click();
+                        }
+                        break;
+
+                    case 'n':
+                        e.preventDefault();
+                        newPvPBtn?.click();
+                        break;
+
+                    case 'a':
+                        e.preventDefault();
+                        newAIBtn?.click();
+                        break;
+
+                   case 'escape':
+                        e.preventDefault();
+                        shareModal?.classList.remove('active');
+                        rulebookModal?.classList.remove('active');
+                        fenOverlay?.classList.remove('active');
+
+                        break;
+                }
+            });
 
             if (resignBtn) resignBtn.onclick = () => {
                 if (!gameOver && !paused) {
@@ -2125,6 +2183,7 @@ if (leaveConfirmYes) leaveConfirmYes.addEventListener('click', () => {
 if (leaveConfirmNo) leaveConfirmNo.addEventListener('click', () => {
     leaveConfirmOverlay.style.display = 'none';
 });
+
             
             function showAssetWarning() {
                 const t = document.getElementById('confirmTimerContainer');

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1879,62 +1879,6 @@
             if (pauseBtn) pauseBtn.onclick = () => paused ? resumeGame() : pauseGame();
             if (muteBtn) muteBtn.onclick = toggleMute;
             if (flipBtn) flipBtn.onclick = toggleBoardOrientation;
-            document.addEventListener('keydown', (e) => {
-                const tag = e.target.tagName;
-                if (
-                    tag === 'INPUT' ||
-                    tag === 'TEXTAREA' ||
-                    e.target.isContentEditable ||
-                    e.repeat
-                ) {
-                    return;
-                }
-
-                const key = e.key.toLowerCase();
-
-
-                switch (key) {
-                    case 'f':
-                        e.preventDefault();
-                        flipBtn?.click();
-                        break;
-
-                    case 'p':
-                        e.preventDefault();
-                        pauseBtn?.click();
-                        break;
-
-                    case 'r':
-                        e.preventDefault();
-                        resignBtn?.click();
-                        break;
-
-                    case 'd':
-                        e.preventDefault();
-                        if (gameMode === 'pvp') {
-                            drawBtn?.click();
-                        }
-                        break;
-
-                    case 'n':
-                        e.preventDefault();
-                        newPvPBtn?.click();
-                        break;
-
-                    case 'a':
-                        e.preventDefault();
-                        newAIBtn?.click();
-                        break;
-
-                   case 'escape':
-                        e.preventDefault();
-                        shareModal?.classList.remove('active');
-                        rulebookModal?.classList.remove('active');
-                        fenOverlay?.classList.remove('active');
-
-                        break;
-                }
-            });
 
             if (resignBtn) resignBtn.onclick = () => {
                 if (!gameOver && !paused) {
@@ -2124,7 +2068,29 @@
                 } else if (key === 'p' && pauseBtn && pauseBtn.style.display !== 'none') {
                     e.preventDefault();
                     pauseBtn.click();
-                }// added pause/resume button shortcut
+                } else if (key === 'n' && newPvPBtn) {
+                    e.preventDefault();
+                    newPvPBtn.click();
+
+                } else if (key === 'a' && newAIBtn) {
+                    e.preventDefault();
+                    newAIBtn.click();
+
+                } else if (key === 'escape') {
+                    e.preventDefault();
+
+                    if (shareModal?.style.display === 'flex') {
+                        shareModal.style.display = 'none';
+                    }
+
+                    if (rulebookModal?.style.display === 'flex') {
+                        rulebookModal.style.display = 'none';
+                    }
+
+                    if (fenOverlay?.classList.contains('active')) {
+                        fenOverlay.classList.remove('active');
+                    }
+                }
             });
             // Emote Logic
             let emoteCooldown = false;

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -319,7 +319,14 @@
                         onclick="document.getElementById('rulebookModal').style.display='flex'">📖 Rulebook</button>
                 </div>
                 <div class="keyboard-hints" style="font-size: 0.8rem; color: #888; margin-top: 8px;">
-                    ⌨️ Shortcuts: <kbd>F</kbd> Flip &nbsp; <kbd>R</kbd> Resign &nbsp; <kbd>D</kbd> Draw &nbsp; <kbd>P</kbd> Pause
+                    ⌨️ Shortcuts:
+                    <kbd>F</kbd> Flip &nbsp;
+                    <kbd>R</kbd> Resign &nbsp;
+                    <kbd>D</kbd> Draw &nbsp;
+                    <kbd>P</kbd> Pause &nbsp;
+                    <kbd>N</kbd> New PvP &nbsp;
+                    <kbd>A</kbd> AI Game &nbsp;
+                    <kbd>Esc</kbd> Close Modals
                 </div>
                 <a href="/" class="btn" 
    style="background: #2a1414; color: #ff6b6b;margin-top: 1rem;margin-bottom: 1.5rem; border: 1px solid #632424; text-decoration: none; text-align: center; display: block; line-height: 2.5;">


### PR DESCRIPTION
## Description

Adds keyboard shortcuts for common game controls to improve accessibility and gameplay efficiency.

### Added Shortcuts

* `F` → Flip board
* `P` → Pause/Resume game
* `R` → Resign game
* `D` → Offer draw (PvP only)
* `N` → Start new PvP game
* `A` → Start AI game
* `Esc` → Close active modals

The implementation extends the existing keyboard shortcut handler and reuses existing button actions to keep the codebase maintainable and consistent.

## Type of Change

* [ ] Bug fix (non-breaking change that fixes an issue)
* [x] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Documentation update

## Related Issue

Fixes #991 

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [ ] I have commented my code where necessary
* [ ] I have updated the documentation if needed
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix/feature works
* [x] New and existing tests pass locally

## Screenshots (if applicable)

N/A

## Additional Notes

* Prevented repeated key firing using `e.repeat`
* Ignored shortcuts while typing in input fields
* Reused existing button handlers instead of duplicating logic
* Added modal closing support for the Escape key
