### PR TITLE
fix: add Exit to Home button in game-over modal closes #718

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -171,6 +171,7 @@
             const gameOverTitle = document.getElementById('gameOverTitle');
             const gameOverMessage = document.getElementById('gameOverMessage');
             const gameOverStartBtn = document.getElementById('gameOverStartBtn');
+            const gameOverExitBtn = document.getElementById('gameOverExitBtn');
             const gameOverPvPBtn = document.getElementById('gameOverPvPBtn');
             const gameOverAIBtn = document.getElementById('gameOverAIBtn');
 
@@ -1893,17 +1894,22 @@
 
                 const confettiContainer = gameOverOverlay.querySelector('.confetti-container');
                 if (confettiContainer) {
-                    confettiContainer.remove();
+                 confettiContainer.remove();
                 }
 
                 const swappedColor = playerColor === 'white' ? 'black' : 'white';
                 if (mode === 'ai') {
                     showSideSelectionModal(side => startNewGame(mode, side, diff, null, timeLimitMins));
-                } else {
+                }
+               
+                else {
                     startNewGame(mode, swappedColor, diff, null, timeLimitMins,
                         { white: currentBlackName, black: currentWhiteName });
                 }
             };
+            if (gameOverExitBtn) gameOverExitBtn.onclick = () => {
+            window.location.href = '/';
+                 };
 
             // Theme Switcher
             function initThemeSwitcher() {

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1907,9 +1907,10 @@
                         { white: currentBlackName, black: currentWhiteName });
                 }
             };
-            if (gameOverExitBtn) gameOverExitBtn.onclick = () => {
-            window.location.href = '/';
-                 };
+           if (gameOverExitBtn) gameOverExitBtn.addEventListener('click', () => {
+    const confettiContainer = gameOverOverlay.querySelector('.confetti-container');
+    if (confettiContainer) confettiContainer.remove();
+});
 
             // Theme Switcher
             function initThemeSwitcher() {

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -474,6 +474,11 @@
             <div style="display: flex; flex-direction: column; gap: 12px;">
                 <button type="button" class="btn btn-gold" id="shareResultBtn" style="padding: 12px; font-size: 1rem;">📤 Share Result</button>
                 <button class="btn btn-gold" id="gameOverStartBtn" style="padding: 12px; font-size: 1rem;">Start New Game</button>
+               <button type="button" class="btn" id="gameOverExitBtn" 
+               onclick="window.location.href='/'" 
+              style="padding: 12px; font-size: 1rem; margin-top: 10px; background: #333; color: #fff; cursor: pointer;">
+            Exit to Home
+            </button>
             </div>
         </div>
     </div>

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -474,11 +474,10 @@
             <div style="display: flex; flex-direction: column; gap: 12px;">
                 <button type="button" class="btn btn-gold" id="shareResultBtn" style="padding: 12px; font-size: 1rem;">📤 Share Result</button>
                 <button class="btn btn-gold" id="gameOverStartBtn" style="padding: 12px; font-size: 1rem;">Start New Game</button>
-               <button type="button" class="btn" id="gameOverExitBtn" 
-               onclick="window.location.href='/'" 
-              style="padding: 12px; font-size: 1rem; margin-top: 10px; background: #333; color: #fff; cursor: pointer;">
-            Exit to Home
-            </button>
+               <a href="{% url 'landing' %}" class="btn" id="gameOverExitBtn"
+   style="padding: 12px; font-size: 1rem; margin-top: 10px; background: #333; color: #fff; cursor: pointer; text-align: center; text-decoration: none; display: block;">
+    Exit to Home
+</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Fixes #718

## What was done
- Added "Exit to Home" button in the game-over modal
- Button navigates back to the landing page after game ends

## Clarification
There was a previous misunderstanding between issue #718 and #719.
- Issue #718 (this PR): Exit to Home button inside the game-over modal ✅
- Issue #719: Leave game confirmation modal (already implemented earlier)

PR #959 has been closed as it had unintended file changes from a rebase.
This is a fresh, clean PR with only the required changes.

## Files Changed
- `game/templates/game/board.html` — added Exit to Home button in game-over modal
- `game/static/game/js/board.js` — added click handler for the button

## Screenshots
[
<img width="788" height="762" alt="image" src="https://github.com/user-attachments/assets/e2af8d2d-9c6c-4e67-8130-119aad925c49" />
]