### PR TITLE
Fix column label alignment below chessboard squares

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -1281,7 +1281,8 @@ body {
     }
 
     .files {
-        padding-left: 18px;
+        padding-left: 0px;
+        justify-content: space-evenly;
     }
 
     .files span,


### PR DESCRIPTION
## Description
Fixed the alignment of chessboard column labels below the board squares.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issue
Fixes #1057

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally

## Screenshots
Added before/after alignment fixes for the chessboard labels.