### PR TITLE
fix: add JSON decode error handling in new_game and set_pause

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -122,7 +122,11 @@ def valid_moves(request):
 @require_POST
 def new_game(request):
     """Reset the game to the initial position with selected mode."""
-    data = json.loads(request.body or '{}')
+    try:
+        data = json.loads(request.body or '{}')
+    except json.JSONDecodeError:
+        return JsonResponse({'valid': False, 'message': 'Invalid request data.'}, status=400)
+    
     mode = data.get('mode', 'pvp')
     difficulty = data.get('difficulty', 'medium')
     fen = data.get('fen')
@@ -298,7 +302,11 @@ def set_pause(request):
     if not game_data:
         return JsonResponse({'paused': False})
 
-    data = json.loads(request.body or '{}')
+    try:
+        data = json.loads(request.body or '{}')
+    except json.JSONDecodeError:
+        return JsonResponse({'valid': False, 'message': 'Invalid request data.'}, status=400)
+
     pause = data.get('pause', True)
 
     game = ChessGame.from_dict(game_data)


### PR DESCRIPTION
## Description
Added try/except JSON decode error handling to new_game and 
set_pause endpoints. Previously malformed JSON would cause 
an unhandled exception and return a 500 error. Now returns 
a clean 400 response with an error message.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issue
Fixes #1039
Fixes #1040

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

## Screenshots (if applicable)
N/A

## Additional Notes
The make_move endpoint already handles this correctly with 
try/except. This fix applies the same pattern to new_game 
and set_pause for consistency.