### PR TITLE
fix: handle malformed JSON in offer_draw

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -411,6 +411,7 @@ def ai_move(request):
         'black_name': request.session.get('black_name', 'Black'),
     })
 
+
 @require_POST
 def offer_draw(request):
     """Handle draw offers and agreements."""
@@ -421,7 +422,14 @@ def offer_draw(request):
             {'success': False, 'message': err_msg}, status=400
         )
 
-    data = json.loads(request.body or '{}')
+    try:
+        data = json.loads(request.body or '{}')
+    except json.JSONDecodeError:
+        return JsonResponse(
+            {'success': False, 'message': 'Invalid request data.'},
+            status=400,
+        )
+
     action = data.get('action')  # 'offer' or 'accept'
 
     if action == 'accept':
@@ -430,7 +438,14 @@ def offer_draw(request):
         game.draw_reason = 'agreement'
         request.session['game'] = game.to_dict()
         request.session.modified = True
-        record_game_result(request, game.mode, 'draw', 'agreement', game.player_color)
+        record_game_result(
+            request,
+            game.mode,
+            'draw',
+            'agreement',
+            game.player_color
+        )
+
         return JsonResponse({
             'success': True,
             'game_status': game.game_status,


### PR DESCRIPTION
## Description

Added proper exception handling for malformed JSON in `offer_draw` to prevent server crashes caused by invalid request bodies.

## Type of Change

* [✓] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

## Related Issue

Fixes #1115

## Checklist

* [✓] My code follows the project's style guidelines
* [✓] I have performed a self-review of my code
* [ ] I have commented my code where necessary
* [ ] I have updated the documentation if needed
* [✓] My changes generate no new warnings
* [ ] I have added tests that prove my fix/feature works
* [✓] New and existing tests pass locally

## Screenshots (if applicable)

N/A

## Additional Notes

Wrapped `json.loads()` inside a try-except block and handled `json.JSONDecodeError` by returning a proper `400 Bad Request` response with a clear error message.

