### PR TITLE
fix: prevent stats page database errors from returning 500

### DIFF
--- a/game/templates/game/stats.html
+++ b/game/templates/game/stats.html
@@ -28,6 +28,11 @@
     <h1>CHECK<span>ORA</span> &mdash; Game Statistics</h1>
 
     <h2>AI Game Summary</h2>
+    {% if stats_error %}
+    <div class="empty">
+        <p>{{ stats_error }}</p>
+    </div>
+    {% endif %}
     <div class="summary">
         <div class="card"><div class="num">{{ ai_total }}</div><div class="label">Total AI Games</div></div>
         <div class="card"><div class="num">{{ user_ai_wins }}</div><div class="label">User Wins vs AI</div></div>

--- a/game/tests.py
+++ b/game/tests.py
@@ -7,6 +7,7 @@ from unittest import mock
 
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.db import DatabaseError
 from django.urls import reverse
 from django.test import SimpleTestCase, TestCase, override_settings
 
@@ -1020,6 +1021,20 @@ class StatsCleanupTest(TestCase):
         response = self.client.get('/stats/')
         self.assertNotContains(response, 'Checkmate')
         self.assertContains(response, 'No games played yet.')
+
+    def test_stats_database_error_renders_fallback(self):
+        """Stats page should render a safe fallback instead of a 500."""
+        self.client.login(username='usera', password='password123')
+
+        with mock.patch(
+            'game.views.GameResult.objects.filter',
+            side_effect=DatabaseError('stats query failed'),
+        ):
+            response = self.client.get('/stats/')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Stats are temporarily unavailable.')
+        self.assertContains(response, '<div class="num">0</div>', count=4)
 
 class StaleGameCleanupTest(TestCase):
     def setUp(self):

--- a/game/views.py
+++ b/game/views.py
@@ -16,6 +16,7 @@ from django.contrib.auth.forms import AuthenticationForm
 from smtplib import SMTPException
 from django.core.mail import BadHeaderError, send_mail
 from django.contrib import messages
+from django.db import DatabaseError
 from django.db.models import F, Q
 from .forms import CustomUserCreationForm
 from django.views.decorators.csrf import ensure_csrf_cookie, csrf_exempt
@@ -752,29 +753,51 @@ def logout_view(request):
 
 
 # Protect the stats page with login requirement
+def _empty_stats_context(error_message=None):
+    return {
+        'recent': [],
+        'ai_total': 0,
+        'user_ai_wins': 0,
+        'ai_wins': 0,
+        'ai_draws': 0,
+        'win_percentage': 0,
+        'stats_error': error_message,
+    }
+
+
 @login_required
 def stats_view(request):
     """Display game statistics."""
-    # Only show real database records linked to the logged-in user
-    user_results = GameResult.objects.filter(
-        user=request.user
-    ).exclude(mode__in=['', None])
+    try:
+        # Only show real database records linked to the logged-in user.
+        user_results = GameResult.objects.filter(
+            user=request.user
+        ).exclude(mode__in=['', None])
 
-    recent = user_results.order_by('-played_at')[:20]
-    ai_results = user_results.filter(mode='ai')
+        recent = user_results.order_by('-played_at')[:20]
+        ai_results = user_results.filter(mode='ai')
 
-    # If winner == player_color, the user won
-    user_ai_wins = ai_results.filter(winner=F('player_color')).count()
-    # If winner != player_color and not a draw, the AI won
-    ai_wins = ai_results.filter(
-        Q(winner='white', player_color='black') |
-        Q(winner='black', player_color='white')
-    ).count()
+        # If winner == player_color, the user won.
+        user_ai_wins = ai_results.filter(winner=F('player_color')).count()
+        # If winner != player_color and not a draw, the AI won.
+        ai_wins = ai_results.filter(
+            Q(winner='white', player_color='black') |
+            Q(winner='black', player_color='white')
+        ).count()
 
-    ai_draws = ai_results.filter(winner='draw').count()
-    ai_total = ai_results.count()
+        ai_draws = ai_results.filter(winner='draw').count()
+        ai_total = ai_results.count()
+    except DatabaseError:
+        logger.exception('Failed to load stats for user_id=%s', request.user.id)
+        return render(
+            request,
+            'game/stats.html',
+            _empty_stats_context(
+                'Stats are temporarily unavailable. Please try again later.'
+            ),
+        )
 
-    # Handle explicit edge cases (e.g. division by zero for win rate)
+    # Handle explicit edge cases (e.g. division by zero for win rate).
     win_percentage = (user_ai_wins / ai_total * 100) if ai_total > 0 else 0
 
     return render(request, 'game/stats.html', {
@@ -784,6 +807,7 @@ def stats_view(request):
         'ai_wins': ai_wins,
         'ai_draws': ai_draws,
         'win_percentage': round(win_percentage, 2),
+        'stats_error': None,
     })
 
 @csrf_exempt


### PR DESCRIPTION
## Summary
- catch stats database failures and render a safe fallback instead of the generic 500 page
- keep the exception logged for debugging while showing zeroed summary cards to the user
- add regression coverage for the database-error path

Closes #1058

## Validation
- /tmp/checkora-stats-py312/bin/python manage.py test game.tests.StatsCleanupTest -v 2
- /tmp/checkora-stats-py312/bin/python -m py_compile game/views.py game/tests.py
- /tmp/checkora-stats-py312/bin/python -m flake8 game/views.py game/tests.py --select=E9,F63,F7,F82
- /tmp/checkora-stats-py312/bin/python manage.py check
- git diff --check