### PR TITLE
fix: alphabet alignment

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -293,17 +293,35 @@ body {
     position: relative;
     width: fit-content;
     max-width: 100%;
+    margin-left: auto;
+    margin-right: auto;
+    box-sizing: border-box;
+}
+
+.board-aligned {
+    display: inline-block;
+    width: fit-content;
+    margin: 0 auto;
+    box-sizing: border-box;
 }
 
 .board-row {
     display: flex;
-    align-items: stretch;
+    align-items: flex-start;
+}
+
+.board-grid-wrap {
+    display: flex;
+    flex-direction: column;
+    width: calc(var(--square-size) * 8 + var(--board-border) * 2);
+    box-sizing: border-box;
 }
 
 .ranks {
     display: flex;
     flex-direction: column;
-    padding: 3px 6px 3px 0;
+    width: var(--rank-label-width);
+    padding: 3px 0;
 }
 .ranks span {
     height: var(--square-size);
@@ -316,11 +334,15 @@ body {
 }
 
 .files {
-    display: flex;
-    padding: 4px 0 0 calc(var(--rank-label-width) + 4px);
+    display: grid;
+    grid-template-columns: repeat(8, 1fr);
+    width: calc(var(--square-size) * 8);
+    margin-left: calc(var(--rank-label-width) + var(--board-border));
+    padding-top: 4px;
+    box-sizing: border-box;
 }
 .files span {
-    width: var(--square-size);
+    width: 100%;
     text-align: center;
     font-size: clamp(0.6rem, 1.2vw, 0.75rem);
     color: #5a5a7a;
@@ -329,15 +351,16 @@ body {
 
 .chessboard {
     display: grid;
-    grid-template-columns: repeat(8, var(--square-size));
-    grid-template-rows: repeat(8, var(--square-size));
+    grid-template-columns: repeat(8, 1fr);
+    grid-template-rows: repeat(8, 1fr);
     width: calc(var(--square-size) * 8 + var(--board-border) * 2);
     height: calc(var(--square-size) * 8 + var(--board-border) * 2);
     border: var(--board-border) solid #3d3222;
+    padding: 0;
     border-radius: 2px;
     box-shadow: 0 8px 40px rgba(0, 0, 0, 0.6);
     max-width: 100%;
-    box-sizing: content-box;
+    box-sizing: border-box;
     position: relative;
 }
 
@@ -345,8 +368,8 @@ body {
    Squares
    ============================================================ */
 .square {
-    width: var(--square-size);
-    height: var(--square-size);
+    width: 100%;
+    height: 100%;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -854,7 +877,7 @@ body {
     }
 
     .board-outer {
-    width: 100%;
+    width: fit-content;
     max-width: 100%;
     margin: 0 auto;
     overflow-x: hidden;
@@ -864,8 +887,17 @@ body {
         width: var(--mobile-board-size);
         height: var(--mobile-board-size);
         border-width: var(--board-border-width);
-        grid-template-columns: repeat(8, var(--mobile-square-size));
-        grid-template-rows: repeat(8, var(--mobile-square-size));
+        grid-template-columns: repeat(8, 1fr);
+        grid-template-rows: repeat(8, 1fr);
+    }
+
+    .board-grid-wrap {
+        width: var(--mobile-board-size);
+    }
+
+    .board-aligned {
+        width: fit-content;
+        margin: 0 auto;
     }
 
     .square {
@@ -883,13 +915,13 @@ body {
         font-size: 0.65rem;
     }
 
-    .files {
-        padding-left: 20px;
+    .files span {
+        font-size: 0.65rem;
     }
 
-    .files span {
-        width: var(--mobile-square-size);
-        font-size: 0.65rem;
+    .files {
+        width: calc(var(--mobile-square-size) * 8);
+        margin-left: calc(var(--rank-label-width) + var(--board-border-width));
     }
 
     .piece {
@@ -1238,13 +1270,10 @@ body {
     }
 
     .board-outer {
-        width: 100%;
+        width: fit-content;
         max-width: 100%;
+        margin: 0 auto;
         overflow-x: hidden;
-    }
-
-    .files {
-        padding-left: 18px;
     }
 
     .files span,

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -247,17 +247,21 @@
                 </div>
             </div>
             <div class="board-outer">
-                <div class="board-row">
-                    <div class="ranks" id="ranksLabels">
-                        <span>8</span><span>7</span><span>6</span><span>5</span>
-                        <span>4</span><span>3</span><span>2</span><span>1</span>
+                <div class="board-aligned">
+                    <div class="board-row">
+                        <div class="ranks" id="ranksLabels">
+                            <span>8</span><span>7</span><span>6</span><span>5</span>
+                            <span>4</span><span>3</span><span>2</span><span>1</span>
+                        </div>
+                        <div class="board-grid-wrap">
+                            <div class="chessboard" id="board" role="grid" aria-label="Chess Board"></div>
+                        </div>
+                        <div id="a11y-announcer" class="visually-hidden" aria-live="polite" aria-atomic="true"></div>
                     </div>
-                    <div class="chessboard" id="board" role="grid" aria-label="Chess Board"></div>
-                    <div id="a11y-announcer" class="visually-hidden" aria-live="polite" aria-atomic="true"></div>
-                </div>
-                <div class="files" id="filesLabels">
-                    <span>a</span><span>b</span><span>c</span><span>d</span>
-                    <span>e</span><span>f</span><span>g</span><span>h</span>
+                    <div class="files" id="filesLabels">
+                        <span>a</span><span>b</span><span>c</span><span>d</span>
+                        <span>e</span><span>f</span><span>g</span><span>h</span>
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
## Description

Fixed the misalignment of a–h column labels beneath the chessboard. The labels were shifted 
left and the `h` label was clipped because `.chessboard` used `box-sizing: content-box`, 
which added the 3px border outside the declared width creating a phantom gap. Switched to 
`box-sizing: border-box` and synced the `.files` margin and width to match the actual 
rendered board dimensions on both desktop and mobile.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #1057

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

## Screenshots (if applicable)

<img width="517" height="531" alt="Screenshot 2026-05-24 at 8 31 37 PM" src="https://github.com/user-attachments/assets/7468a88b-8b09-49aa-be46-d266c5545779" />

## Additional Notes

Only `board.css` was modified. No JavaScript changes required. A hard browser refresh 
may be needed to clear cached styles on production.