### PR TITLE
fix: guard default secret key in production (#1256)

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -14,6 +14,7 @@ import os
 import dj_database_url
 from pathlib import Path
 from dotenv import load_dotenv
+from django.core.exceptions import ImproperlyConfigured
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -21,16 +22,37 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Load environment variables from .env file
 load_dotenv(BASE_DIR / '.env')
 
+DEFAULT_SECRET_KEY = 'django-insecure-dev-key-for-local-testing'
+
+
+def env_bool(name, default=False):
+    """Parse boolean environment variables with explicit fallbacks."""
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {'1', 'true', 'yes', 'on'}
+
+
+def get_secret_key(debug_enabled):
+    """Allow the local dev fallback only while debug mode is enabled."""
+    secret_key = os.environ.get('SECRET_KEY', DEFAULT_SECRET_KEY)
+    if not debug_enabled and secret_key == DEFAULT_SECRET_KEY:
+        raise ImproperlyConfigured(
+            'SECRET_KEY must be set to a non-default value when DEBUG is false.'
+        )
+    return secret_key
+
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/6.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get('SECRET_KEY', 'django-insecure-dev-key-for-local-testing')
+DEBUG = env_bool('DEBUG', True)
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = get_secret_key(DEBUG)
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get('DEBUG', 'True').lower() == 'true'
-
 ALLOWED_HOSTS = ['.vercel.app', '*']
 
 

--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -554,13 +554,24 @@ body {
    ============================================================ */
 .status-bar {
     min-height: 22px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
     text-align: center;
     font-size: 0.82rem;
     color: #f0c040;
-    padding: 4px 0;
+    padding: 8px 0 0;
     width: 100%;
     max-width: calc(var(--square-size) * 8 + var(--board-border) * 2 + var(--rank-label-width) + 8px);
     box-sizing: border-box;
+}
+
+.game-status-text {
+    flex: 1 1 180px;
+    min-width: 0;
+    text-align: left;
 }
 .square:focus,
 .square:focus-visible {
@@ -826,6 +837,20 @@ body {
     .keyboard-hints {
         font-size: 0.72rem !important;
         line-height: 1.35;
+    }
+
+    .status-bar {
+        justify-content: center;
+    }
+
+    .game-status-text {
+        flex-basis: 100%;
+        text-align: center;
+    }
+
+    .score-panel {
+        width: 100%;
+        justify-content: center;
     }
 }
 
@@ -1603,10 +1628,11 @@ body {
 
 .score-panel {
     display: flex;
-    justify-content: center;
+    justify-content: flex-end;
     gap: 12px;
-
-    margin-top: 10px;
+    flex: 0 1 auto;
+    max-width: 100%;
+    margin-top: 0;
     flex-wrap: wrap;
 }
 
@@ -1638,8 +1664,14 @@ body {
 }
 
 @media (max-width: 600px) {
+    .status-bar {
+        gap: 8px;
+    }
+
     .score-panel {
         gap: 8px;
+        width: 100%;
+        justify-content: center;
     }
 
     .score-box {

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -265,9 +265,8 @@
                 </div>
             </div>
 
-            <div class="status-bar" id="statusBar" style="height: 22px; box-sizing: border-box;">
-                <!--Score bar-->
-                  <div id="game-status">Game started</div>
+            <div class="status-bar status-bar--with-score" id="statusBar">
+                  <div id="game-status" class="game-status-text">Game started</div>
                    <div class="score-panel">
                    <div class="score-box">
                        <span class="score-label">White</span>

--- a/game/tests.py
+++ b/game/tests.py
@@ -1,9 +1,11 @@
 """Tests for the Checkora chess engine and API endpoints."""
 
 import json
+import os
 import sys
 from smtplib import SMTPException
 from unittest import mock
+from django.core.exceptions import ImproperlyConfigured
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -112,6 +114,33 @@ class NotFoundPageTest(TestCase):
         self.assertContains(response, 'This move is illegal!', status_code=404)
         self.assertContains(response, 'Return to Main Menu', status_code=404)
         self.assertContains(response, reverse('landing'), status_code=404)
+
+
+class SettingsSecurityTest(SimpleTestCase):
+    """Security-sensitive settings helpers should guard production defaults."""
+
+    def test_get_secret_key_allows_dev_fallback_when_debug_enabled(self):
+        from core.settings import DEFAULT_SECRET_KEY, get_secret_key
+
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(get_secret_key(True), DEFAULT_SECRET_KEY)
+
+    def test_get_secret_key_requires_non_default_value_when_debug_disabled(self):
+        from core.settings import get_secret_key
+
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(ImproperlyConfigured):
+                get_secret_key(False)
+
+    def test_get_secret_key_uses_explicit_env_value_when_debug_disabled(self):
+        from core.settings import get_secret_key
+
+        with mock.patch.dict(
+            os.environ,
+            {'SECRET_KEY': 'prod-secret-key'},
+            clear=True,
+        ):
+            self.assertEqual(get_secret_key(False), 'prod-secret-key')
 
 
 class ServerErrorPageTest(SimpleTestCase):

--- a/game/tests.py
+++ b/game/tests.py
@@ -82,6 +82,13 @@ class BoardViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Checkora')
 
+    def test_board_page_exposes_responsive_score_footer_hooks(self):
+        response = self.client.get('/play/')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'status-bar--with-score')
+        self.assertContains(response, 'game-status-text')
+
 class LandingViewTest(TestCase):
     """The landing page at / should load and link to the game."""
 


### PR DESCRIPTION
## Summary\n- add a small get_secret_key() helper that keeps the local dev fallback only while debug mode is enabled\n- raise a clear configuration error if DEBUG is false and the app would otherwise boot with the hardcoded default secret key\n- add focused tests covering the development fallback and the production guard path\n\n## Testing\n- python manage.py test game.tests.SettingsSecurityTest\n- python manage.py check\n- git diff --check