### PR TITLE
fix: center orphan capability card on landing page (#1206)

### DIFF
--- a/game/static/game/css/landing.css
+++ b/game/static/game/css/landing.css
@@ -690,7 +690,7 @@ body {
 
 .capabilities-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 2rem;
     justify-content: center;
 }
@@ -731,6 +731,10 @@ body {
     border-color: rgba(240, 192, 64, 0.3);
 }
 
+.capability-card--orphan {
+    grid-column: 2;
+}
+
 .capability-title {
     font-size: 1.2rem;
     font-weight: 600;
@@ -749,6 +753,17 @@ body {
    Media Queries & Responsiveness Breakpoints
    ========================================================================== */
 @media (max-width: 1024px) {
+    .capabilities-grid {
+        grid-template-columns: repeat(2, minmax(280px, 1fr));
+    }
+
+    .capability-card--orphan {
+        grid-column: 1 / -1;
+        justify-self: center;
+        max-width: min(100%, 420px);
+        width: 100%;
+    }
+
     .footer-container {
         grid-template-columns: 1.5fr 1fr;
         gap: 3rem;
@@ -756,6 +771,16 @@ body {
 }
 
 @media (max-width: 768px) {
+    .capabilities-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .capability-card--orphan {
+        grid-column: auto;
+        justify-self: stretch;
+        max-width: none;
+    }
+
     .navbar {
         flex-direction: column;
         gap: 1rem;

--- a/game/templates/game/landing.html
+++ b/game/templates/game/landing.html
@@ -311,7 +311,7 @@
             <p class="capability-desc">Rigorous real-time move validation covering castling, en passant, and pawn promotions.</p>
           </div>
 
-          <div class="capability-card">
+          <div class="capability-card capability-card--orphan">
             <div class="capability-icon">
               <svg aria-hidden="true" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <circle cx="12" cy="12" r="3"/>

--- a/game/tests.py
+++ b/game/tests.py
@@ -89,6 +89,7 @@ class LandingViewTest(TestCase):
         response = self.client.get('/')
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Checkora')
+        self.assertContains(response, 'capability-card--orphan')
 
     def test_landing_page_links_to_play(self):
         response = self.client.get('/')


### PR DESCRIPTION
## Summary\n- add a dedicated orphan-card hook for the final Platform Capabilities item\n- center the lone final card cleanly on desktop and keep it spanning/centering gracefully at the tablet breakpoint\n- add a focused landing-page regression assertion so the orphan-card hook stays present\n\nFixes #1206\n\n## Verification\n- python manage.py test game.tests.LandingViewTest\n- python manage.py check\n- git diff --check\n\nNotes:\n- python manage.py check still reports the repo's existing DEFAULT_AUTO_FIELD warning\n- the local test run also warns about the missing staticfiles/ directory in this checkout, which is pre-existing and unrelated to this layout fix