### PR TITLE
fix: clear stale move highlights when starting a new game

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1758,7 +1758,10 @@
                 }
                 movesEl.innerHTML = '<span class="placeholder">No moves yet</span>';
                 wCapEl.innerHTML = bCapEl.innerHTML = '';
-
+                lastMove = null;
+                highlightedSquare = null;
+                selected = null;
+                hints = [];
                 await loadGame();
                 // Apply active state after UI reload
                 updateModeButtonsUI(gameMode);


### PR DESCRIPTION
Actual Behavior:
The previous game's move highlight remained visible after starting a new game.

Expected Behavior:
Starting a new game should fully reset the board state and clear old move highlights.

Changes Made:
- Reset lastMove state on new game
- Cleared selected highlights and hint states
- Ensured fresh board state after restart

Fixes #1106


<img width="1434" height="914" alt="image" src="https://github.com/user-attachments/assets/1033d02a-6ce6-4182-8c81-71f00673d3a9" />
