### PR TITLE
Fix coordinate validation on chess move API endpoint

### DIFF
--- a/game/tests.py
+++ b/game/tests.py
@@ -342,6 +342,115 @@ class MoveValidationTest(TestCase):
         self.assertTrue(data['valid'])
         self.assertEqual(data['captured'], 'p')
 
+
+class MoveCoordinatesValidationTest(TestCase):
+    """Test coordinate validation for chess move API endpoint."""
+
+    def setUp(self):
+        self.client.get('/play/')
+        self.validate_patcher = mock.patch.object(ChessGame, 'validate_move')
+        self.mock_validate = self.validate_patcher.start()
+        self.mock_validate.return_value = (True, "Mock validation.")
+
+        self.engine_patcher = mock.patch.object(ChessGame, '_call_engine')
+        self.mock_engine = self.engine_patcher.start()
+        self.mock_engine.return_value = "STATUS ok"
+
+    def tearDown(self):
+        self.validate_patcher.stop()
+        self.engine_patcher.stop()
+
+    def test_valid_coordinates(self):
+        """Move with valid coordinates (0-7) should succeed validation."""
+        response = self.client.post(
+            '/api/move/',
+            data=json.dumps({
+                'from_row': 6, 'from_col': 4,
+                'to_row': 4, 'to_col': 4,
+            }),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()['valid'])
+
+    def test_negative_coordinates(self):
+        """Move with negative coordinates should return 400 Bad Request."""
+        invalid_payloads = [
+            {'from_row': -1, 'from_col': 4, 'to_row': 4, 'to_col': 4},
+            {'from_row': 6, 'from_col': -4, 'to_row': 4, 'to_col': 4},
+            {'from_row': 6, 'from_col': 4, 'to_row': -1, 'to_col': 4},
+            {'from_row': 6, 'from_col': 4, 'to_row': 4, 'to_col': -8},
+        ]
+        for payload in invalid_payloads:
+            response = self.client.post(
+                '/api/move/',
+                data=json.dumps(payload),
+                content_type='application/json',
+            )
+            self.assertEqual(response.status_code, 400)
+            self.assertEqual(response.json(), {"error": "Invalid board coordinates"})
+
+    def test_coordinates_greater_than_7(self):
+        """Move with coordinates greater than 7 should return 400 Bad Request."""
+        invalid_payloads = [
+            {'from_row': 8, 'from_col': 4, 'to_row': 4, 'to_col': 4},
+            {'from_row': 6, 'from_col': 9, 'to_row': 4, 'to_col': 4},
+            {'from_row': 6, 'from_col': 4, 'to_row': 10, 'to_col': 4},
+            {'from_row': 6, 'from_col': 4, 'to_row': 4, 'to_col': 8},
+        ]
+        for payload in invalid_payloads:
+            response = self.client.post(
+                '/api/move/',
+                data=json.dumps(payload),
+                content_type='application/json',
+            )
+            self.assertEqual(response.status_code, 400)
+            self.assertEqual(response.json(), {"error": "Invalid board coordinates"})
+
+    def test_non_integer_coordinates(self):
+        """Move with non-integer coordinates should return 400 Bad Request."""
+        invalid_payloads = [
+            {'from_row': '6', 'from_col': 4, 'to_row': 4, 'to_col': 4},
+            {'from_row': 6.5, 'from_col': 4, 'to_row': 4, 'to_col': 4},
+            {'from_row': True, 'from_col': 4, 'to_row': 4, 'to_col': 4},
+            {'from_row': 6, 'from_col': [4], 'to_row': 4, 'to_col': 4},
+            {'from_row': 6, 'from_col': 4, 'to_row': None, 'to_col': 4},
+            {'from_row': 6, 'from_col': 4, 'to_row': 4, 'to_col': {'val': 4}},
+        ]
+        for payload in invalid_payloads:
+            response = self.client.post(
+                '/api/move/',
+                data=json.dumps(payload),
+                content_type='application/json',
+            )
+            self.assertEqual(response.status_code, 400)
+            self.assertEqual(response.json(), {"error": "Invalid board coordinates"})
+
+    def test_malformed_input_values(self):
+        """Move with malformed/missing coordinate inputs should return 400 Bad Request."""
+        invalid_payloads = [
+            {},
+            {'from_row': 6, 'from_col': 4},
+            {'from_row': 6, 'from_col': 4, 'to_row': 4},
+        ]
+        for payload in invalid_payloads:
+            response = self.client.post(
+                '/api/move/',
+                data=json.dumps(payload),
+                content_type='application/json',
+            )
+            self.assertEqual(response.status_code, 400)
+            self.assertEqual(response.json(), {"error": "Invalid board coordinates"})
+
+        response = self.client.post(
+            '/api/move/',
+            data="not-a-json-string",
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"error": "Invalid board coordinates"})
+
+
 class ValidMovesTest(TestCase):
     """Test /api/valid-moves/ endpoint."""
 

--- a/game/views.py
+++ b/game/views.py
@@ -58,14 +58,32 @@ def make_move(request):
     """Validate and execute a chess move via the C++ engine."""
     try:
         data = json.loads(request.body)
-        from_row = int(data['from_row'])
-        from_col = int(data['from_col'])
-        to_row = int(data['to_row'])
-        to_col = int(data['to_col'])
+        coords = ['from_row', 'from_col', 'to_row', 'to_col']
+        for coord in coords:
+            if coord not in data:
+                return JsonResponse(
+                    {"error": "Invalid board coordinates"},
+                    status=400,
+                )
+            val = data[coord]
+            if not isinstance(val, int) or isinstance(val, bool):
+                return JsonResponse(
+                    {"error": "Invalid board coordinates"},
+                    status=400,
+                )
+            if not (0 <= val <= 7):
+                return JsonResponse(
+                    {"error": "Invalid board coordinates"},
+                    status=400,
+                )
+        from_row = data['from_row']
+        from_col = data['from_col']
+        to_row = data['to_row']
+        to_col = data['to_col']
         promotion_piece = data.get('promotion_piece', None)
     except (json.JSONDecodeError, KeyError, ValueError, TypeError):
         return JsonResponse(
-            {'valid': False, 'message': 'Invalid request data.'},
+            {"error": "Invalid board coordinates"},
             status=400,
         )
 


### PR DESCRIPTION
## Description

This PR fixes a bug where the chess move API endpoint (`/api/move/`) accepted invalid board coordinates (such as negative values, values greater than 7, floats, booleans, or strings) without proper validation. 

Coordinates (`from_row`, `from_col`, `to_row`, `to_col`) are now strictly validated to ensure they are integers between 0 and 7 inclusive before they reach the game engine. Malformed payloads or invalid coordinate types/values will result in an `HTTP 400 Bad Request` returning `{"error": "Invalid board coordinates"}`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #1234 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Additional Notes

New unit tests were added inside [MoveCoordinatesValidationTest](file:///c:/GSSOC-26/Checkora/game/tests.py#L345) to cover negative coordinates, out-of-bounds coordinates, non-integer coordinates, valid coordinates, and malformed request objects.
