### PR TITLE
fix: remove duplicate landing hero section

### DIFF
--- a/game/templates/game/landing.html
+++ b/game/templates/game/landing.html
@@ -111,16 +111,6 @@
     </nav>
 
     <main class="hero" id="hero">
-      <h1 class="hero-title">
-        Master Chess with Checkora's Hybrid Intelligence
-      </h1>
-      <p class="hero-subtitle">
-        A lightweight Django frontend orchestrating Python logic with a
-        high-performance C++ minimax engine.
-      </p>
-      <div class="hero-actions">
-        <a href="{% url 'index' %}" class="btn-primary">Start Game</a>
-        <a href="#features" class="btn-secondary">Learn More</a>
       <div class="ambient-glow glow-gold"></div>
       <div class="ambient-glow glow-blue"></div>
 


### PR DESCRIPTION
##issue1052

## Description

This PR removes the duplicate hero content rendering on the landing page.

### Changes Made

* Removed the extra hero title, subtitle, and CTA section from `landing.html`
* Fixed the hero section structure by keeping only the intended modern hero layout
* Prevented overlapping/duplicated rendering on the landing page

### Result

* Only one hero section is displayed
* CTA buttons render correctly
* Layout appears centered and consistent

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update

## Checklist

* [x] Code follows project structure
* [x] Self-review completed
* [x] No unrelated files modified

## Preview::
<img width="1907" height="913" alt="image" src="https://github.com/user-attachments/assets/c5966f2e-79ba-4fc3-9f14-285c918684ef" />
<img width="1904" height="904" alt="image" src="https://github.com/user-attachments/assets/c3090b43-a183-4d2a-9997-21aa9b880632" />

