### PR TITLE
fix: replace broken Back to Home link and add logout button on stats page

### DIFF
--- a/game/templates/game/stats.html
+++ b/game/templates/game/stats.html
@@ -19,12 +19,26 @@
         a { color: #f0c040; text-decoration: none; }
         a:hover { text-decoration: underline; }
         .back { text-align: center; margin-top: 30px; }
+        .nav-bar { display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px; flex-wrap: wrap; gap: 10px; }
+        .btn { display: inline-block; padding: 10px 20px; border-radius: 8px; font-weight: bold; cursor: pointer; text-decoration: none; border: none; font-size: 14px; }
+        .btn-gold { background: #f0c040; color: #0f0f1a; }
+        .btn-gold:hover { background: #e0b030; text-decoration: none; }
+        .btn-outline { background: transparent; color: #f0c040; border: 1px solid #f0c040; }
+        .btn-outline:hover { background: #f0c040; color: #0f0f1a; text-decoration: none; }
+        .btn-danger { background: transparent; color: #e57373; border: 1px solid #e57373; }
+        .btn-danger:hover { background: #e57373; color: #fff; text-decoration: none; }
     </style>
 </head>
 <body>
-    <div style="margin-bottom: 20px;">
-        <a href="/" class="back-btn">← Back to Home</a>
+    <!-- FIX #980: replaced hardcoded href="/" with proper navigation -->
+    <div class="nav-bar">
+        <a href="{% url 'index' %}" class="btn btn-gold">← Back to Game</a>
+        <form method="POST" action="{% url 'logout' %}" style="margin: 0;">
+            {% csrf_token %}
+            <button type="submit" class="btn btn-danger">Log Out</button>
+        </form>
     </div>
+
     <h1>CHECK<span>ORA</span> &mdash; Game Statistics</h1>
 
     <h2>AI Game Summary</h2>


### PR DESCRIPTION
Fixes #980

## Problem
The stats page had a hardcoded `href="/"` that sent logged-in users to the landing page instead of the game board. There was also no logout button, forcing users to navigate elsewhere to log out.

## Fix
- Replaced `href="/"` with `{% url 'index' %}` so the link goes directly to the game board
- Renamed the link to **"← Back to Game"** for clarity
- Added a **Log Out** button using `{% url 'logout' %}` with CSRF token
- Added a clean flex nav-bar layout at the top of the page

## File Changed
- `game/templates/game/stats.html`