### PR TITLE
fix: restore mobile tap to move selection functionality

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -629,10 +629,10 @@
                         d.setAttribute('aria-label', getSquareLabel(r, c));
                         d.onkeydown = (e) => handleSquareKeydown(e, r, c);
                          
-                        d.onclick = (e) => {if (!dragging && !touchDragging) {
-                         selectPiece(r, c);
-                       }
-                };
+                        d.onclick = () => {
+                            if (dragging || touchDragging) return;
+                            onClick(r, c);
+                        };
 
                         boardEl.appendChild(d);
                     }

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -628,6 +628,11 @@
                         d.setAttribute('data-col', c);
                         d.setAttribute('aria-label', getSquareLabel(r, c));
                         d.onkeydown = (e) => handleSquareKeydown(e, r, c);
+                         
+                        d.onclick = (e) => {if (!dragging && !touchDragging) {
+                         selectPiece(r, c);
+                       }
+                };
 
                         boardEl.appendChild(d);
                     }


### PR DESCRIPTION
## Description
Restored mobile tap to move selection functionality that was missing

## Type of Change

- [x ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #1172 

## Checklist

- [x ] My code follows the project's style guidelines
- [ x] I have performed a self-review of my code
- [ x] I have commented my code where necessary
- [ x] I have updated the documentation if needed
- [ x] My changes generate no new warnings
- [x ] I have added tests that prove my fix/feature works
- [ x] New and existing tests pass locally

## Screenshots (if applicable)
<img width="519" height="556" alt="image" src="https://github.com/user-attachments/assets/3702a715-98ed-42fd-a6da-d2258aa0dd12" />

## Additional Notes

Any additional information reviewers should know.
