### PR TITLE
Fix Mobile Touch Drag Ghost Piece Cleanup on touchcancel (#1180)

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -2600,4 +2600,27 @@ if (leaveConfirmNo) leaveConfirmNo.addEventListener('click', () => {
                 touchDragging = false;
             }, { passive: false });
 
+            boardEl.addEventListener('touchcancel', (e) => {
+                if (!touchDragSrc) return;
+
+                if (touchDragging) {
+                    const srcSquareEl = sq(touchDragSrc.r, touchDragSrc.c);
+                    const pieceImg = srcSquareEl ? srcSquareEl.querySelector('.piece') : null;
+                    if (pieceImg) {
+                        pieceImg.classList.remove('touch-dragging-original');
+                    }
+
+                    if (activeTouchPieceClone) {
+                        activeTouchPieceClone.remove();
+                        activeTouchPieceClone = null;
+                    }
+
+                    deselect();
+                }
+
+                touchStartPos = null;
+                touchDragSrc = null;
+                touchDragging = false;
+            }, { passive: true });
+
 })();


### PR DESCRIPTION
## Fixes #1180

## Description 🐛 ➡️ 🟩

This PR fixes a mobile touch interaction bug where interrupting or cancelling a drag-and-drop gesture caused a stuck “ghost” chess piece clone to remain on the board, kept the original piece dimmed, and left the internal drag state inconsistent.

The issue occurred because cleanup logic was only handled on the `touchend` event, while `touchcancel` events triggered by the OS (such as system gestures, notifications, or dragging outside the active viewport) were not handled.

### Changes
- Added a `touchcancel` event listener to `boardEl` in `board.js`.
- Ensures cleanup logic executes properly when touch gestures are interrupted or cancelled.
- Removes the active touch drag clone element (`activeTouchPieceClone`) from the DOM.
- Restores the original piece styling by removing the `touch-dragging-original` class.
- Clears highlighted squares and selected hints using `deselect()`.
- Resets touch interaction state variables:
  - `touchStartPos`
  - `touchDragSrc`
  - `touchDragging`

---

## Steps to Reproduce

1. Open the chess game on a mobile browser or mobile viewport.
2. Touch and drag any chess piece.
3. Interrupt or cancel the touch gesture:
   - drag outside the active window,
   - trigger a system swipe/gesture,
   - or allow a system dialog/notification to interrupt the interaction.
4. Observe that:
   - the temporary drag clone is removed correctly,
   - the original piece returns to normal opacity,
   - and the board remains fully interactive without stuck drag state.

---

## Visual Verification

- [x] Temporary drag clone is removed on `touchcancel`
- [x] Original piece styling is restored
- [x] Highlighted squares and hints are cleared properly
- [x] Drag state resets correctly without stuck interactions
