### PR TITLE
ci: use psycopg2 source package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,11 @@ jobs:
           restore-keys: |
             pip-test-${{ runner.os }}-
 
+      - name: 🐘 Install PostgreSQL build headers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpq-dev
+
       - name: 📥 Install project dependencies
         run: |
           pip install --upgrade pip
@@ -216,6 +221,11 @@ jobs:
           restore-keys: |
             pip-migrate-${{ runner.os }}-
 
+      - name: 🐘 Install PostgreSQL build headers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpq-dev
+
       - name: 📥 Install dependencies
         run: |
           pip install --upgrade pip
@@ -252,6 +262,11 @@ jobs:
           key: pip-audit-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
           restore-keys: |
             pip-audit-${{ runner.os }}-
+
+      - name: 🐘 Install PostgreSQL build headers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpq-dev
 
       - name: 📥 Install pip-audit
         run: pip install pip-audit
@@ -345,6 +360,11 @@ jobs:
           key: pip-selenium-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
           restore-keys: |
             pip-selenium-${{ runner.os }}-
+
+      - name: 🐘 Install PostgreSQL build headers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpq-dev
 
       - name: 📥 Install dependencies
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 django>=6.0,<7.0
 dj-database-url>=2.1.0
-psycopg2>=2.9.9
+psycopg2==2.9.9
 python-dotenv>=1.0.0
 whitenoise>=6.6.0
 flake8>=7.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 django>=6.0,<7.0
 dj-database-url>=2.1.0
-psycopg2-binary>=2.9.9
+psycopg2>=2.9.9
 python-dotenv>=1.0.0
 whitenoise>=6.6.0
 flake8>=7.0.0


### PR DESCRIPTION
## Summary
- replace the production dependency `psycopg2-binary` with `psycopg2` in `requirements.txt`
- install `libpq-dev` in CI jobs that install project requirements so source builds have `pg_config` available

Fixes #1046

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'ci yaml parsed'"`
- `rg -n "psycopg2|libpq-dev|PostgreSQL build" requirements.txt .github/workflows/ci.yml`
- `git diff --check`

Note: a local source-build smoke check failed before the workflow update because this machine does not have `pg_config`; the CI header install is included to provide that tool on Ubuntu runners.

Suggested labels from the issue: `GSSoC`, `bug`.