### PR TITLE
fix: center lone card in Platform Capabilities grid

### DIFF
--- a/game/static/game/css/landing.css
+++ b/game/static/game/css/landing.css
@@ -694,8 +694,10 @@ body {
     gap: 2rem;
     justify-content: center;
 }
-.capabilities-grid > .capability-card:last-child:nth-child(3n - 2) {
-    grid-column: 2;
+@media (min-width: 900px) {
+    .capabilities-grid > .capability-card:last-child:nth-child(3n - 2) {
+        grid-column: 2;
+    }
 }
 
 .capability-card {

--- a/game/static/game/css/landing.css
+++ b/game/static/game/css/landing.css
@@ -694,6 +694,9 @@ body {
     gap: 2rem;
     justify-content: center;
 }
+.capabilities-grid > .capability-card:last-child:nth-child(3n - 2) {
+    grid-column: 2;
+}
 
 .capability-card {
     background-color: var(--card-bg);


### PR DESCRIPTION
## Problem
The Platform Capabilities section displays 7 cards in a 3-column grid. 
The last card (REST API Architecture) was left-aligned and orphaned in 
its row, creating a large empty gap on the right.

Closes #[1206]

## Solution
Added a CSS rule to center the last card when it's the only one in its row:
.capabilities-grid > .capability-card:last-child:nth-child(3n - 2) {
    grid-column: 2;
}

## Screenshots
<img width="631" height="313" alt="Screenshot 2026-05-27 at 10 01 44 AM" src="https://github.com/user-attachments/assets/a2bc2462-4d99-477b-ad8e-1fd310af18cc" />
<img width="638" height="416" alt="Screenshot 2026-05-27 at 10 02 00 AM" src="https://github.com/user-attachments/assets/90ff50ee-8b95-4797-a616-26f7dc3d1bab" />

First is the "Before" version, then the "After" version follows