### PR TITLE
Fix OTP verification UX by displaying masked recipient email

### DIFF
--- a/game/templates/game/verify_otp.html
+++ b/game/templates/game/verify_otp.html
@@ -48,7 +48,7 @@
 
     <div class="header">
         <h1>Verify your Email</h1>
-        <p>We've sent a 6-digit code to your email address.</p>
+        <p>We've sent a 6-digit code to {{ user_email|default:"your email address" }}.</p>
     </div>
 
     <div class="auth-card">
@@ -74,7 +74,7 @@
         </div>
     </div>
 <script>
-    let remainingTime = {{ remaining_time|default:0 }};
+    let remainingTime = Number("{{ remaining_time|default:'0' }}");
     const resendLink = document.getElementById("resend-link");
     const timer = document.getElementById("timer");
 

--- a/game/templates/game/verify_otp.html
+++ b/game/templates/game/verify_otp.html
@@ -70,13 +70,13 @@
         <div class="auth-footer">
             Didn't receive the code? 
             <a href="{% url 'resend_otp' %}" id = "resend-link">Try again</a>
-            <span id="timer"></span>
+            <span id="timer" data-remaining-time="{{ remaining_time|default:0 }}"></span>
         </div>
     </div>
 <script>
-    let remainingTime = Number("{{ remaining_time|default:'0' }}");
     const resendLink = document.getElementById("resend-link");
     const timer = document.getElementById("timer");
+    let remainingTime = parseInt(timer.dataset.remainingTime || "0", 10);
 
     function updateTimer() {
         if (remainingTime > 0) {

--- a/game/views.py
+++ b/game/views.py
@@ -597,8 +597,10 @@ def verify_otp(request):
 
     if request.method == 'POST':
         entered_otp = request.POST.get('otp', '').strip()
-        # Verify hash
-        entered_otp_hash = hashlib.sha256(f"{entered_otp}:{settings.SECRET_KEY}".encode()).hexdigest()
+
+        entered_otp_hash = hashlib.sha256(
+            f"{entered_otp}:{settings.SECRET_KEY}".encode()
+        ).hexdigest()
 
         if entered_otp_hash == stored_otp_hash:
             try:
@@ -606,29 +608,56 @@ def verify_otp(request):
                 user.is_active = True
                 user.save()
 
-                # Clear session data
                 del request.session['registration_user_id']
                 del request.session['registration_otp_hash']
 
                 login(request, user)
-                messages.success(request, 'Registration successful! Welcome to Checkora.')
+                messages.success(
+                    request,
+                    'Registration successful! Welcome to Checkora.'
+                )
                 request.session.cycle_key()
                 return redirect('index')
 
             except User.DoesNotExist:
                 messages.error(
-                    request, 'User not found. Please register again.'
+                    request,
+                    'User not found. Please register again.'
                 )
                 return redirect('register')
+
         else:
             messages.error(request, 'Invalid OTP. Please try again.')
 
     remaining_time = 0
     last_otp_time = request.session.get('last_otp_time')
+
     if last_otp_time:
         elapsed = int(time.time() - last_otp_time)
         remaining_time = max(0, 60 - elapsed)
-    return render(request, 'game/verify_otp.html', {'remaining_time': remaining_time})
+
+    try:
+        user = User.objects.get(id=user_id)
+        email = user.email
+
+        if email and '@' in email:
+            name, domain = email.split('@', 1)
+            masked_name = name[:2] + '*' * max(len(name) - 2, 0)
+            user_email = f"{masked_name}@{domain}"
+        else:
+            user_email = None
+
+    except User.DoesNotExist:
+        user_email = None
+
+    return render(
+        request,
+        'game/verify_otp.html',
+        {
+            'remaining_time': remaining_time,
+            'user_email': user_email,
+        }
+    )
 
 def resend_otp(request):
     user_id = request.session.get('registration_user_id')

--- a/game/views.py
+++ b/game/views.py
@@ -606,6 +606,7 @@ def verify_otp(request):
             try:
                 user = User.objects.get(id=user_id)
                 user.is_active = True
+                user.full_clean()
                 user.save()
 
                 del request.session['registration_user_id']
@@ -642,7 +643,10 @@ def verify_otp(request):
 
         if email and '@' in email:
             name, domain = email.split('@', 1)
-            masked_name = name[:2] + '*' * max(len(name) - 2, 0)
+            if len(name) <= 2:
+                masked_name = name[:1]
+            else:
+                masked_name = name[:2] + '*' * (len(name) - 2)
             user_email = f"{masked_name}@{domain}"
         else:
             user_email = None


### PR DESCRIPTION
## Description

This PR improves the OTP verification user experience by replacing the generic email placeholder text with the registered user's masked email address.

changes made :
1. Retrieved the registered user's email in the `verify_otp` view using the session user ID
2. Added masking logic to protect user privacy while still showing the recipient email
3. Passed the masked email to the OTP verification template context
4. Updated the OTP verification page to dynamically display the masked email instead of generic text
5. Verified resend OTP, invalid OTP handling, and countdown timer behavior after the change

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #958 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshot attached

<img width="1280" height="706" alt="image" src="https://github.com/user-attachments/assets/86a7a313-8351-4b3a-abea-cbcde5a4175b" />

Added screenshots showing:
1. OTP verification page displaying masked email
2. Resend OTP working correctly
3. Invalid OTP error message display

## Additional Notes

The email is masked intentionally to improve UX while maintaining user privacy.
