### PR TITLE
Fix duplicate account creation with same email address

### DIFF
--- a/game/forms.py
+++ b/game/forms.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.contrib.auth.forms import SetPasswordForm, UserCreationForm
 from django.contrib.auth.forms import PasswordResetForm
+from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 
 class CustomUserCreationForm(UserCreationForm):
@@ -9,6 +10,15 @@ class CustomUserCreationForm(UserCreationForm):
     class Meta(UserCreationForm.Meta):
         fields = UserCreationForm.Meta.fields + ('email',)
 
+    def clean_email(self):
+        email = self.cleaned_data.get('email')
+
+        if User.objects.filter(email=email).exists():
+            raise forms.ValidationError(
+                "An account with this email already exists. Please log in instead."
+            )
+
+        return email 
 
 class CustomSetPasswordForm(SetPasswordForm):
     """Prevent password resets from reusing the account's current password."""

--- a/game/views.py
+++ b/game/views.py
@@ -508,32 +508,6 @@ def register_view(request):
         form = CustomUserCreationForm(request.POST)
         is_valid = form.is_valid()
         
-        # Ghost Account Cleanup: Only run if form is perfectly valid except for username/email conflicts
-        if not is_valid and set(form.errors.keys()).issubset({'username', 'email'}):
-            username = request.POST.get('username')
-            email = request.POST.get('email')
-            
-            if username and email:
-                deleted = False
-                # 1. Exact match (User retrying with the exact same details)
-                if User.objects.filter(username=username, email=email, is_active=False).exists():
-                    User.objects.filter(username=username, email=email, is_active=False).delete()
-                    deleted = True
-                else:
-                    # 2. Username conflict (Free up unverified, abandoned usernames)
-                    if User.objects.filter(username=username, is_active=False).exists():
-                        User.objects.filter(username=username, is_active=False).delete()
-                        deleted = True
-                    # 3. Email conflict (Free up unverified, abandoned emails)
-                    if User.objects.filter(email=email, is_active=False).exists():
-                        User.objects.filter(email=email, is_active=False).delete()
-                        deleted = True
-                
-                if deleted:
-                    # Re-validate the form now that conflicts are cleared
-                    form = CustomUserCreationForm(request.POST)
-                    is_valid = form.is_valid()
-
         if is_valid:
             user = form.save(commit=False)
             user.is_active = False  # Deactivate account till OTP is verified


### PR DESCRIPTION
## Description
This PR fixes a security and validation issue where users could create multiple accounts using the same email address.

Previously, the registration flow allowed duplicate emails because email uniqueness was not properly validated before account creation. Additionally, the existing ghost account cleanup logic attempted to delete inactive users, which could trigger database foreign key constraint errors.

## Changes Made
- Added email uniqueness validation in `CustomUserCreationForm`
- Prevented duplicate account registration with existing email addresses
- Added a clear and user-friendly validation error message
- Removed unsafe ghost account cleanup logic causing database integrity issues
- Improved overall registration flow stability and security

## Expected Behavior
Users can no longer register multiple accounts with the same email address. Instead, they receive a validation message:

"An account with this email already exists. Please log in instead."

Closes #737