### PR TITLE
Fix Resume button visibility after draw acceptance and game reset

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1679,6 +1679,10 @@
                 aiThinking = false;
                 premove = null;
                 refreshPremoveHighlight();
+                
+                    if (welcomeResumeBtn) {
+                        welcomeResumeBtn.style.display = 'none';
+                    }
 
                 clearTimeout(pgnDownloadTimeout);
                 clearTimeout(fenCopyTimeout);


### PR DESCRIPTION
## Description

Fixed a UI inconsistency where the Resume button remained visible after accepting a draw offer or initializing a new game.

The issue occurred because the Resume button state was not being reset during fresh game initialization. Added logic inside `startNewGame()` to properly hide the button whenever a new active game session begins.

This ensures that the Resume button is displayed only during paused game states.

---

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

---

## Related Issue

Fixes #1134

---

## Changes Made

- Added Resume button reset handling inside `startNewGame()`
- Ensured proper UI synchronization between paused and active game states
- Prevented stale Resume button visibility after draw acceptance or game reset

---

## Testing

- [x] Tested locally
- [x] Verified Resume button appears only during paused state
- [x] Verified Resume button hides correctly after new game initialization
- [x] Verified normal gameplay behavior remains unaffected