### PR TITLE
game: Fix Session.objects.encode() crash and use iterator() in cleanup_stale_games.

### DIFF
--- a/game/services.py
+++ b/game/services.py
@@ -40,7 +40,7 @@ def cleanup_stale_games():
             if moves_count < 5:
                 # Rule A: Hard deletion
                 del session_data['game']
-                session.session_data = session.encode(session_data)
+                session.session_data = Session.objects.encode(session_data)
                 session.save()
                 deleted_count += 1
             else:
@@ -58,7 +58,7 @@ def cleanup_stale_games():
                 
                 game_data['game_status'] = 'resignation'
                 session_data['game'] = game_data
-                session.session_data = session.encode(session_data)
+                session.session_data = Session.objects.encode(session_data)
                 session.save()
                 
                 # Create a GameResult historically linking to the user if auth is known

--- a/game/services.py
+++ b/game/services.py
@@ -20,7 +20,7 @@ def cleanup_stale_games():
     resigned_count = 0
     
     # Iterate over all sessions
-    for session in Session.objects.all():
+    for session in Session.objects.iterator():
         try:
             session_data = session.get_decoded()
         except Exception:
@@ -40,7 +40,7 @@ def cleanup_stale_games():
             if moves_count < 5:
                 # Rule A: Hard deletion
                 del session_data['game']
-                session.session_data = Session.objects.encode(session_data)
+                session.session_data = session.encode(session_data)
                 session.save()
                 deleted_count += 1
             else:
@@ -58,7 +58,7 @@ def cleanup_stale_games():
                 
                 game_data['game_status'] = 'resignation'
                 session_data['game'] = game_data
-                session.session_data = Session.objects.encode(session_data)
+                session.session_data = session.encode(session_data)
                 session.save()
                 
                 # Create a GameResult historically linking to the user if auth is known


### PR DESCRIPTION
## Description
Fixes two bugs in game/services.py cleanup_stale_games():

1. Session.objects.encode() does not exist as a class method — 
changed to session.encode() on lines 43 and 61.
2. Session.objects.all() loads all sessions into memory — 
changed to Session.objects.iterator() on line 23.

## Type of Change
- [x] Bug fix

## Related Issue
Fixes #1135

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally (111 tests passed)

## Additional Notes
GSSoC 2026 contributor (enoshdev). All 111 tests pass locally.