### PR TITLE
Fix duplicate password visibility toggle on registration page

### DIFF
--- a/game/templates/game/register.html
+++ b/game/templates/game/register.html
@@ -59,46 +59,6 @@
     <script src="{% static 'game/js/auth.js' %}?v=7"></script>
       <script src="{% static 'game/js/toast.js' %}"></script>
     <script>
-
-    // Add eye toggle to password fields
-    document.querySelectorAll('input[type="password"]').forEach(input => {
-        const wrapper = document.createElement('div');
-        wrapper.style.cssText = 'position: relative;';
-        input.parentNode.insertBefore(wrapper, input);
-        wrapper.appendChild(input);
-
-        const eye = document.createElement('button');
-eye.type = 'button';
-eye.setAttribute('aria-label', 'Show password');
-
-eye.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path><circle cx="12" cy="12" r="3"></circle></svg>`;
-
-eye.style.cssText = `
-    position: absolute;
-    right: 12px;
-    top: 50%;
-    transform: translateY(-50%);
-    cursor: pointer;
-    color: rgba(255,255,255,0.5);
-    font-size: 16px;
-    user-select: none;
-    background: transparent;
-    border: none;
-        `;
-        eye.addEventListener('click', () => {
-    if (input.type === 'password') {
-        input.type = 'text';
-        eye.setAttribute('aria-label', 'Hide password');
-        eye.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path><line x1="1" y1="1" x2="23" y2="23"></line></svg>`;
-    } else {
-        input.type = 'password';
-        eye.setAttribute('aria-label', 'Show password');
-        eye.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path><circle cx="12" cy="12" r="3"></circle></svg>`;
-    }
-});
-        wrapper.appendChild(eye);
-    });
-        
         const usernameInput = document.querySelector('#id_username');
         const checkUsernameUrl = "{% url 'check_username' %}";
 


### PR DESCRIPTION
## Description

Fixes duplicate password visibility toggle icons on the registration page.

The issue occurred because password toggle logic was implemented both in `auth.js` and inline within `register.html`, causing two eye icons to appear after entering a valid password. This PR removes the duplicate inline implementation and keeps `auth.js` as the single source of truth for password visibility toggling.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #957 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

<img width="761" height="705" alt="Screenshot 2026-05-22 at 6 54 14 PM" src="https://github.com/user-attachments/assets/6073d024-6769-4256-8c47-d95afc64d2cf" />


Before: Duplicate password visibility toggle icons appearing on registration page.

After: Only a single password visibility toggle icon is displayed as expected.

## Additional Notes

This was a frontend UI bug caused by duplicate password toggle rendering logic. The fix simplifies maintenance by keeping password toggle behavior centralized in `auth.js`.
