### PR TITLE
Fix previous move highlight persisting after starting a new game

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1677,6 +1677,7 @@
                 aiRequestSeq = 0;
                 aiThinking = false;
                 premove = null;
+                lastMove = null;
                 refreshPremoveHighlight();
 
                 clearTimeout(pgnDownloadTimeout);


### PR DESCRIPTION
## Description
Fixed an issue where the previous move highlight remained visible after starting a new game.  
The board state is now properly reset and old highlighted squares are cleared when a new game begins.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issue

Fixes #1106

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have tested the fix locally