### PR TITLE
Add Post-Game Move Replay System for Completed Chess Matches

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -599,6 +599,45 @@ body {
 /* ============================================================
    Move History
    ============================================================ */
+/* ============================================================
+   Replay Controls
+   ============================================================ */
+
+.replay-controls {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    margin-top: 14px;
+    flex-wrap: wrap;
+}
+
+.replay-controls button {
+    background: linear-gradient(135deg, #222, #2e2e2e);
+    color: #f0c040;
+    border: 1px solid #555;
+    border-radius: 8px;
+    padding: 10px 14px;
+    cursor: pointer;
+    font-size: 16px;
+    transition: all 0.2s ease;
+    min-width: 48px;
+}
+
+.replay-controls button:hover {
+    background: linear-gradient(135deg, #333, #444);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(240, 192, 64, 0.18);
+}
+
+.replay-controls button:active {
+    transform: scale(0.96);
+}
+
+.hidden {
+    display: none !important;
+}
+
 .moves-list {
     max-height: min(460px, 48vh);
     overflow-y: auto;

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -192,7 +192,15 @@
             const gameOverExitBtn = document.getElementById('gameOverExitBtn');
             const gameOverPvPBtn = document.getElementById('gameOverPvPBtn');
             const gameOverAIBtn = document.getElementById('gameOverAIBtn');
-
+    
+            const replayControls = document.getElementById('replayControls');
+            const firstReplayBtn = document.getElementById('firstReplayBtn');
+            const prevReplayBtn = document.getElementById('prevReplayBtn');
+            const playReplayBtn = document.getElementById('playReplayBtn');
+            const nextReplayBtn = document.getElementById('nextReplayBtn');
+            const lastReplayBtn = document.getElementById('lastReplayBtn');
+            const replayGameBtn = document.getElementById('replayGameBtn');
+    
             const resignBtn = document.getElementById('resignBtn');
             const drawBtn = document.getElementById('drawBtn');
             const drawOverlay = document.getElementById('drawOverlay');
@@ -245,6 +253,12 @@
             let gameOver = false;
             let aiThinking = false;
             let aiRequestSeq = 0; // Sequence token to cancel stale AI responses
+            
+            let replayMode = false;
+            let replayMoves = [];
+            let replayIndex = 0;
+            let replayBoard = null;
+            let autoReplayInterval = null;
 
             let pgnDownloadTimeout = null;
             let fenCopyTimeout = null;
@@ -481,7 +495,10 @@
 
                 if (drawBtn) drawBtn.style.display = gameMode === 'pvp' ? 'block' : 'none';
                 if (pauseBtn)  pauseBtn.style.display  = 'block';  
-                if (resignBtn) resignBtn.style.display = 'block'; 
+                if (resignBtn) {
+                    resignBtn.style.display = 'block';
+                    resignBtn.hidden = false;
+                }
 
                 updatePlayerNames(data);
                 updateTurn();
@@ -1130,6 +1147,7 @@
             EVENTS
             ========================================================== */
             async function onClick(r, c) {
+                if (replayMode) return;
                 if (dragging) return;
 
                 const piece = board[r][c];
@@ -1222,11 +1240,86 @@
             }
 
             async function onDrop(e, tr, tc) {
+                if (replayMode) return;
                 if (!dragSrc) return;
                 await tryMove(dragSrc.r, dragSrc.c, tr, tc);
                 dragSrc = null;
             }
 
+            function resetReplayBoard() {
+                if (window.Chess) {
+                    replayBoard = new window.Chess();
+                }
+            }
+
+            function renderReplayPosition() {
+
+                if (!replayBoard) return;
+
+                const fen = replayBoard.fen();
+                const position = fen.split(' ')[0];
+                const rows = fen.split(' ')[0].split('/');
+
+                board = rows.map(row => {
+
+                    const expanded = [];
+
+                    for (const ch of row) {
+
+                        if (!isNaN(ch)) {
+
+                            for (let i = 0; i < Number(ch); i++) {
+                                expanded.push(null);
+                            }
+
+                        } else {
+                            expanded.push(ch);
+                        }
+                    }
+
+                    return expanded;
+                });
+
+                buildBoard();
+                if (typeof syncPieces === 'function') {
+                    syncPieces();
+                }
+
+                if (typeof updateMaterialUI === 'function') {
+                    updateMaterialUI(board);
+                }
+            }
+            function goToReplayMove(index) {
+
+                if (!window.Chess) {
+                    console.error("Chess.js not loaded");
+                    return;
+                }
+
+                replayBoard = new window.Chess();
+
+                try {
+
+                    for (let i = 0; i < index; i++) {
+
+                        const move = replayMoves[i];
+
+                        if (move) {
+                            const result = replayBoard.move(move);
+                            console.log("Replaying:", move, result)
+                        }
+                    }
+
+                    replayIndex = index;
+
+                    renderReplayPosition();
+
+                } catch (e) {
+
+                    console.error("Replay move error:", e);
+                }
+            }
+            
             /* ==========================================================
             UI UPDATES
             ========================================================== */
@@ -1336,6 +1429,7 @@
             function endGame(reason, color, drawReason = null) {
                 if (gameOver) return;
                 gameOver = true;
+                replayMode = true;
                 paused = true;
                 clearInterval(timerInterval);
                 
@@ -1389,6 +1483,38 @@
                 if (gameStartTime) {
                     const duration = Date.now() - gameStartTime;
                     durationText = `\nGame duration: ${formatGameDuration(duration)}.`;
+                }
+                
+                replayMoves = [];
+                replayIndex = 0;
+
+                // USE ORIGINAL HISTORY INSTEAD OF REVERSED DOM
+                const moveSpans = document.querySelectorAll('.move-white, .move-black');
+
+                moveSpans.forEach(span => {
+
+                const move = span.textContent
+                    ?.replace(/[+#]/g, '')
+                    ?.replace(/\s+/g, '')
+                    ?.trim();
+
+                if (move && move !== '...') {
+
+                    console.log("Replay move added:", move);
+
+                    replayMoves.push(move);
+                }
+            });
+
+            console.log("FINAL REPLAY MOVES:", replayMoves);
+
+                if (window.Chess) {
+                    replayBoard = new window.Chess();
+                }
+                resetReplayBoard();
+
+                if (replayControls) {
+                    replayControls.classList.remove('hidden');
                 }
 
                 gameOverTitle.textContent = title;
@@ -1748,6 +1874,20 @@
             }
 
             async function startNewGame(mode, pColor = 'white', difficulty = 'medium', fen = null, timeLimitMins = null, overrideNames = null) {
+                replayMode = false;
+
+                if (autoReplayInterval) {
+                    clearInterval(autoReplayInterval);
+                    autoReplayInterval = null;
+                }
+
+                if (playReplayBtn) {
+                    playReplayBtn.textContent = '▶';
+                }
+
+                if (replayControls) {
+                    replayControls.classList.add('hidden');
+                }
                 // Reset AI request sequence and thinking state on new game
                 aiRequestSeq = 0;
                 aiThinking = false;
@@ -1823,7 +1963,10 @@
                 gameMode = d.mode;
                 playerColor = d.player_color || 'white';
                 currentDifficulty = d.difficulty || difficulty;
-                if (resignBtn) resignBtn.style.display = '';
+                if (resignBtn) {
+                    resignBtn.style.display = 'block';
+                    resignBtn.hidden = false;
+                }
                 if (pauseBtn) pauseBtn.style.display = '';
                 if (drawBtn) drawBtn.style.display = (gameMode === 'pvp') ? 'block' : 'none';
                 if (gameMode === 'ai') {
@@ -1859,6 +2002,104 @@
             }
 
             
+            if (nextReplayBtn) {
+                nextReplayBtn.onclick = () => {
+                    if (replayIndex < replayMoves.length) {
+                        replayIndex++;
+                        goToReplayMove(replayIndex );
+                    }
+                };
+            }
+
+            if (prevReplayBtn) {
+                prevReplayBtn.onclick = () => {
+                    if (replayIndex > 0) {
+                        replayIndex--;
+                        goToReplayMove(replayIndex);
+                    }
+                };
+            }
+
+            if (firstReplayBtn) {
+                firstReplayBtn.onclick = () => {
+                    replayIndex = 0;
+
+                    goToReplayMove(0);
+                };
+            }
+
+            if (lastReplayBtn) {
+                lastReplayBtn.onclick = () => {
+                    replayIndex = replayMoves.length;
+                    goToReplayMove(replayIndex);
+                };
+            }
+            if (replayGameBtn) {
+
+                replayGameBtn.onclick = () => {
+
+                    // hide popup
+                    gameOverOverlay.classList.remove('active');
+
+                    // show replay controls
+                    replayControls.classList.remove('hidden');
+
+                    // stop old replay
+                    if (autoReplayInterval) {
+                        clearInterval(autoReplayInterval);
+                        autoReplayInterval = null;
+                    }
+                    replayIndex = 0;
+                    // reset replay
+                    goToReplayMove(0);
+
+                    // start autoplay
+                    playReplayBtn.textContent = '⏸';
+
+                    autoReplayInterval = setInterval(() => {
+
+                        if (replayIndex >= replayMoves.length) {
+
+                            clearInterval(autoReplayInterval);
+                            autoReplayInterval = null;
+
+                            playReplayBtn.textContent = '▶';
+
+                            return;
+                        }
+                        replayIndex++;
+                        goToReplayMove(replayIndex);
+
+                    }, 1000);
+                };
+            }
+    
+            if (playReplayBtn) {
+                playReplayBtn.onclick = () => {
+
+                    if (autoReplayInterval) {
+                        clearInterval(autoReplayInterval);
+                        autoReplayInterval = null;
+                        playReplayBtn.textContent = '▶';
+                        return;
+                    }
+                    playReplayBtn.textContent = '⏸';
+
+                    autoReplayInterval = setInterval(() => {
+
+                        if (replayIndex >= replayMoves.length) {
+                            clearInterval(autoReplayInterval);
+                            autoReplayInterval = null;
+                            playReplayBtn.textContent = '▶';
+                            return;
+                        }
+                        replayIndex++;
+                        goToReplayMove(replayIndex);
+
+                    }, 1000);
+                };
+            }
+    
 
             /* ==========================================================
             EVENT LISTENERS
@@ -2193,7 +2434,8 @@
                             const result = await post('/api/resign/', {});
                             if (result.valid) {
                                 if (soundEnabled) { sounds.draw.currentTime = 0; sounds.draw.play().catch(() => {}); }
-                                endGame('resign', turn);
+                                const loserColor = result.winner === 'white' ? 'black' : 'white';
+                                endGame('resign', loserColor);
                             } else {
                                 showStatus('Resign failed. Please try again.', true);
                             }

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -266,6 +266,13 @@
             </div>
 
             <div class="status-bar" id="statusBar" style="height: 22px; box-sizing: border-box;">
+                <div id="replayControls" class="replay-controls hidden">
+                    <button id="firstReplayBtn">⏮</button>
+                    <button id="prevReplayBtn">◀</button>
+                    <button id="playReplayBtn">▶</button>
+                    <button id="nextReplayBtn">▶▶</button>
+                    <button id="lastReplayBtn">⏭</button>
+                </div>
                 <!--Score bar-->
                   <div id="game-status">Game started</div>
                    <div class="score-panel">
@@ -478,6 +485,10 @@
             <div style="display: flex; flex-direction: column; gap: 12px;">
                 <button type="button" class="btn btn-gold" id="shareResultBtn" style="padding: 12px; font-size: 1rem;">📤 Share Result</button>
                 <button class="btn btn-gold" id="gameOverStartBtn" style="padding: 12px; font-size: 1rem;">Start New Game</button>
+                <button class="btn" id="replayGameBtn"
+                style="padding:12px;font-size:1rem;background:#222;color:white;border:1px solid #555;">
+                    ▶ Replay Game
+                </button>
                <a href="{% url 'landing' %}" class="btn" id="gameOverExitBtn"
    style="padding: 12px; font-size: 1rem; margin-top: 10px; background: #333; color: #fff; cursor: pointer; text-align: center; text-decoration: none; display: block;">
     Exit to Home
@@ -565,6 +576,7 @@
     <script>
         window.SOUND_BASE_URL = "{% static 'game/sounds/' %}";
     </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/chess.js/0.10.3/chess.min.js"></script>
     <script src="{% static 'game/js/board.js' %}"></script>
 
     <script>


### PR DESCRIPTION
## Overview
This PR adds a complete post-game move replay system for completed chess matches, allowing users to review games move-by-move directly on the chessboard.

The replay system improves gameplay analysis, learning experience, and overall post-game interaction for both PvP and AI matches.

Closes #1155

---

## Features Added

- Step-by-step move replay
- Previous / Next move navigation
- Jump to first and last move
- Auto replay functionality
- Dynamic board updates during replay
- Replay controls shown after game completion
- Replay support for both PvP and AI games

---

## Technical Changes

### Frontend
- Added replay controls UI
- Implemented replay state management
- Added replay navigation handlers
- Integrated Chess.js replay reconstruction
- Synced replay positions with board rendering

### Replay Logic
- Rebuilds board positions move-by-move
- Supports SAN notation replay
- Handles replay navigation safely
- Updates board state dynamically during replay

---

## UI/UX Improvements

- Improved post-game experience
- Easier game analysis for players
- Professional replay functionality similar to modern chess platforms

---

## Tested

- PvP matches
- AI matches
- Replay controls
- Auto replay
- First / Last move navigation
- Replay after resignation
- Replay after checkmate
- Board synchronization during replay