### PR TITLE
fix: Record GameResult when a player's clock expires on timeout

### DIFF
--- a/game/tests.py
+++ b/game/tests.py
@@ -2,6 +2,7 @@
 
 import json
 import sys
+import time
 from smtplib import SMTPException
 from unittest import mock
 
@@ -1338,3 +1339,101 @@ class InsufficientMaterialDrawTest(TestCase):
         with mock.patch.object(game, '_call_engine', return_value="STATUS DRAW"):
             status = game.check_game_status()
             self.assertEqual(status, 'draw')
+
+
+class TimeoutResultRecordingTest(TestCase):
+    """A GameResult row must be persisted to the database when a player's clock expires."""
+
+    def _make_timed_out_session(self, timed_out_side='white', mode='pvp'):
+        """Return a serialised game dict whose active side is about to time out."""
+        game = ChessGame()
+        game.mode = mode
+        game.player_color = 'white'
+        game.paused = False
+        if timed_out_side == 'white':
+            game.white_time = 1
+            game.current_turn = 'white'
+        else:
+            game.black_time = 1
+            game.current_turn = 'black'
+        game.last_ts = time.time() - 10
+        return game.to_dict()
+
+    def _post_move(self, from_row, from_col, to_row, to_col):
+        return self.client.post(
+            '/api/move/',
+            data=json.dumps({
+                'from_row': from_row,
+                'from_col': from_col,
+                'to_row': to_row,
+                'to_col': to_col,
+            }),
+            content_type='application/json',
+        )
+
+    def test_white_timeout_creates_result_with_black_as_winner(self):
+        """When white's clock expires, a GameResult with winner='black' must be saved."""
+        from .models import GameResult
+        session = self.client.session
+        session['game'] = self._make_timed_out_session('white')
+        session.save()
+
+        with mock.patch.object(ChessGame, 'validate_move', return_value=(True, 'Valid move.')):
+            response = self._post_move(6, 4, 4, 4)
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['game_status'], 'timeout')
+
+        result = GameResult.objects.filter(end_reason='timeout').first()
+        self.assertIsNotNone(result, 'A GameResult row must be created when white times out.')
+        self.assertEqual(result.winner, 'black')
+        self.assertEqual(result.end_reason, 'timeout')
+
+    def test_black_timeout_creates_result_with_white_as_winner(self):
+        """When black's clock expires, a GameResult with winner='white' must be saved."""
+        from .models import GameResult
+        session = self.client.session
+        session['game'] = self._make_timed_out_session('black')
+        session.save()
+
+        with mock.patch.object(ChessGame, 'validate_move', return_value=(True, 'Valid move.')):
+            response = self._post_move(1, 4, 3, 4)
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['game_status'], 'timeout')
+
+        result = GameResult.objects.filter(end_reason='timeout').first()
+        self.assertIsNotNone(result, 'A GameResult row must be created when black times out.')
+        self.assertEqual(result.winner, 'white')
+        self.assertEqual(result.end_reason, 'timeout')
+
+    def test_timeout_updates_game_status_in_session(self):
+        """After a timeout, the session game_status must reflect 'timeout'."""
+        session = self.client.session
+        session['game'] = self._make_timed_out_session('white')
+        session.save()
+
+        with mock.patch.object(ChessGame, 'validate_move', return_value=(True, 'Valid move.')):
+            self._post_move(6, 4, 4, 4)
+
+        updated_session = self.client.session
+        self.assertEqual(updated_session['game']['game_status'], 'timeout')
+
+    def test_no_duplicate_result_rows_on_repeated_timeout_call(self):
+        """A second move after timeout must not create a second GameResult row."""
+        from .models import GameResult
+        session = self.client.session
+        session['game'] = self._make_timed_out_session('white')
+        session.save()
+
+        with mock.patch.object(ChessGame, 'validate_move', return_value=(True, 'Valid move.')):
+            self._post_move(6, 4, 4, 4)
+            self._post_move(6, 4, 4, 4)
+
+        self.assertEqual(
+            GameResult.objects.filter(end_reason='timeout').count(),
+            1,
+            'Exactly one GameResult row must exist even if the endpoint is hit twice.',
+        )

--- a/game/views.py
+++ b/game/views.py
@@ -82,6 +82,12 @@ def make_move(request):
             record_game_result(request, game.mode, winner, 'checkmate', game.player_color)
         elif game_status in ('stalemate', 'draw'):
             record_game_result(request, game.mode, 'draw', game.draw_reason or 'stalemate', game.player_color)
+    elif game_status == 'timeout' and game_data.get('game_status') != 'timeout':
+        winner = 'black' if game.white_time == 0 else 'white'
+        game.game_status = 'timeout'
+        request.session['game'] = game.to_dict()
+        request.session.modified = True
+        record_game_result(request, game.mode, winner, 'timeout', game.player_color)
 
     return JsonResponse({
         'valid': success,
@@ -387,6 +393,12 @@ def ai_move(request):
             record_game_result(request, game.mode, winner, 'checkmate', game.player_color)
         elif game_status in ('stalemate', 'draw'):
             record_game_result(request, game.mode, 'draw', game.draw_reason or 'stalemate', game.player_color)
+    elif game_status == 'timeout' and game_data.get('game_status') != 'timeout':
+        winner = 'black' if game.white_time == 0 else 'white'
+        game.game_status = 'timeout'
+        request.session['game'] = game.to_dict()
+        request.session.modified = True
+        record_game_result(request, game.mode, winner, 'timeout', game.player_color)
 
     return JsonResponse({
         'valid': success,


### PR DESCRIPTION
Closes #1036 

## What this PR does

`make_move()` and `ai_move()` in `views.py` only called `record_game_result()` for
checkmate, stalemate, and draw outcomes. When a player's clock hit zero, `engine.py`
returned `game_status='timeout'` but the view had no handler for it — the result was
silently dropped with no database row created, meaning timed-out games never appeared
on the stats page.

## Changes

### `game/views.py`
- Added `elif game_status == 'timeout'` branch in `make_move()` that determines the
  winner by checking which clock is at zero, updates `game.game_status` to `'timeout'`,
  saves the session, and calls `record_game_result()` with `end_reason='timeout'`.
- Added the same branch in `ai_move()` for consistency.
- Added `and game_data.get('game_status') != 'timeout'` guard on both branches to
  prevent duplicate `GameResult` rows if the endpoint is called again after the game
  has already ended.

### `game/tests.py`
- Added `import time` to the imports block.
- Added `TimeoutResultRecordingTest` class with 4 new test cases:
  - `test_white_timeout_creates_result_with_black_as_winner`
  - `test_black_timeout_creates_result_with_white_as_winner`
  - `test_timeout_updates_game_status_in_session`
  - `test_no_duplicate_result_rows_on_repeated_timeout_call`

## Test results

All tests pass with 0 failures. The 4 new tests are included in the count.