### PR TITLE
fix: fix back button routing in rulebook

### DIFF
--- a/game/templates/game/rules.html
+++ b/game/templates/game/rules.html
@@ -1241,7 +1241,7 @@ document.addEventListener('DOMContentLoaded', () => {
     } else {
         // Loaded as a standalone page (from the Landing Page Footer)
         backBtn.innerHTML = '← Back to Home';
-        backBtn.href = '/'; // Forces the link to go to the home page
+         // Forces the link to go to the home page
     }
 });
 </script>

--- a/game/templates/game/rules.html
+++ b/game/templates/game/rules.html
@@ -1241,7 +1241,7 @@ document.addEventListener('DOMContentLoaded', () => {
     } else {
         // Loaded as a standalone page (from the Landing Page Footer)
         backBtn.innerHTML = '← Back to Home';
-         // Forces the link to go to the home page
+        backBtn.href = backBtn.getAttribute('href');// Forces the link to go to the home page
     }
 });
 </script>

--- a/game/templates/game/rules.html
+++ b/game/templates/game/rules.html
@@ -543,21 +543,8 @@
     <!-- Sidebar -->
     <nav class="sidebar">
         <div style="margin-bottom: 20px; margin-top: 10px; text-align: center; width: 50%;">
-            <a href="{% url 'index' %}"
-               class="back-btn"
-               style="color:#f0c040; display:inline-block;"
-               onclick="
-                try {
-                    var modal = window.parent.document.getElementById('rulebookModal');
-                    if (modal) {
-                        modal.style.display='none';
-                        return false;
-                    }
-                } catch(e) {
-                    console.error('Modal close failed:', e);
-                }
-               ">
-               ← Back to Game
+            <a href="/" id="dynamicBackBtn" class="back-btn" style="color:#f0c040; display:inline-block;">
+               ← Back to Home
             </a>
         </div>
         <div class="sidebar-title">Rulebook</div>
@@ -1230,6 +1217,32 @@ window.onload = () => {
     initStalemate();
     buildBoard('board-promo'); promoStep(0);
 };
+document.addEventListener('DOMContentLoaded', () => {
+    const backBtn = document.getElementById('dynamicBackBtn');
+    if (!backBtn) return;
+
+    // Check if the rulebook is loaded inside an iframe (Game Modal)
+    if (window !== window.parent) {
+        backBtn.innerHTML = '← Back to Game';
+        backBtn.href = '#';
+        backBtn.onclick = (e) => {
+            e.preventDefault();
+            try {
+                // Securely tell the parent window (board.html) to hide the modal
+                const parentModal = window.parent.document.getElementById('rulebookModal');
+                if (parentModal) {
+                    parentModal.style.display = 'none';
+                }
+            } catch (err) {
+                console.error("Could not close modal", err);
+            }
+        };
+    } else {
+        // Loaded as a standalone page (from the Landing Page Footer)
+        backBtn.innerHTML = '← Back to Home';
+        backBtn.href = '/'; // Forces the link to go to the home page
+    }
+});
 </script>
 </body>
 </html>

--- a/game/templates/game/rules.html
+++ b/game/templates/game/rules.html
@@ -1,3 +1,4 @@
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -543,7 +544,7 @@
     <!-- Sidebar -->
     <nav class="sidebar">
         <div style="margin-bottom: 20px; margin-top: 10px; text-align: center; width: 50%;">
-            <a href="/" id="dynamicBackBtn" class="back-btn" style="color:#f0c040; display:inline-block;">
+            <a href="{% url 'landing' %}" id="dynamicBackBtn" class="back-btn" style="color:#f0c040; display:inline-block;">
                ← Back to Home
             </a>
         </div>


### PR DESCRIPTION
## Description
This PR fixes a navigation bug in the Rulebook (rules.html). Previously, the "Back" button had a hardcoded href and onclick behavior, which caused it to route users back to the game engine even if they accessed the Rulebook from the landing page footer.

I replaced the hardcoded inline logic with a context-aware JavaScript listener. The script now checks if the page is rendered inside an iframe (window !== window.parent):

- If inside the game modal: The button reads "← Back to Game" and safely closes the modal overlay.

- If accessed as a standalone page (footer): The button reads "← Back to Home" and routes the user back to the / landing page.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


## Related Issue

Fixes #765 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally

## Screenshots (if applicable)
### Rulebook from game section should have Back to Game
<img width="863" height="377" alt="image" src="https://github.com/user-attachments/assets/39ac2f41-a647-4440-848e-1747eb45bcf2" />

### Rulebook from footer should have Back to Home
<img width="777" height="413" alt="image" src="https://github.com/user-attachments/assets/baeff725-dbeb-4ea3-9b04-f64e50e4f424" />


## Additional Notes
I'm a GSSOC contributor.
