### PR TITLE
Add square highlight annotations using right-click interaction

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -449,6 +449,13 @@ body {
 /* Last-move highlight */
 .square.last-move.light { background-color: var(--sq-last-light); }
 .square.last-move.dark  { background-color: var(--sq-last-dark); }
+.custom-highlight.light {
+    background-color: rgba(80, 180, 255, 0.45) !important;
+}
+
+.custom-highlight.dark {
+    background-color: rgba(40, 120, 220, 0.55) !important;
+}
 
 .square.premove.light {
     background-color: rgba(255, 80, 80, 0.45);

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -24,7 +24,7 @@
             let hints = [];
             let lastMove = null;
             let premove = null;
-            let highlightedSquares = null;
+            let highlightedSquare = null;
 
             let dragging = false;
             let dragSrc = null;

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -24,6 +24,7 @@
             let hints = [];
             let lastMove = null;
             let premove = null;
+            let highlightedSquares = [];
 
             let dragging = false;
             let dragSrc = null;
@@ -530,6 +531,10 @@
                         d.dataset.r = r;
                         d.dataset.c = c;
                         d.onclick = () => onClick(r, c);
+                        d.oncontextmenu = (e) => {
+                            e.preventDefault();
+                            toggleSquareHighlight(r, c);
+                        };
                         d.ondragover = e => e.preventDefault();
                         d.ondrop = e => onDrop(e, r, c);
 
@@ -623,7 +628,7 @@
 
             function refreshHighlights() {
                 boardEl.querySelectorAll('.square').forEach(el => {
-                    el.classList.remove('selected', 'last-move', 'in-check');
+                    el.classList.remove('selected', 'last-move', 'in-check', 'custom-highlight');
                     el.querySelectorAll('.move-dot, .capture-ring').forEach(n => n.remove());
                 });
 
@@ -631,7 +636,9 @@
                     sq(lastMove.from[0], lastMove.from[1]).classList.add('last-move');
                     sq(lastMove.to[0], lastMove.to[1]).classList.add('last-move');
                 }
-
+                highlightedSquares.forEach(h => {
+                    sq(h.r, h.c).classList.add('custom-highlight');
+                });
                 if (selected) {
                     sq(selected.r, selected.c).classList.add('selected');
                     hints.forEach(h => {
@@ -742,7 +749,26 @@
 
                 refreshHighlights();
             }
+            function toggleSquareHighlight(r, c) {
+                const cell = sq(r, c);
 
+                const alreadyHighlighted =
+                    highlightedSquares.length &&
+                    highlightedSquares[0].r === r &&
+                    highlightedSquares[0].c === c;
+
+                // remove old highlights
+                highlightedSquares.forEach(h => {
+                    sq(h.r, h.c).classList.remove('custom-highlight');
+                });
+
+                if (alreadyHighlighted) {
+                    highlightedSquares = [];
+                } else {
+                    highlightedSquares = [{ r, c }];
+                    cell.classList.add('custom-highlight');
+                }
+            }
             function deselect() {
                 selected = null;
                 hints = [];

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -24,7 +24,7 @@
             let hints = [];
             let lastMove = null;
             let premove = null;
-            let highlightedSquares = [];
+            let highlightedSquares = null;
 
             let dragging = false;
             let dragSrc = null;
@@ -533,6 +533,7 @@
                         d.onclick = () => onClick(r, c);
                         d.oncontextmenu = (e) => {
                             e.preventDefault();
+                            e.stopPropagation();
                             toggleSquareHighlight(r, c);
                         };
                         d.ondragover = e => e.preventDefault();
@@ -636,9 +637,10 @@
                     sq(lastMove.from[0], lastMove.from[1]).classList.add('last-move');
                     sq(lastMove.to[0], lastMove.to[1]).classList.add('last-move');
                 }
-                highlightedSquares.forEach(h => {
-                    sq(h.r, h.c).classList.add('custom-highlight');
-                });
+                if (highlightedSquare) {
+                    sq(highlightedSquare.r, highlightedSquare.c)
+                        .classList.add('custom-highlight');
+                }
                 if (selected) {
                     sq(selected.r, selected.c).classList.add('selected');
                     hints.forEach(h => {
@@ -750,23 +752,20 @@
                 refreshHighlights();
             }
             function toggleSquareHighlight(r, c) {
-                const cell = sq(r, c);
+                if (highlightedSquare) {
+                    sq(highlightedSquare.r, highlightedSquare.c)
+                        .classList.remove('custom-highlight');
+                }
 
-                const alreadyHighlighted =
-                    highlightedSquares.length &&
-                    highlightedSquares[0].r === r &&
-                    highlightedSquares[0].c === c;
-
-                // remove old highlights
-                highlightedSquares.forEach(h => {
-                    sq(h.r, h.c).classList.remove('custom-highlight');
-                });
-
-                if (alreadyHighlighted) {
-                    highlightedSquares = [];
+                if (
+                    highlightedSquare &&
+                    highlightedSquare.r === r &&
+                    highlightedSquare.c === c
+                ) {
+                    highlightedSquare = null;
                 } else {
-                    highlightedSquares = [{ r, c }];
-                    cell.classList.add('custom-highlight');
+                    highlightedSquare = { r, c };
+                    sq(r, c).classList.add('custom-highlight');
                 }
             }
             function deselect() {


### PR DESCRIPTION
## Description

This PR adds interactive square highlighting support to improve gameplay analysis and board planning experience.

Users can now right-click on board squares to toggle visual highlights directly during gameplay.

## Type of Change

* [x] New feature (non-breaking change that adds functionality)

## Related Issue

Fixes #1033

## Changes Made

* Added right-click square highlight interaction
* Added toggle-based square annotation system
* Prevented browser context menu on board interaction
* Added custom highlight rendering for both light and dark squares
* Improved visual clarity for board planning and analysis

## Benefits

* Better gameplay analysis experience
* Improved tactical planning visibility
* More interactive and professional board interaction
* Enhanced overall chess UX

## Testing

* Verified right-click highlighting works correctly
* Verified highlight toggling works properly
* Verified normal move interactions remain unaffected
* Tested on both light and dark board squares

## Screenshots
<img width="639" height="664" alt="image" src="https://github.com/user-attachments/assets/991b66be-67b0-48d6-936e-fd3b5d5fa7d5" />

## Additional Notes

This PR introduces the initial annotation system foundation, which can later be extended to support advanced features such as move arrows and multi-color annotations.
