### PR TITLE
fix: clean up expired pending OTP accounts (#1201)

### DIFF
--- a/game/tests.py
+++ b/game/tests.py
@@ -182,6 +182,56 @@ class RegistrationViewTest(TestCase):
         self.assertNotIn('registration_user_id', self.client.session)
         self.assertNotIn('registration_otp_hash', self.client.session)
 
+    def test_expired_otp_removes_pending_inactive_user(self):
+        user = User.objects.create_user(
+            username='pendingplayer',
+            email='pendingplayer@example.com',
+            password='StrongPass123!',
+            is_active=False,
+        )
+        session = self.client.session
+        session['registration_user_id'] = user.id
+        session['registration_otp_hash'] = 'stored-hash'
+        session['otp_created_at'] = 100.0
+        session.save()
+
+        with mock.patch('game.views.time.time', return_value=401.0):
+            response = self.client.post('/verify-otp/', data={'otp': '123456'})
+
+        self.assertRedirects(response, '/register/')
+        self.assertFalse(User.objects.filter(id=user.id).exists())
+        self.assertNotIn('registration_user_id', self.client.session)
+        self.assertNotIn('registration_otp_hash', self.client.session)
+        self.assertNotIn('otp_created_at', self.client.session)
+
+    @override_settings(
+        EMAIL_HOST_USER='sender@example.com',
+        EMAIL_HOST_PASSWORD='app-password'
+    )
+    def test_resend_otp_refreshes_expiry_window(self):
+        user = User.objects.create_user(
+            username='resendplayer',
+            email='resendplayer@example.com',
+            password='StrongPass123!',
+            is_active=False,
+        )
+        session = self.client.session
+        session['registration_user_id'] = user.id
+        session['registration_otp_hash'] = 'old-hash'
+        session['otp_created_at'] = 100.0
+        session.save()
+
+        with (
+            mock.patch('game.views.send_mail'),
+            mock.patch('game.views.time.time', return_value=200.0),
+        ):
+            response = self.client.get('/resend-otp/')
+
+        self.assertRedirects(response, '/verify-otp/')
+        self.assertEqual(self.client.session['otp_created_at'], 200.0)
+        self.assertEqual(self.client.session['last_otp_time'], 200.0)
+        self.assertNotEqual(self.client.session['registration_otp_hash'], 'old-hash')
+
 
 class CustomSetPasswordFormTest(TestCase):
     """Password reset form should reject reusing the current password."""

--- a/game/views.py
+++ b/game/views.py
@@ -630,6 +630,11 @@ def verify_otp(request):
 
         if otp_created_at:
             if time.time() - otp_created_at > 300:
+                try:
+                    pending_user = User.objects.get(id=user_id, is_active=False)
+                    pending_user.delete()
+                except User.DoesNotExist:
+                    pass
 
                 messages.error(
                     request,
@@ -756,6 +761,7 @@ def resend_otp(request):
     ).hexdigest()
 
     request.session['registration_otp_hash'] = otp_hash
+    request.session['otp_created_at'] = time.time()
 
     try:
         send_mail(
@@ -980,5 +986,3 @@ def password_reset_account_selection(request):
             'email': email
         }
     )
-
-    


### PR DESCRIPTION
## Summary\n- delete inactive pending users when their registration OTP has expired instead of only clearing the session\n- refresh the OTP creation timestamp on resend so retried verification gets a fresh expiry window\n- add focused registration-flow regressions for expired pending accounts and resend expiry refresh\n\nFixes #1201\n\n## Verification\n- python manage.py test game.tests.RegistrationViewTest\n- python manage.py check\n- git diff --check\n\nNotes:\n- python manage.py check still reports the repo's existing DEFAULT_AUTO_FIELD warning\n- the test run also shows the pre-existing missing staticfiles/ directory warning in this checkout