### PR TITLE
put a 'resume to continue' message on the board

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -338,6 +338,7 @@ body {
     box-shadow: 0 8px 40px rgba(0, 0, 0, 0.6);
     max-width: 100%;
     box-sizing: content-box;
+    position: relative;
 }
 
 /* ============================================================
@@ -1416,7 +1417,32 @@ body {
 
 /* ================= PAUSE STATE ================= */
 .chessboard.paused {
+    pointer-events: none;
+}
+
+/* Blur squares only — not ::after, so the pause label stays sharp */
+.chessboard.paused .square {
     filter: blur(15px);
+}
+
+.chessboard.paused::after {
+    content: "Resume to Continue";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: rgba(0, 0, 0, 0.85);
+    color: #f0c040;
+    padding: 20px 40px;
+    border-radius: 12px;
+    font-size: 1.5rem;
+    font-weight: 600;
+    letter-spacing: 1px;
+    white-space: nowrap;
+    border: 2px solid #f0c040;
+    z-index: 9999;
+    box-shadow: 0 8px 32px rgba(240, 192, 64, 0.4);
+    filter: none;
     pointer-events: none;
 }
 


### PR DESCRIPTION
## Description

Improved the paused game UI by adding a centered overlay message on the blurred chess board. This enhancement provides clearer visual feedback to users when the game is paused and improves the overall user experience.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [x] New feature (non-breaking change that adds functionality) feature that would cause existing functionality to change)

## Related Issue

Fixes #1009 

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] I have commented my code where necessary
* [x] I have updated the documentation if needed
* [x] My changes generate no new warnings
* [x] New and existing tests pass locally

## Screenshots (if applicable)

Before 

<img width="1417" height="993" alt="image" src="https://github.com/user-attachments/assets/c016d608-cd9e-4720-bc74-75fd60887be8" />

After

<img width="1300" height="983" alt="image" src="https://github.com/user-attachments/assets/8b8ffc0b-6366-4748-a438-5d86e67d75f4" />


## Additional Notes

This update improves accessibility and user understanding of the current game state without affecting existing gameplay functionality.
