### PR TITLE
ui: fix chessboard border alignment

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -339,7 +339,8 @@ body {
     border-radius: 2px;
     box-shadow: 0 8px 40px rgba(0, 0, 0, 0.6);
     max-width: 100%;
-    box-sizing: content-box;
+    box-sizing: border-box;
+    overflow: hidden;
     position: relative;
 }
 


### PR DESCRIPTION
## Summary\n- make the chessboard use border-box sizing so its declared board size includes the frame\n- clip board contents to the frame so squares meet the border cleanly at every edge and corner\n- keep the existing square-size variables intact for desktop and mobile layouts\n\nFixes #1066\n\n## Validation\n- `git diff --check`\n- `python3 manage.py check` could not run because Django is not installed in this local environment