### PR TITLE
[GSSoC'26] Make paused board and "Resume to Continue" overlay clickable

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -1509,12 +1509,13 @@ body {
 
 /* ================= PAUSE STATE ================= */
 .chessboard.paused {
-    pointer-events: none;
+    cursor: pointer;
 }
 
 /* Blur squares only — not ::after, so the pause label stays sharp */
 .chessboard.paused .square {
     filter: blur(15px);
+    pointer-events: none;
 }
 
 .chessboard.paused::after {
@@ -1535,7 +1536,8 @@ body {
     z-index: 9999;
     box-shadow: 0 8px 32px rgba(240, 192, 64, 0.4);
     filter: none;
-    pointer-events: none;
+    pointer-events: auto;
+    cursor: pointer;
 }
 
 #pauseBtn.paused {

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -2465,6 +2465,12 @@ if (leaveConfirmNo) leaveConfirmNo.addEventListener('click', () => {
                 loadGame();
             }
 
+            boardEl.addEventListener('click', (e) => {
+                if (paused && !gameOver) {
+                    resumeGame();
+                }
+            });
+
             boardEl.addEventListener('contextmenu', (e) => {
                 e.preventDefault();
 


### PR DESCRIPTION
### Description
This PR makes the paused board and its overlay clickable to easily resume the game, providing a much smoother and modern user experience.

### Changes
- Updated `board.css` to remove `pointer-events: none` from `.chessboard.paused` so it can handle clicks.
- Disabled pointer events specifically on individual squares while the board is paused to prevent piece dragging.
- Enabled pointer events (`pointer-events: auto`) and added a cursor hand pointer (`cursor: pointer`) to the `::after` overlay element.
- Added a click event listener in JS to `boardEl` that calls `resumeGame()` when clicked in a paused state.

### Contribution Details
I am contributing on behalf of GSSoc’26.
Fixes #1168.