### PR TITLE
Fix pause overlay overlapping with draw offer modal during paused game

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1667,6 +1667,7 @@
                     async () => {
                         drawMessage.textContent = `${offeringPlayer} offers a draw. ${receivingPlayer}, do you accept?`;
                         drawOverlay.classList.add('active');
+                        pauseOverlay.classList.remove('active');
                         await pauseGame();
                     },
                     '#f0c040'


### PR DESCRIPTION
## Description

Resolved a UI issue where the “Resume to Continue” pause overlay overlapped with the draw offer modal during paused gameplay.

The issue occurred because both the pause overlay and draw offer modal were active at the same time, causing visual clutter and affecting user interaction.

Updated the draw offer flow to properly hide the pause overlay whenever the draw offer modal is displayed, ensuring a clean and uninterrupted user experience.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Verified draw offer modal appears correctly during paused gameplay
- [x] Verified pause overlay no longer overlaps the modal
- [x] Verified Resume functionality still works as expected
- [x] Verified draw accept/decline actions work correctly
- [x] Tested locally in PvP mode

## Related Issue

Fixes #1133