### PR TITLE
fix: restore site header and footer on static pages (#1210)

### DIFF
--- a/game/static/game/css/landing.css
+++ b/game/static/game/css/landing.css
@@ -690,7 +690,7 @@ body {
 
 .capabilities-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 2rem;
     justify-content: center;
 }
@@ -731,6 +731,10 @@ body {
     border-color: rgba(240, 192, 64, 0.3);
 }
 
+.capability-card--orphan {
+    grid-column: 2;
+}
+
 .capability-title {
     font-size: 1.2rem;
     font-weight: 600;
@@ -749,6 +753,17 @@ body {
    Media Queries & Responsiveness Breakpoints
    ========================================================================== */
 @media (max-width: 1024px) {
+    .capabilities-grid {
+        grid-template-columns: repeat(2, minmax(280px, 1fr));
+    }
+
+    .capability-card--orphan {
+        grid-column: 1 / -1;
+        justify-self: center;
+        max-width: min(100%, 420px);
+        width: 100%;
+    }
+
     .footer-container {
         grid-template-columns: 1.5fr 1fr;
         gap: 3rem;
@@ -756,6 +771,16 @@ body {
 }
 
 @media (max-width: 768px) {
+    .capabilities-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .capability-card--orphan {
+        grid-column: auto;
+        justify-self: stretch;
+        max-width: none;
+    }
+
     .navbar {
         flex-direction: column;
         gap: 1rem;

--- a/game/static/game/css/static_page.css
+++ b/game/static/game/css/static_page.css
@@ -1,0 +1,194 @@
+.static-page-shell {
+    flex: 1;
+    width: min(100%, 1120px);
+    margin: 0 auto;
+    padding: 2rem 1.5rem 4rem;
+}
+
+.static-page-card {
+    background: #131522;
+    border-radius: 18px;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    box-shadow: 0 20px 50px rgba(0, 0, 0, 0.45);
+    padding: 3rem;
+}
+
+.static-page-card--narrow {
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.static-page-card--wide {
+    max-width: 1000px;
+    margin: 0 auto;
+}
+
+.static-page-title {
+    color: #ffffff;
+    font-size: 2.5rem;
+    font-weight: 700;
+    margin-bottom: 0.5rem;
+    letter-spacing: -0.5px;
+}
+
+.static-page-title--accent {
+    color: var(--accent-gold);
+}
+
+.static-page-subtitle,
+.static-page-updated {
+    color: var(--text-secondary);
+    font-size: 0.98rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    padding-bottom: 1.5rem;
+    margin-bottom: 2rem;
+}
+
+.static-page-copy {
+    color: rgba(255, 255, 255, 0.88);
+    font-size: 1.05rem;
+    line-height: 1.7;
+}
+
+.static-page-section {
+    margin-bottom: 2rem;
+}
+
+.static-page-section h2 {
+    color: #ffffff;
+    font-size: 1.35rem;
+    font-weight: 600;
+    margin-bottom: 0.75rem;
+}
+
+.static-page-section p {
+    margin-bottom: 0.95rem;
+}
+
+.static-page-section ul {
+    margin: 0 0 0.95rem 1.25rem;
+}
+
+.static-page-section li {
+    margin-bottom: 0.5rem;
+}
+
+.static-page-copy a {
+    color: var(--accent-gold);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.static-page-copy a:hover {
+    text-decoration: underline;
+}
+
+.contact-grid {
+    display: grid;
+    grid-template-columns: 0.8fr 1.5fr;
+    gap: 3.75rem;
+}
+
+.contact-info-column {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.contact-info-card h3 {
+    color: #ffffff;
+    font-size: 1.2rem;
+    font-weight: 600;
+    margin-bottom: 0.75rem;
+}
+
+.contact-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.contact-form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+}
+
+.contact-form-group label {
+    color: #ffffff;
+    font-size: 0.9rem;
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+}
+
+.contact-form-control {
+    background-color: #1a1d30;
+    border: 1px solid #2b2f4a;
+    border-radius: 8px;
+    padding: 0.9rem 1.1rem;
+    color: #ffffff;
+    font-family: inherit;
+    font-size: 0.95rem;
+    transition: border-color 0.25s ease, box-shadow 0.25s ease, background-color 0.25s ease;
+    width: 100%;
+}
+
+.contact-form-control:hover {
+    border-color: rgba(255, 255, 255, 0.15);
+}
+
+.contact-form-control:focus {
+    outline: none;
+    background-color: #1e213a;
+    border-color: var(--accent-gold);
+    box-shadow: 0 0 0 4px rgba(240, 192, 64, 0.12);
+}
+
+textarea.contact-form-control {
+    resize: vertical;
+    min-height: 150px;
+}
+
+.contact-submit {
+    background: linear-gradient(135deg, var(--accent-gold), #d4a020);
+    color: #1a1a2e;
+    border: none;
+    padding: 0.95rem 2rem;
+    font-size: 1rem;
+    font-weight: 700;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.25s ease;
+    align-self: flex-start;
+    box-shadow: 0 4px 15px rgba(240, 192, 64, 0.2);
+}
+
+.contact-submit:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 24px rgba(240, 192, 64, 0.35);
+}
+
+@media (max-width: 768px) {
+    .static-page-shell {
+        padding: 1.5rem 1rem 3rem;
+    }
+
+    .static-page-card {
+        padding: 1.5rem;
+    }
+
+    .static-page-title {
+        font-size: 2rem;
+    }
+
+    .contact-grid {
+        grid-template-columns: 1fr;
+        gap: 2.5rem;
+    }
+
+    .contact-submit {
+        width: 100%;
+        text-align: center;
+    }
+}

--- a/game/templates/game/contact.html
+++ b/game/templates/game/contact.html
@@ -1,312 +1,59 @@
-{% load static %}
+{% extends "game/static_page_base.html" %}
 
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+{% block title %}Contact Us - Checkora{% endblock %}
+{% block card_class %}static-page-card--wide{% endblock %}
 
-    <title>Contact Us - Checkora</title>
+{% block static_content %}
+<h1 class="static-page-title">Contact Us</h1>
+<p class="static-page-subtitle">
+    Have questions about the C++ platform integration or found a glitch? Reach out to the maintainers.
+</p>
 
-    <style>
-        /* Base Reset & Variables */
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-
-        :root {
-            --bg-color: #0d0e15;
-            --card-bg: #131522;
-            --text-main: #ffffff;
-            --text-muted: #9fa3b9;
-            --accent-color: #ffc107;
-            --line-height: 1.7;
-            --input-bg: #1a1d30;
-            --input-border: #2b2f4a;
-        }
-
-        body {
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-            background: radial-gradient(circle at 50% -20%, #1a1c2e 0%, #0d0e15 60%);
-            background-attachment: fixed;
-            color: var(--text-main);
-            line-height: var(--line-height);
-            padding: 0 20px;
-            display: flex;
-            flex-direction: column;
-            min-height: 100vh;
-        }
-
-        /* Header / Navigation */
-        header {
-            max-width: 1000px; /* Increased to allow wider layout tracking */
-            width: 100%;
-            margin: 0 auto;
-            padding: 40px 0 10px 0;
-        }
-
-        .back-link {
-            color: var(--accent-color);
-            text-decoration: none;
-            font-weight: 600;
-            font-size: 0.95rem;
-            transition: opacity 0.2s ease, transform 0.2s ease;
-            display: inline-block;
-        }
-
-        .back-link:hover {
-            opacity: 0.9;
-            transform: translateX(-3px);
-        }
-
-        /* Main Content Container */
-        .container {
-            max-width: 1000px; /* Expanded from 900px to expand general card boundary */
-            width: 100%;
-            margin: 30px auto 60px auto;
-            background-color: var(--card-bg);
-            padding: 50px;
-            border-radius: 16px;
-            border: none;
-            box-shadow: 0 20px 50px rgba(0, 0, 0, 0.7);
-            flex: 1;
-        }
-
-        h1 {
-            color: #ffffff;
-            font-size: 2.6rem;
-            font-weight: 700;
-            margin-bottom: 10px;
-            letter-spacing: -0.5px;
-        }
-
-        .subtitle-desc {
-            color: var(--text-muted);
-            font-size: 1.05rem;
-            margin-bottom: 40px;
-            border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-            padding-bottom: 25px;
-        }
-
-        /* Contact Grid Split Layout - Form area widened */
-        .contact-grid {
-            display: grid;
-            grid-template-columns: 0.8fr 1.5fr; /* Shifted from 1fr 1.3fr to widen the form panel */
-            gap: 60px;
-        }
-
-        /* Information Column */
-        .info-col {
-            display: flex;
-            flex-direction: column;
-            gap: 35px;
-        }
-
-        .info-card h3 {
-            color: #ffffff;
-            font-size: 1.25rem;
-            font-weight: 600;
-            margin-bottom: 10px;
-            display: flex;
-            align-items: center;
-            gap: 10px;
-        }
-
-        .info-card p {
-            color: var(--text-muted);
-            font-size: 0.95rem;
-            line-height: 1.6;
-        }
-
-        .info-card a {
-            color: var(--accent-color);
-            text-decoration: none;
-            font-weight: 500;
-            transition: color 0.2s ease;
-        }
-
-        .info-card a:hover {
-            color: #ffffff;
-            text-decoration: underline;
-        }
-
-        /* Interactive Form Fields */
-        .form-col form {
-            display: flex;
-            flex-direction: column;
-            gap: 24px;
-        }
-
-        .form-group {
-            display: flex;
-            flex-direction: column;
-            gap: 10px;
-        }
-
-        .form-group label {
-            color: #ffffff;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.5px;
-            text-transform: uppercase;
-            opacity: 0.9;
-        }
-
-        .form-control {
-            background-color: var(--input-bg);
-            border: 1px solid var(--input-border);
-            border-radius: 8px;
-            padding: 14px 18px;
-            color: #ffffff;
-            font-family: inherit;
-            font-size: 0.95rem;
-            transition: border-color 0.25s ease, box-shadow 0.25s ease, background-color 0.25s ease;
-            width: 100%;
-        }
-
-        .form-control:hover {
-            border-color: rgba(255, 255, 255, 0.15);
-        }
-
-        .form-control:focus {
-            outline: none;
-            background-color: #1e213a;
-            border-color: var(--accent-color);
-            box-shadow: 0 0 0 4px rgba(240, 192, 64, 0.12);
-        }
-
-        textarea.form-control {
-            resize: vertical;
-            min-height: 150px;
-        }
-
-        /* Premium Accent Action Button */
-        .btn-submit {
-            background: linear-gradient(135deg, var(--accent-color), #d4a020);
-            color: #1a1a2e;
-            border: none;
-            padding: 15px 32px;
-            font-size: 1rem;
-            font-weight: 700;
-            border-radius: 8px;
-            cursor: pointer;
-            transition: all 0.25s ease;
-            align-self: flex-start;
-            box-shadow: 0 4px 15px rgba(240, 192, 64, 0.2);
-        }
-
-        .btn-submit:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 8px 24px rgba(240, 192, 64, 0.35);
-        }
-
-        .btn-submit:active {
-            transform: translateY(0);
-        }
-
-        /* Footer Settings */
-        footer {
-            max-width: 1000px;
-            width: 100%;
-            margin: 0 auto;
-            padding: 40px 0;
-            text-align: center;
-            border-top: 1px solid rgba(255, 255, 255, 0.05);
-        }
-
-        .footer-copy {
-            color: var(--text-muted);
-            font-size: 0.9rem;
-        }
-
-        /* Responsive Configuration for Small Viewports */
-        @media (max-width: 768px) {
-            .container {
-                padding: 35px 25px;
-                margin-top: 20px;
-            }
-
-            .contact-grid {
-                grid-template-columns: 1fr;
-                gap: 45px;
-            }
-
-            h1 {
-                font-size: 2.1rem;
-            }
-            
-            .btn-submit {
-                width: 100%;
-                text-align: center;
-            }
-        }
-    </style>
-</head>
-
-<body>
-
-    <header>
-        <a href="{% url 'landing' %}" class="back-link">&larr; Back to Home</a>
-    </header>
-
-    <div class="container">
-
-        <h1>Contact Us</h1>
-        <p class="subtitle-desc">Have questions about the C++ platform integration or found a glitch? Reach out to the maintainers.</p>
-
-        <div class="contact-grid">
-            
-            <div class="info-col">
-                <div class="info-card">
-                    <h3>Community Support</h3>
-                    <p>For instant technical coordination, join our active development spaces on the <a href="https://discord.gg/WfrpMuNZn" target="_blank" rel="noopener noreferrer">Discord Server</a>.</p>
-                </div>
-
-                <div class="info-card">
-                    <h3>Open Source &amp; Bugs</h3>
-                    <p>Found a calculation variant failure or a move validation flaw? Open an inspection thread on our <a href="https://github.com/Checkora" target="_blank" rel="noopener noreferrer">GitHub Issue Tracker</a>.</p>
-                </div>
-
-                <div class="info-card">
-                    <h3>Maintainer Reach</h3>
-                    <p>Email: <a href="mailto:support@checkora.example.com">support@checkora.example.com</a></p>
-                </div>
-            </div>
-
-            <div class="form-col">
-                <form action="#" method="POST" onsubmit="alert('Message logged locally inside development environment container loop.'); return false;">
-                    {% csrf_token %}
-                    
-                    <div class="form-group">
-                        <label for="name">Name</label>
-                        <input type="text" id="name" name="name" class="form-control" placeholder="Your name" required />
-                    </div>
-
-                    <div class="form-group">
-                        <label for="email">Email Address</label>
-                        <input type="email" id="email" name="email" class="form-control" placeholder="username@example.com" required />
-                    </div>
-
-                    <div class="form-group">
-                        <label for="message">Message</label>
-                        <textarea id="message" name="message" class="form-control" placeholder="Type your query regarding engine or interface states..." required></textarea>
-                    </div>
-
-                    <button type="submit" class="btn-submit">Send Message</button>
-                </form>
-            </div>
-
+<div class="contact-grid">
+    <div class="contact-info-column">
+        <div class="contact-info-card">
+            <h3>Community Support</h3>
+            <p>
+                For instant technical coordination, join our active development spaces on the
+                <a href="https://discord.gg/WfrpMuNZn" target="_blank" rel="noopener noreferrer">Discord Server</a>.
+            </p>
         </div>
 
+        <div class="contact-info-card">
+            <h3>Open Source &amp; Bugs</h3>
+            <p>
+                Found a calculation variant failure or a move validation flaw? Open an inspection thread on our
+                <a href="https://github.com/Checkora" target="_blank" rel="noopener noreferrer">GitHub Issue Tracker</a>.
+            </p>
+        </div>
+
+        <div class="contact-info-card">
+            <h3>Maintainer Reach</h3>
+            <p>Email: <a href="mailto:support@checkora.example.com">support@checkora.example.com</a></p>
+        </div>
     </div>
 
-    <footer>
-        <span class="footer-copy">
-            &copy; {% now "Y" %} Checkora Hybrid Engine. All rights reserved.
-        </span>
-    </footer>
+    <div>
+        <form action="#" method="POST" class="contact-form" onsubmit="alert('Message logged locally inside development environment container loop.'); return false;">
+            {% csrf_token %}
 
-</body>
-</html>
+            <div class="contact-form-group">
+                <label for="name">Name</label>
+                <input type="text" id="name" name="name" class="contact-form-control" placeholder="Your name" required />
+            </div>
+
+            <div class="contact-form-group">
+                <label for="email">Email Address</label>
+                <input type="email" id="email" name="email" class="contact-form-control" placeholder="username@example.com" required />
+            </div>
+
+            <div class="contact-form-group">
+                <label for="message">Message</label>
+                <textarea id="message" name="message" class="contact-form-control" placeholder="Type your query regarding engine or interface states..." required></textarea>
+            </div>
+
+            <button type="submit" class="contact-submit">Send Message</button>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/game/templates/game/landing.html
+++ b/game/templates/game/landing.html
@@ -311,7 +311,7 @@
             <p class="capability-desc">Rigorous real-time move validation covering castling, en passant, and pawn promotions.</p>
           </div>
 
-          <div class="capability-card">
+          <div class="capability-card capability-card--orphan">
             <div class="capability-icon">
               <svg aria-hidden="true" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <circle cx="12" cy="12" r="3"/>

--- a/game/templates/game/privacy.html
+++ b/game/templates/game/privacy.html
@@ -1,269 +1,82 @@
-{% load static %}
+{% extends "game/static_page_base.html" %}
 
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+{% block title %}Privacy Policy - Checkora{% endblock %}
 
-    <title>Privacy Policy - Checkora</title>
+{% block static_content %}
+<h1 class="static-page-title static-page-title--accent">Privacy Policy</h1>
+<div class="static-page-updated">Last updated: May 2026</div>
 
-    <style>
-        /* Base Reset & Variables */
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+<section class="static-page-section">
+    <h2>1. Information We Collect</h2>
+    <p>
+        Checkora is an open-source hybrid chess platform designed for transparent,
+        secure, and performant online gameplay. We only collect basic information
+        necessary to manage user authentication and orchestrate your chess matches:
+    </p>
+    <ul>
+        <li>
+            <strong>Account Data:</strong>
+            Username, email address, and encrypted password profiles when you choose to register.
+        </li>
+        <li>
+            <strong>Gameplay Metrics:</strong>
+            Move history, win/loss stats, match durations, and bullet/blitz time preferences
+            to compute accurate leaderboard rankings.
+        </li>
+        <li>
+            <strong>Technical Logs:</strong>
+            Minimal background telemetry data such as session tokens to keep you securely
+            logged in across page reloads.
+        </li>
+    </ul>
+</section>
 
-        :root {
-            --bg-color: #0d0e15;
-            --card-bg: #131522;
-            --text-main: #ffffff;
-            --text-muted: #9fa3b9;
-            --accent-color: #ffc107;
-            --line-height: 1.7;
-        }
+<section class="static-page-section">
+    <h2>2. How Your Data is Used</h2>
+    <p>
+        Your data remains dedicated exclusively to powering your active application experiences.
+        We use the tracked parameters to:
+    </p>
+    <ul>
+        <li>Maintain your personalized player profile dashboard and performance metrics.</li>
+        <li>Calculate real-time material scores and process live move-validation checks.</li>
+        <li>Optimize the sync pipeline between backend systems and computation services.</li>
+    </ul>
+</section>
 
-        body {
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-            background: radial-gradient(circle at 50% -20%, #1a1c2e 0%, #0d0e15 60%);
-            background-attachment: fixed;
-            color: var(--text-main);
-            line-height: var(--line-height);
-            padding: 0 20px;
-            display: flex;
-            flex-direction: column;
-            min-height: 100vh;
-        }
+<section class="static-page-section">
+    <h2>3. Cookies and Session Storage</h2>
+    <p>
+        We use essential cookies and local storage tokens to manage system authentication
+        states and secure form submissions against Cross-Site Request Forgery (CSRF).
+        No tracking cookies or behavioral profile monitors are embedded inside the platform.
+    </p>
+</section>
 
-        /* Header / Navigation */
-        header {
-            max-width: 900px;
-            width: 100%;
-            margin: 0 auto;
-            padding: 30px 0 10px 0;
-        }
+<section class="static-page-section">
+    <h2>4. Data Retention &amp; Security</h2>
+    <p>
+        We retain your profile credentials and match logs for as long as your account
+        remains active. Passwords are securely stored using Django authentication
+        hashing mechanisms.
+    </p>
+</section>
 
-        .back-link {
-            color: var(--accent-color);
-            text-decoration: none;
-            font-weight: 600;
-            font-size: 0.95rem;
-            transition: opacity 0.2s ease;
-        }
+<section class="static-page-section">
+    <h2>5. Open Source Transparency &amp; User Rights</h2>
+    <p>
+        In alignment with our open-source framework and GSSoC community policies,
+        users maintain full authority over their data and may request account deletion
+        or data removal at any time.
+    </p>
+</section>
 
-        .back-link:hover {
-            opacity: 0.8;
-            text-decoration: underline;
-        }
-
-        /* Main Content Container */
-        .container {
-            max-width: 900px;
-            width: 100%;
-            margin: 40px auto;
-            background-color: var(--card-bg);
-            padding: 40px;
-            border-radius: 12px;
-            border: 1px solid rgba(255, 255, 255, 0.03);
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
-            flex: 1;
-        }
-
-        h1 {
-            color: var(--accent-color);
-            font-size: 2.5rem;
-            font-weight: 700;
-            margin-bottom: 8px;
-            letter-spacing: -0.5px;
-        }
-
-        .last-updated {
-            color: var(--text-muted);
-            font-size: 0.9rem;
-            margin-bottom: 40px;
-            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-            padding-bottom: 20px;
-        }
-
-        /* Policy Sections */
-        section {
-            margin-bottom: 35px;
-        }
-
-        h2 {
-            color: var(--text-main);
-            font-size: 1.4rem;
-            font-weight: 600;
-            margin-bottom: 12px;
-        }
-
-        p {
-            color: rgba(255, 255, 255, 0.85);
-            font-size: 1.05rem;
-            margin-bottom: 15px;
-        }
-
-        ul {
-            margin-left: 20px;
-            margin-bottom: 15px;
-            color: rgba(255, 255, 255, 0.85);
-        }
-
-        li {
-            margin-bottom: 8px;
-            font-size: 1.05rem;
-        }
-
-        /* Footer Settings */
-        footer {
-            max-width: 900px;
-            width: 100%;
-            margin: 0 auto;
-            padding: 40px 0;
-            text-align: center;
-            border-top: 1px solid rgba(255, 255, 255, 0.05);
-        }
-
-        .footer-copy {
-            color: var(--text-muted);
-            font-size: 0.9rem;
-        }
-
-        /* Responsive Breakpoints */
-        @media (max-width: 768px) {
-            .container {
-                padding: 20px;
-                margin-top: 20px;
-            }
-
-            h1 {
-                font-size: 2rem;
-            }
-
-            h2 {
-                font-size: 1.25rem;
-            }
-        }
-    </style>
-</head>
-
-<body>
-
-    <header>
-        <a href="{% url 'landing' %}" class="back-link">
-            ← Back to Home
-        </a>
-    </header>
-
-    <div class="container">
-
-        <h1>Privacy Policy</h1>
-
-        <div class="last-updated">
-            Last updated: May 2026
-        </div>
-
-        <section>
-            <h2>1. Information We Collect</h2>
-
-            <p>
-                Checkora is an open-source hybrid chess platform designed for transparent,
-                secure, and performant online gameplay. We only collect basic information
-                necessary to manage user authentication and orchestrate your chess matches:
-            </p>
-
-            <ul>
-                <li>
-                    <strong>Account Data:</strong>
-                    Username, email address, and encrypted password profiles when you choose to register.
-                </li>
-
-                <li>
-                    <strong>Gameplay Metrics:</strong>
-                    Move history, win/loss stats, match durations, and bullet/blitz time preferences
-                    to compute accurate leaderboard rankings.
-                </li>
-
-                <li>
-                    <strong>Technical Logs:</strong>
-                    Minimal background telemetry data such as session tokens to keep you securely
-                    logged in across page reloads.
-                </li>
-            </ul>
-        </section>
-
-        <section>
-            <h2>2. How Your Data is Used</h2>
-
-            <p>
-                Your data remains dedicated exclusively to powering your active application experiences.
-                We use the tracked parameters to:
-            </p>
-
-            <ul>
-                <li>
-                    Maintain your personalized player profile dashboard and performance metrics.
-                </li>
-
-                <li>
-                    Calculate real-time material scores and process live move-validation checks.
-                </li>
-
-                <li>
-                    Optimize the sync pipeline between backend systems and computation services.
-                </li>
-            </ul>
-        </section>
-
-        <section>
-            <h2>3. Cookies and Session Storage</h2>
-
-            <p>
-                We use essential cookies and local storage tokens to manage system authentication
-                states and secure form submissions against Cross-Site Request Forgery (CSRF).
-                No tracking cookies or behavioral profile monitors are embedded inside the platform.
-            </p>
-        </section>
-
-        <section>
-            <h2>4. Data Retention &amp; Security</h2>
-
-            <p>
-                We retain your profile credentials and match logs for as long as your account
-                remains active. Passwords are securely stored using Django authentication
-                hashing mechanisms.
-            </p>
-        </section>
-
-        <section>
-            <h2>5. Open Source Transparency &amp; User Rights</h2>
-
-            <p>
-                In alignment with our open-source framework and GSSoC community policies,
-                users maintain full authority over their data and may request account deletion
-                or data removal at any time.
-            </p>
-        </section>
-
-        <section>
-            <h2>6. Contact &amp; Community Channels</h2>
-
-            <p>
-                If you have questions or feedback regarding this Privacy Policy,
-                please open an issue on our GitHub repository or contact the project
-                maintainers directly.
-            </p>
-        </section>
-
-    </div>
-
-    <footer>
-        <span class="footer-copy">
-            &copy; 2026 Checkora Hybrid Engine. All rights reserved.
-        </span>
-    </footer>
-
-</body>
-</html>
+<section class="static-page-section">
+    <h2>6. Contact &amp; Community Channels</h2>
+    <p>
+        If you have questions or feedback regarding this Privacy Policy,
+        please open an issue on our GitHub repository or contact the project
+        maintainers directly.
+    </p>
+</section>
+{% endblock %}

--- a/game/templates/game/static_page_base.html
+++ b/game/templates/game/static_page_base.html
@@ -1,0 +1,136 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Checkora{% endblock %}</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="{% static 'game/css/landing.css' %}" />
+    <link rel="stylesheet" href="{% static 'game/css/static_page.css' %}" />
+</head>
+<body>
+    <nav class="navbar">
+      <div class="nav-left">
+        <a href="{% url 'landing' %}" class="logo-link">
+          <img
+            src="{% static 'game/checkora_icon_only.png' %}"
+            alt="Checkora Logo"
+            class="logo-img"
+          />
+          <span class="logo-text">CHECK<span class="logo-accent">ORA</span></span>
+        </a>
+        <div class="nav-links">
+          <a href="{% url 'landing' %}">Home</a>
+          <a href="{% url 'landing' %}#about">About</a>
+          <a href="{% url 'landing' %}#features">Features</a>
+        </div>
+      </div>
+      <div class="nav-right">
+        {% if user.is_authenticated %}
+        <a href="{% url 'index' %}" class="btn-signin">Dashboard</a>
+        <form method="post" action="{% url 'logout' %}" style="display: inline">
+          {% csrf_token %}
+          <button type="submit" class="btn-register">Log Out</button>
+        </form>
+        {% else %}
+        <a href="{% url 'login' %}" class="btn-signin">Sign In</a>
+        <a href="{% url 'register' %}" class="btn-register">Register</a>
+        {% endif %}
+      </div>
+    </nav>
+
+    <main class="static-page-shell">
+      <div class="static-page-card {% block card_class %}static-page-card--narrow{% endblock %}">
+        <div class="static-page-copy">
+          {% block static_content %}{% endblock %}
+        </div>
+      </div>
+    </main>
+
+    <footer class="footer">
+      <div class="footer-container">
+        <div class="footer-col brand-column">
+          <a href="{% url 'landing' %}" class="logo-link">
+            <img
+              src="{% static 'game/checkora_icon_only.png' %}"
+              alt="Checkora Logo"
+              class="logo-img"
+            />
+            <span class="logo-text">CHECK<span class="logo-accent">ORA</span></span>
+          </a>
+          <p class="brand-desc">
+            Experience high-performance chess with Checkora's hybrid C++ engine.
+            Challenge the AI, track your stats, and master the board.
+          </p>
+        </div>
+
+        <div class="footer-col">
+          <h4>Platform</h4>
+          <ul class="footer-nav-list">
+            <li><a href="{% url 'index' %}" class="footer-link">Play Game</a></li>
+            <li><a href="{% url 'stats' %}" class="footer-link">Statistics</a></li>
+            <li><a href="{% url 'rules' %}" class="footer-link">Rulebook</a></li>
+          </ul>
+        </div>
+
+        <div class="footer-col">
+          <h4>Community</h4>
+          <ul class="footer-nav-list">
+            <li>
+              <a href="https://github.com/Checkora" target="_blank" rel="noopener noreferrer" class="footer-link">
+                GitHub Organization
+              </a>
+            </li>
+            <li>
+              <a href="https://discord.gg/WfrpMuNZn" target="_blank" rel="noopener noreferrer" class="footer-link">
+                Discord Community
+              </a>
+            </li>
+            <li class="maintainer-item">
+              <span class="footer-meta-text">
+                Maintainers:
+                <a href="https://github.com/triemerge" target="_blank" rel="noopener noreferrer">@triemerge</a> &amp;
+                <a href="https://github.com/EDWARD-012" target="_blank" rel="noopener noreferrer">@EDWARD-012</a>
+              </span>
+            </li>
+          </ul>
+        </div>
+
+        <div class="footer-col">
+          <h4>Legal</h4>
+          <ul class="footer-nav-list">
+            <li><a href="{% url 'privacy' %}" class="footer-link">Privacy Policy</a></li>
+            <li><a href="{% url 'terms' %}" class="footer-link">Terms &amp; Conditions</a></li>
+            <li><a href="{% url 'contact' %}" class="footer-link">Contact Us</a></li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="footer-bottom">
+        <span class="footer-copy">
+          &copy; {% now "Y" %} Checkora Hybrid Engine. All rights reserved.
+        </span>
+        <div class="footer-socials">
+          <a href="https://github.com/Checkora" target="_blank" rel="noopener noreferrer" aria-label="GitHub Link">
+            <svg width="20" height="20" viewBox="0 0 24 24">
+              <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" fill="currentColor"/>
+            </svg>
+          </a>
+          <a href="https://discord.gg/WfrpMuNZn" target="_blank" rel="noopener noreferrer" aria-label="Discord Link">
+            <svg width="20" height="20" viewBox="0 0 24 24">
+              <path d="M19.27 5.33C17.94 4.71 16.5 4.26 15 4a.09.09 0 0 0-.07.03c-.18.33-.39.76-.53 1.09a16.09 16.09 0 0 0-4.8 0c-.14-.34-.35-.76-.54-1.09c-.01-.02-.04-.03-.07-.03c-1.5.26-2.93.71-4.27 1.33c-.01 0-.02.01-.03.02c-2.72 4.07-3.47 8.03-3.1 11.95c0 .02.02.04.03.05c1.8 1.32 3.53 2.12 5.24 2.65c.03.01.06 0 .07-.02c.4-.55.76-1.13 1.07-1.74c.02-.04 0-.08-.04-.09c-.57-.22-1.11-.48-1.64-.78c-.04-.02-.04-.08-.01-.11c.11-.08.22-.17.33-.25c.02-.02.05-.02.07-.01c3.44 1.57 7.15 1.57 10.55 0c.02-.01.05-.01.07.01c.11.09.22.17.33.26c.04.03.04.09-.01.11c-.52.31-1.07.56-1.64.78c-.04.01-.05.06-.04.09c.32.61.68 1.19 1.07 1.74c.03.01.06 0 .09.01c1.72-.53 3.45-1.33 5.25-2.65c.02-.01.03-.03.03-.05.44-4.53-.73-8.46-3.1-11.95c-.01-.01-.02-.02-.04-.02zM8.52 14.91c-1.03 0-1.89-.95-1.89-2.12s.84-2.12 1.89-2.12c1.06 0 1.9.96 1.89 2.12c0 1.17-.84 2.12-1.89 2.12zm6.97 0c-1.03 0-1.89-.95-1.89-2.12s.84-2.12 1.89-2.12c1.06 0 1.9.96 1.89 2.12c0 1.17-.83 2.12-1.89 2.12z" fill="currentColor"/>
+            </svg>
+          </a>
+        </div>
+      </div>
+    </footer>
+</body>
+</html>

--- a/game/templates/game/terms.html
+++ b/game/templates/game/terms.html
@@ -1,216 +1,56 @@
-{% load static %}
+{% extends "game/static_page_base.html" %}
 
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+{% block title %}Terms and Conditions - Checkora{% endblock %}
 
-    <title>Terms and Conditions - Checkora</title>
+{% block static_content %}
+<h1 class="static-page-title static-page-title--accent">Terms and Conditions</h1>
+<div class="static-page-updated">Last updated: May 2026</div>
 
-    <style>
-        /* Base Reset & Variables */
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+<section class="static-page-section">
+    <h2>1. Acceptance of Terms</h2>
+    <p>
+        By accessing, registering for, or interacting with the Checkora Chess Platform,
+        you agree to comply with and be bound by these functional Terms and Conditions.
+        If you do not accept these parameters, you are advised to discontinue platform interaction.
+    </p>
+</section>
 
-        :root {
-            --bg-color: #0d0e15;
-            --card-bg: #131522;
-            --text-main: #ffffff;
-            --text-muted: #9fa3b9;
-            --accent-color: #ffc107;
-            --line-height: 1.7;
-        }
+<section class="static-page-section">
+    <h2>2. Fair Play and Anti-Cheat Policy</h2>
+    <p>
+        Checkora runs a native high-performance C++ minimax engine designed to provide
+        competitive gameplay. To safeguard the integrity of the ecosystem matches:
+    </p>
+    <ul>
+        <li>The addition or use of third-party engine assistance, browser modifications, or state-manipulation scripts during active matchmaking is strictly prohibited.</li>
+        <li>Intentionally stalling game clocks or throwing matches (sandbagging) to manipulate performance tier metrics violates our core guidelines.</li>
+    </ul>
+</section>
 
-        body {
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-            background: radial-gradient(circle at 50% -20%, #1a1c2e 0%, #0d0e15 60%);
-            background-attachment: fixed;
-            color: var(--text-main);
-            line-height: var(--line-height);
-            padding: 0 20px;
-            display: flex;
-            flex-direction: column;
-            min-height: 100vh;
-        }
+<section class="static-page-section">
+    <h2>3. Account Management and Security</h2>
+    <p>
+        When creating profile credentials and completing OTP verification loops, you are fully accountable
+        for preserving credential confidentiality. Checkora reserves authority to clean up, disable, or
+        wipe idle ghost account instances that remain completely abandoned to free system schema namespaces.
+    </p>
+</section>
 
-        /* Header / Navigation */
-        header {
-            max-width: 900px;
-            width: 100%;
-            margin: 0 auto;
-            padding: 30px 0 10px 0;
-        }
+<section class="static-page-section">
+    <h2>4. Open Source and Modifications</h2>
+    <p>
+        Checkora operates openly under the MIT License deed. While customization of backend logic modules
+        is encouraged for developer variants, users tracking data configurations across our deployment networks
+        are requested to interact fairly and maintain the software's style parameters.
+    </p>
+</section>
 
-        .back-link {
-            color: var(--accent-color);
-            text-decoration: none;
-            font-weight: 600;
-            font-size: 0.95rem;
-            transition: opacity 0.2s ease;
-        }
-
-        .back-link:hover {
-            opacity: 0.8;
-            text-decoration: underline;
-        }
-
-        /* Main Content Container */
-        .container {
-            max-width: 900px;
-            width: 100%;
-            margin: 40px auto;
-            background-color: var(--card-bg);
-            padding: 40px;
-            border-radius: 12px;
-            border: none;
-            box-shadow: 0 10px 40px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(255, 255, 255, 0.02);
-            flex: 1;
-        }
-
-        h1 {
-            color: var(--accent-color);
-            font-size: 2.5rem;
-            font-weight: 700;
-            margin-bottom: 8px;
-            letter-spacing: -0.5px;
-        }
-
-        .last-updated {
-            color: var(--text-muted);
-            font-size: 0.9rem;
-            margin-bottom: 40px;
-            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-            padding-bottom: 20px;
-        }
-
-        /* Policy Sections */
-        section {
-            margin-bottom: 35px;
-        }
-
-        h2 {
-            color: var(--text-main);
-            font-size: 1.4rem;
-            font-weight: 600;
-            margin-bottom: 12px;
-        }
-
-        p {
-            color: rgba(255, 255, 255, 0.85);
-            font-size: 1.05rem;
-            margin-bottom: 15px;
-        }
-
-        ul {
-            margin-left: 20px;
-            margin-bottom: 15px;
-            color: rgba(255, 255, 255, 0.85);
-        }
-
-        li {
-            margin-bottom: 8px;
-            font-size: 1.05rem;
-        }
-
-        /* Footer Settings */
-        footer {
-            max-width: 900px;
-            width: 100%;
-            margin: 0 auto;
-            padding: 40px 0;
-            text-align: center;
-            border-top: 1px solid rgba(255, 255, 255, 0.05);
-        }
-
-        .footer-copy {
-            color: var(--text-muted);
-            font-size: 0.9rem;
-        }
-
-        /* Responsive Breakpoints */
-        @media (max-width: 768px) {
-            .container {
-                padding: 20px;
-                margin-top: 20px;
-            }
-
-            h1 {
-                font-size: 2rem;
-            }
-
-            h2 {
-                font-size: 1.25rem;
-            }
-        }
-    </style>
-</head>
-
-<body>
-
-    <header>
-        <a href="{% url 'landing' %}" class="back-link">
-            &larr; Back to Home
-        </a>
-    </header>
-
-    <div class="container">
-
-        <h1>Terms and Conditions</h1>
-
-        <div class="last-updated">
-            Last updated: May 2026
-        </div>
-
-        <section>
-            <h2>1. Acceptance of Terms</h2>
-            <p>
-                By accessing, registering for, or interacting with the Checkora Chess Platform, you agree to comply with and be bound by these functional Terms and Conditions. If you do not accept these parameters, you are advised to discontinue platform interaction.
-            </p>
-        </section>
-
-        <section>
-            <h2>2. Fair Play and Anti-Cheat Policy</h2>
-            <p>
-                Checkora runs a native high-performance C++ minimax engine designed to provide competitive gameplay. To safeguard the integrity of the ecosystem matches:
-            </p>
-            <ul>
-                <li>The addition or use of third-party engine assistance, browser modifications, or state-manipulation scripts during active matchmaking is strictly prohibited.</li>
-                <li>Intentionally stalling game clocks or throwing matches (sandbagging) to manipulate performance tier metrics violates our core guidelines.</li>
-            </ul>
-        </section>
-
-        <section>
-            <h2>3. Account Management and Security</h2>
-            <p>
-                When creating profile credentials and completing OTP verification loops, you are fully accountable for preserving credential confidentiality. Checkora reserves authority to clean up, disable, or wipe idle ghost account instances that remain completely abandoned to free system schema namespaces.
-            </p>
-        </section>
-
-        <section>
-            <h2>4. Open Source and Modifications</h2>
-            <p>
-                Checkora operates openly under the MIT License deed. While customization of backend logic modules is encouraged for developer variants, users tracking data configurations across our deployment networks are requested to interact fairly and maintain the software’s style parameters.
-            </p>
-        </section>
-
-        <section>
-            <h2>5. Disclaimer of Liability</h2>
-            <p>
-                The platform services and integrated AI engines are offered on an "as-is" operational basis. The maintenance team assumes no liability for match state disruptions, profile cache rollbacks during backend server updates, or local dependency failures in client-side setups.
-            </p>
-        </section>
-
-    </div>
-
-    <footer>
-        <span class="footer-copy">
-            &copy; 2026 Checkora Hybrid Engine. All rights reserved.
-        </span>
-    </footer>
-
-</body>
-</html>
+<section class="static-page-section">
+    <h2>5. Disclaimer of Liability</h2>
+    <p>
+        The platform services and integrated AI engines are offered on an "as-is" operational basis.
+        The maintenance team assumes no liability for match state disruptions, profile cache rollbacks
+        during backend server updates, or local dependency failures in client-side setups.
+    </p>
+</section>
+{% endblock %}

--- a/game/tests.py
+++ b/game/tests.py
@@ -89,6 +89,7 @@ class LandingViewTest(TestCase):
         response = self.client.get('/')
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Checkora')
+        self.assertContains(response, 'capability-card--orphan')
 
     def test_landing_page_links_to_play(self):
         response = self.client.get('/')

--- a/game/tests.py
+++ b/game/tests.py
@@ -96,6 +96,25 @@ class LandingViewTest(TestCase):
         self.assertContains(response, '/play/')
 
 
+class StaticPageLayoutTest(TestCase):
+    """Footer-linked static pages should use the shared site navigation layout."""
+
+    def test_footer_linked_pages_render_site_header_and_footer(self):
+        pages = (
+            reverse('privacy'),
+            reverse('terms'),
+            reverse('contact'),
+        )
+
+        for page in pages:
+            with self.subTest(page=page):
+                response = self.client.get(page)
+                self.assertEqual(response.status_code, 200)
+                self.assertContains(response, 'class="navbar"')
+                self.assertContains(response, 'class="footer"')
+                self.assertNotContains(response, 'Back to Home')
+
+
 class NotFoundPageTest(TestCase):
     """Custom 404 page should match the product theme and navigation flow."""
 


### PR DESCRIPTION
## Summary
- move the footer-linked static pages onto a shared site layout with the standard navbar and footer
- remove the standalone back-to-home pattern from privacy, terms, and contact
- add a regression test to keep the shared layout on those pages

## Verification
- `python manage.py test game.tests.StaticPageLayoutTest game.tests.LandingViewTest`
- `python manage.py check`
- `git diff --check`