### PR TITLE
# Pull Request: Add Mobile Touch Drag-and-Drop Support for Chess Pieces

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -510,6 +510,7 @@ body {
 }
 .piece.playable { cursor: pointer; }
 .piece.dragging { opacity: 0.3; transition: none; }
+.piece.touch-dragging-original { opacity: 0.3 !important; }
 .piece.moving {
     z-index: 100;
 }

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -29,6 +29,13 @@
             let dragging = false;
             let dragSrc = null;
 
+            // Touch drag-and-drop state variables
+            let touchStartPos = null;
+            let activeTouchPieceClone = null;
+            let touchDragSrc = null;
+            let touchDragging = false;
+            let touchOffset = { x: 0, y: 0 };
+
             let whiteTime = 0;
             let blackTime = 0;
             let paused = false;
@@ -2458,5 +2465,132 @@ if (leaveConfirmNo) leaveConfirmNo.addEventListener('click', () => {
                 refreshPremoveHighlight();
                 showStatus("Premove cancelled", false);
             });
+
+            // Mobile Touch Drag-and-Drop Implementation
+            boardEl.addEventListener('touchstart', (e) => {
+                const touch = e.touches[0];
+                const squareEl = e.target.closest('.square');
+                if (!squareEl) return;
+
+                const r = parseInt(squareEl.dataset.r);
+                const c = parseInt(squareEl.dataset.c);
+                const piece = board[r][c];
+                if (!piece || paused || gameOver) return;
+
+                // Check if the piece is playable by the current player (including AI premoves)
+                const isPremoveDrag = gameMode === 'ai' && turn !== playerColor && pColor(piece) === playerColor;
+                const isNormalDrag = gameMode === 'ai' ? (turn === playerColor && pColor(piece) === playerColor) : (pColor(piece) === turn);
+
+                if (!isPremoveDrag && !isNormalDrag) return;
+
+                touchStartPos = { x: touch.clientX, y: touch.clientY };
+                touchDragSrc = { r, c };
+                touchDragging = false;
+            }, { passive: true });
+
+            boardEl.addEventListener('touchmove', (e) => {
+                if (!touchDragSrc) return;
+
+                const touch = e.touches[0];
+                
+                if (!touchDragging) {
+                    const dx = touch.clientX - touchStartPos.x;
+                    const dy = touch.clientY - touchStartPos.y;
+                    const distance = Math.sqrt(dx * dx + dy * dy);
+
+                    if (distance > 8) {
+                        touchDragging = true;
+                        
+                        // Select the piece to show move hints
+                        selectPiece(touchDragSrc.r, touchDragSrc.c);
+
+                        // Find the original piece image
+                        const squareEl = sq(touchDragSrc.r, touchDragSrc.c);
+                        const pieceImg = squareEl ? squareEl.querySelector('.piece') : null;
+                        if (pieceImg) {
+                            // Create premium floating clone
+                            activeTouchPieceClone = pieceImg.cloneNode(true);
+                            activeTouchPieceClone.className = 'piece touch-drag-clone';
+                            
+                            // Measure and style the clone
+                            const rect = pieceImg.getBoundingClientRect();
+                            touchOffset = { x: rect.width / 2, y: rect.height / 2 };
+                            
+                            activeTouchPieceClone.style.position = 'fixed';
+                            activeTouchPieceClone.style.pointerEvents = 'none';
+                            activeTouchPieceClone.style.zIndex = '9999';
+                            activeTouchPieceClone.style.width = rect.width + 'px';
+                            activeTouchPieceClone.style.height = rect.height + 'px';
+                            activeTouchPieceClone.style.transform = 'scale(1.15)';
+                            activeTouchPieceClone.style.filter = 'drop-shadow(0 8px 16px rgba(0, 0, 0, 0.45))';
+                            activeTouchPieceClone.style.transition = 'none';
+                            activeTouchPieceClone.style.willChange = 'left, top';
+                            
+                            document.body.appendChild(activeTouchPieceClone);
+                            
+                            // Make original piece semi-transparent
+                            pieceImg.classList.add('touch-dragging-original');
+                        }
+                    }
+                }
+
+                if (touchDragging && activeTouchPieceClone) {
+                    activeTouchPieceClone.style.left = (touch.clientX - touchOffset.x) + 'px';
+                    activeTouchPieceClone.style.top = (touch.clientY - touchOffset.y) + 'px';
+                    
+                    // Prevent page scrolling while dragging
+                    if (e.cancelable) e.preventDefault();
+                }
+            }, { passive: false });
+
+            boardEl.addEventListener('touchend', (e) => {
+                if (!touchDragSrc) return;
+
+                const touch = e.changedTouches[0];
+                let movedToSquare = false;
+
+                if (touchDragging) {
+                    // Clean up original piece transparency
+                    const srcSquareEl = sq(touchDragSrc.r, touchDragSrc.c);
+                    const pieceImg = srcSquareEl ? srcSquareEl.querySelector('.piece') : null;
+                    if (pieceImg) {
+                        pieceImg.classList.remove('touch-dragging-original');
+                    }
+
+                    // Clean up clone
+                    if (activeTouchPieceClone) {
+                        activeTouchPieceClone.remove();
+                        activeTouchPieceClone = null;
+                    }
+
+                    // Identify target square element under the touch coordinates
+                    const targetEl = document.elementFromPoint(touch.clientX, touch.clientY);
+                    const destSquareEl = targetEl ? targetEl.closest('.square') : null;
+                    if (destSquareEl) {
+                        const tr = parseInt(destSquareEl.dataset.r);
+                        const tc = parseInt(destSquareEl.dataset.c);
+
+                        if (tr !== touchDragSrc.r || tc !== touchDragSrc.c) {
+                            tryMove(touchDragSrc.r, touchDragSrc.c, tr, tc);
+                            movedToSquare = true;
+                        }
+                    }
+
+                    if (!movedToSquare) {
+                        deselect();
+                    }
+
+                    // Prevent click generation
+                    e.preventDefault();
+                } else {
+                    // Quick tap -> trigger default click/tap behavior
+                    onClick(touchDragSrc.r, touchDragSrc.c);
+                }
+
+                // Reset state
+                touchStartPos = null;
+                touchDragSrc = null;
+                touchDragging = false;
+            }, { passive: false });
 
 })();


### PR DESCRIPTION
Closes #1141

## Overview

This PR adds full mobile touch drag-and-drop support for chess pieces, enabling mobile users to interact with the board using intuitive drag gestures while preserving the existing tap-to-move behavior.

Previously, mobile gameplay relied entirely on tap interactions, creating an inconsistent experience compared to desktop drag-and-drop controls. This implementation introduces a dedicated touch gesture engine optimized for mobile devices without affecting current desktop functionality.

---

## Features

### Mobile Drag-and-Drop Support
- Drag chess pieces directly using touch gestures on mobile devices.
- Seamlessly coexists with existing tap-to-move controls.

### Gesture Discrimination
To avoid conflicts between taps and drags:
- Touch interactions begin with coordinate tracking on `touchstart`.
- Movement distance is measured during `touchmove`.
- Interactions below an `8px` displacement threshold are treated as taps.
- Interactions exceeding the threshold activate drag mode.

This preserves current click/tap logic while enabling responsive drag gestures.

---

## Visual Interaction Improvements

During active dragging:

- A floating clone of the dragged piece is dynamically created.
- The clone is visually enhanced with:
  - `scale(1.15)`
  - `drop-shadow(0 8px 16px rgba(0,0,0,0.45))`
- The original piece is dimmed using:
  - `opacity: 0.3`

These effects provide clearer spatial feedback and a more tactile mobile interaction experience.

---

## Scroll & Gesture Handling

While dragging:
- Page scrolling is temporarily disabled using `e.preventDefault()`.
- Rubber-band bounce behavior is suppressed on mobile browsers.

This ensures smooth and uninterrupted drag interactions similar to native mobile applications.

---

## Move Resolution

On `touchend`:
- The destination square is resolved using `document.elementFromPoint()`.
- If a valid square is detected:
  - `tryMove()` is triggered with source and target coordinates.
- All temporary drag artifacts are cleaned up:
  - Floating clones removed
  - Original opacity restored
  - Synthetic click emulation suppressed

Dragging outside the board cancels gracefully without UI corruption or freezes.

---

## Files Changed

### `board.css`
- Added helper styles for:
  - Dragging state visuals
  - Original piece opacity during mobile drag

### `board.js`
Added:
- Touch state tracking variables
- Drag threshold detection
- Floating drag clone management
- Event delegation handlers for:
  - `touchstart`
  - `touchmove`
  - `touchend`

Event delegation is implemented on `boardEl` for improved performance and compatibility.

---
<img width="393" height="809" alt="Screenshot 2026-05-24 202109" src="https://github.com/user-attachments/assets/6c2045dc-0099-436a-8573-23c5662374d9" />

