### PR TITLE
fix: display masked recipient email on OTP verification page

### DIFF
--- a/game/templates/game/verify_otp.html
+++ b/game/templates/game/verify_otp.html
@@ -48,8 +48,7 @@
 
     <div class="header">
         <h1>Verify your Email</h1>
-        <p>We've sent a 6-digit code to your email address.</p>
-    </div>
+        <p>We've sent a 6-digit code to {% if masked_email %}<strong>{{ masked_email }}</strong>{% else %}your email address{% endif %}.</p>    </div>
 
     <div class="auth-card">
         <form method="POST">

--- a/game/views.py
+++ b/game/views.py
@@ -628,7 +628,21 @@ def verify_otp(request):
     if last_otp_time:
         elapsed = int(time.time() - last_otp_time)
         remaining_time = max(0, 60 - elapsed)
-    return render(request, 'game/verify_otp.html', {'remaining_time': remaining_time})
+
+    masked_email = None
+    try:
+        user = User.objects.get(id=user_id)
+        email = user.email
+        local, domain = email.split('@')
+        masked_local = local[0] + '*' * (len(local) - 1)
+        masked_email = f"{masked_local}@{domain}"
+    except Exception:
+        pass
+
+    return render(request, 'game/verify_otp.html', {
+        'remaining_time': remaining_time,
+        'masked_email': masked_email,
+    })
 
 def resend_otp(request):
     user_id = request.session.get('registration_user_id')


### PR DESCRIPTION
## Description

Improves the OTP verification page UX by displaying the masked recipient email address so users know which email to check for the code.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

Fixes #(issue number)
Fixes #958

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

## Screenshots (if applicable)

Not applicable — no visual screenshot available locally, but the change updates the subtitle text from:
"We've sent a 6-digit code to your email address."
to:
"We've sent a 6-digit code to j***@gmail.com."
## Additional Notes

Any additional information reviewers should know.
The email is masked using the format first_character + asterisks + @ + domain 
to protect privacy while still being helpful to the user.