### PR TITLE
fix: relocate page title to header and refactor header layout for rulebook

### DIFF
--- a/game/templates/game/rules.html
+++ b/game/templates/game/rules.html
@@ -33,6 +33,8 @@
             font-family: 'DM Sans', sans-serif;
             min-height: 100vh;
             overflow-x: hidden;
+            margin: 0;
+            padding: 0;  
         }
 
         /* ── Header ── */
@@ -40,12 +42,19 @@
             display: flex;
             align-items: center;
             justify-content: space-between;
-            padding: 1.2rem 2.5rem;
+            padding: 0.4rem 2.5rem;
             border-bottom: 1px solid var(--border);
             background: var(--surface);
             position: sticky;
             top: 0;
             z-index: 100;
+        }
+
+        .header-left {
+            display: flex;
+            flex-direction: row;
+            align-items: center;
+            gap: 14px;
         }
 
         .logo {
@@ -73,6 +82,17 @@
                 0 0 10px rgba(212, 165, 116, 0.5),
                 0 0 20px rgba(212, 165, 116, 0.3);
         }
+
+        .header-subtitle {
+            font-size: 0.82rem;
+            color: #4fc3f7;           /* bright blue — distinct from gold logo */
+            font-weight: 700;
+            letter-spacing: 0.14em;
+            text-transform: uppercase;
+            border-left: 2px solid #2c3245;   /* thin divider between the two */
+            padding-left: 14px;
+        }
+
         @keyframes logoGlow {
             0% {
                 filter: brightness(1.6) contrast(1.3)
@@ -153,20 +173,6 @@
         main {
             padding: 3rem 4rem;
             max-width: 900px;
-        }
-
-        .page-title {
-            font-family: 'Playfair Display', serif;
-            font-size: 2.5rem;
-            color: var(--gold);
-            margin-bottom: 0.4rem;
-        }
-
-        .page-subtitle {
-            color: var(--muted);
-            font-size: 1rem;
-            margin-bottom: 3rem;
-            font-weight: 300;
         }
 
         /* ── Rule Card ── */
@@ -454,89 +460,83 @@
         }
         .piece-card.active .piece-name { color: var(--gold); }
 
-        /* Auto-play animation */
         @keyframes pulse {
             0%, 100% { opacity: 1; }
             50% { opacity: 0.5; }
         }
         .animating { animation: pulse 0.5s ease; }
+
         #menuToggle {
-    display: none;
-    background: #f4c430;
-    color: #0a0b10;
-    border: none;
-    border-radius: 6px;
-    padding: 8px 14px;
-    font-size: 0.95rem;
-    font-weight: 700;
-    cursor: pointer;
-}
+            display: none;
+            background: #f4c430;
+            color: #0a0b10;
+            border: none;
+            border-radius: 6px;
+            padding: 8px 14px;
+            font-size: 0.95rem;
+            font-weight: 700;
+            cursor: pointer;
+        }
 
-/* ── Overlay ── */
-.sidebar-overlay {
-    display: none;
-    position: fixed;
-    inset: 0;
-    background: rgba(0,0,0,0.6);
-    z-index: 200;
-}
-.sidebar-overlay.open {
-    display: block;
-}
+        .sidebar-overlay {
+            display: none;
+            position: fixed;
+            inset: 0;
+            background: rgba(0,0,0,0.6);
+            z-index: 200;
+        }
+        .sidebar-overlay.open {
+            display: block;
+        }
 
-/* ── Mobile ── */
-@media (max-width: 768px) {
-    #menuToggle {
-        display: block;
-    }
+        @media (max-width: 768px) {
+            #menuToggle { display: block; }
 
-    .layout {
-        grid-template-columns: 1fr;
-    }
+            .layout { grid-template-columns: 1fr; }
 
-    .sidebar {
-        display: none;
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 260px;
-        height: 100vh;
-        z-index: 300;
-        overflow-y: auto;
-        padding-top: 1rem;
-        background: var(--surface);
-        border-right: 1px solid var(--border);
-    }
+            .sidebar {
+                display: none;
+                position: fixed;
+                top: 0;
+                left: 0;
+                width: 260px;
+                height: 100vh;
+                z-index: 300;
+                overflow-y: auto;
+                padding-top: 1rem;
+                background: var(--surface);
+                border-right: 1px solid var(--border);
+            }
 
-    .sidebar.open {
-        display: block;
-    }
+            .sidebar.open { display: block; }
 
-    main {
-        padding: 1.5rem 1rem;
-    }
+            main { padding: 1.5rem 1rem; }
 
-    .mini-board {
-        width: 100% !important;
-        max-width: 300px;
-    }
+            .mini-board {
+                width: 100% !important;
+                max-width: 300px;
+            }
 
-    .mini-board-container {
-        flex-direction: column;
-    }
-}
+            .mini-board-container { flex-direction: column; }
+
+            .header-subtitle { display: none; }
+        }
     </style>
 </head>
 <body>
 
     <header>
-        <a href="/" class="logo" style="display: flex; align-items: center; gap: 8px; text-decoration: none;">
-            <img src="/static/game/checkora_icon_only.png" 
-                style="height: 2rem; width: auto; object-fit: contain;" alt="Checkora">
-            <span style="font-family: 'Cinzel', serif; color: #f0c040; font-size: 1.5rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;">Checkora</span>
-        </a>
+        <div class="header-left">
+            <a href="/" class="logo">
+                <img src="/static/game/checkora_icon_only.png" 
+                    style="height: 2rem; width: auto; object-fit: contain;" alt="Checkora">
+                <span>Checkora</span>
+            </a>
+            <span class="header-subtitle">Interactive Chess Rulebook</span>
+        </div>
         <button id="menuToggle" type="button" onclick="toggleSidebar()" aria-label="Toggle navigation menu" aria-controls="sidebar" aria-expanded="false">☰ Menu</button>
     </header>
+
     <div class="sidebar-overlay" id="sidebarOverlay" onclick="closeSidebar()"
          role="presentation" aria-hidden="true"></div>
 
@@ -577,8 +577,6 @@
 
     <!-- Main -->
     <main>
-        <h1 class="page-title">Chess Rulebook</h1>
-        <p class="page-subtitle">Interactive visual guide — click any rule to see it in action.</p>
 
         <!-- ══ BASICS ══ -->
         <div class="rule-card active" id="rule-basics">
@@ -846,17 +844,11 @@
 </div>
 
 <script>
-/* ══════════════════════════════════════════════
-   PIECE UNICODE
-══════════════════════════════════════════════ */
 const P = {
     wK:'♔\u200B', wQ:'♕\u200B', wR:'♖\u200B', wB:'♗\u200B', wN:'♘\u200B', wP:'♙\u200B',
     bK:'♚', bQ:'♛', bR:'♜', bB:'♝', bN:'♞', bP:'♟'
 };
 
-/* ══════════════════════════════════════════════
-   BOARD BUILDER
-══════════════════════════════════════════════ */
 function buildBoard(id) {
     const el = document.getElementById(id);
     el.innerHTML = '';
@@ -882,7 +874,7 @@ function clearBoard(id) {
 function place(id, r, c, piece) {
     const sq = document.getElementById(`${id}-${r}-${c}`);
     if (sq) {
-        sq.textContent = piece[0]; // Extract the solid character
+        sq.textContent = piece[0];
         const isWhite = piece.includes('\u200B');
         sq.style.color = isWhite ? '#ffffff' : '#111111';
         sq.style.textShadow = isWhite 
@@ -911,9 +903,6 @@ function highlightCapture(id, r, c) {
     sq.appendChild(ring);
 }
 
-/* ══════════════════════════════════════════════
-   NAVIGATION
-══════════════════════════════════════════════ */
 const rules = ['basics','pieces','pawn','castling','enpassant','check','stalemate','promotion'];
 
 function showRule(name) {
@@ -923,13 +912,10 @@ function showRule(name) {
     });
     document.getElementById('rule-' + name).classList.add('active');
     document.getElementById('nav-' + name).classList.add('active');
-    closeSidebar(); // ADD THIS
+    closeSidebar();
     window.scrollTo({ top: 0, behavior: 'smooth' });
 }
 
-/* ══════════════════════════════════════════════
-   BASICS — Starting Position
-══════════════════════════════════════════════ */
 function initBasics() {
     buildBoard('board-basics');
     const back = [P.bR, P.bN, P.bB, P.bQ, P.bK, P.bB, P.bN, P.bR];
@@ -940,9 +926,6 @@ function initBasics() {
     front.forEach((p, c) => place('board-basics', 7, c, p));
 }
 
-/* ══════════════════════════════════════════════
-   PIECES — Movement patterns
-══════════════════════════════════════════════ */
 const pieceDescs = {
     king:   { title: 'King ♔', points: ['Moves 1 square in any direction', 'Cannot move into check', 'Most important piece — protect it!'] },
     queen:  { title: 'Queen ♕', points: ['Moves any number of squares', 'In any direction (rank, file, diagonal)', 'Most powerful piece on the board'] },
@@ -957,7 +940,7 @@ function showPieceMove(piece) {
     document.getElementById('pc-' + piece).classList.add('active');
 
     buildBoard('board-pieces');
-    const r = 4, c = 3; // center-ish
+    const r = 4, c = 3;
 
     const moves = {
         king:   [[r-1,c-1],[r-1,c],[r-1,c+1],[r,c-1],[r,c+1],[r+1,c-1],[r+1,c],[r+1,c+1]],
@@ -985,15 +968,9 @@ function showPieceMove(piece) {
         `<h4>${desc.title}</h4><ul>${desc.points.map(p=>`<li>${p}</li>`).join('')}</ul>`;
 }
 
-/* ══════════════════════════════════════════════
-   PAWN STEPS
-══════════════════════════════════════════════ */
 function pawnStep(n) {
-    [0,1,2].forEach(i => {
-        document.getElementById('pstep-'+i).classList.remove('active');
-    });
+    [0,1,2].forEach(i => document.getElementById('pstep-'+i).classList.remove('active'));
     document.getElementById('pstep-'+n).classList.add('active');
-
     buildBoard('board-pawn');
     if (n === 0) {
         place('board-pawn', 6, 3, P.wP);
@@ -1014,13 +991,9 @@ function pawnStep(n) {
     }
 }
 
-/* ══════════════════════════════════════════════
-   CASTLING STEPS
-══════════════════════════════════════════════ */
 function castleStep(n) {
     [0,1,2,3].forEach(i => document.getElementById('cstep-'+i).classList.remove('active'));
     document.getElementById('cstep-'+n).classList.add('active');
-
     buildBoard('board-castling');
     if (n === 0) {
         place('board-castling', 7, 4, P.wK);
@@ -1028,7 +1001,6 @@ function castleStep(n) {
         place('board-castling', 7, 7, P.wR);
         document.getElementById('board-castling-7-4').classList.add('last');
     } else if (n === 1) {
-        // Kingside
         place('board-castling', 7, 6, P.wK);
         place('board-castling', 7, 5, P.wR);
         place('board-castling', 7, 0, P.wR);
@@ -1037,7 +1009,6 @@ function castleStep(n) {
         highlight('board-castling', 7, 7);
         highlight('board-castling', 7, 4);
     } else if (n === 2) {
-        // Queenside
         place('board-castling', 7, 2, P.wK);
         place('board-castling', 7, 3, P.wR);
         place('board-castling', 7, 7, P.wR);
@@ -1046,7 +1017,6 @@ function castleStep(n) {
         highlight('board-castling', 7, 0);
         highlight('board-castling', 7, 4);
     } else {
-        // Cannot castle in check
         place('board-castling', 7, 4, P.wK);
         place('board-castling', 7, 0, P.wR);
         place('board-castling', 7, 7, P.wR);
@@ -1056,68 +1026,50 @@ function castleStep(n) {
     }
 }
 
-/* ══════════════════════════════════════════════
-   EN PASSANT STEPS
-══════════════════════════════════════════════ */
 function epStep(n) {
     [0,1,2].forEach(i => document.getElementById('epstep-'+i).classList.remove('active'));
     document.getElementById('epstep-'+n).classList.add('active');
     buildBoard('board-ep');
-
     if (n === 0) {
-        // White pawn on 5th rank (row 3)
         place('board-ep', 3, 3, P.wP);
         document.getElementById('board-ep-3-3').classList.add('last');
-        // Black pawn in starting position (row 1)
         place('board-ep', 1, 4, P.bP);
         document.getElementById('board-ep-1-4').style.opacity = '0.5';
     } else if (n === 1) {
-        // Black pawn jumps 2 squares, lands beside white
         place('board-ep', 3, 3, P.wP);
         place('board-ep', 3, 4, P.bP);
         document.getElementById('board-ep-3-3').classList.add('last');
         document.getElementById('board-ep-3-4').classList.add('hl');
-        // Arrow showing capture square
         highlight('board-ep', 2, 4);
     } else {
-        // White captures, black pawn gone
         place('board-ep', 2, 4, P.wP);
         document.getElementById('board-ep-2-4').classList.add('last');
         document.getElementById('board-ep-3-4').style.background = 'rgba(220,60,60,0.3)';
-        // Show ghost of where black pawn was
         document.getElementById('board-ep-3-4').textContent = '✕';
         document.getElementById('board-ep-3-4').style.color = 'rgba(220,60,60,0.6)';
         document.getElementById('board-ep-3-4').style.fontSize = '1rem';
     }
 }
-/* ══════════════════════════════════════════════
-   CHECK STEPS
-══════════════════════════════════════════════ */
+
 function checkStep(n) {
     [0,1,2].forEach(i => document.getElementById('chstep-'+i).classList.remove('active'));
     document.getElementById('chstep-'+n).classList.add('active');
     buildBoard('board-check');
-
     if (n === 0) {
-        // King in check from rook
         place('board-check', 7, 4, P.wK);
         place('board-check', 0, 4, P.bR);
         document.getElementById('board-check-7-4').classList.add('check');
         document.getElementById('board-check-0-4').classList.add('last');
-        // Highlight the attack line
         [1,2,3,4,5,6].forEach(r => {
             document.getElementById(`board-check-${r}-4`).style.background = 'rgba(255,50,50,0.35)';
         });
-        // Show escape squares
         [[6,3],[6,5],[7,3],[7,5]].forEach(([r,c]) => highlight('board-check',r,c));
     } else if (n === 1) {
-        // Block with a piece
         place('board-check', 7, 4, P.wK);
         place('board-check', 0, 4, P.bR);
         place('board-check', 4, 4, P.wR);
         document.getElementById('board-check-0-4').classList.add('last');
         document.getElementById('board-check-4-4').classList.add('last');
-        // Show the block working
         [1,2,3].forEach(r => {
             document.getElementById(`board-check-${r}-4`).style.background = 'rgba(255,50,50,0.35)';
         });
@@ -1125,13 +1077,11 @@ function checkStep(n) {
             document.getElementById(`board-check-${r}-4`).style.background = 'rgba(50,255,50,0.35)';
         });
     } else {
-        // Clear checkmate position — king trapped in corner
         place('board-check', 0, 0, P.bK);
         place('board-check', 1, 2, P.wQ);
         place('board-check', 0, 2, P.wR);
         document.getElementById('board-check-0-0').classList.add('check');
         document.getElementById('board-check-1-2').classList.add('last');
-        // All escape squares blocked
         [[0,1],[1,0],[1,1]].forEach(([r,c]) => {
             const sq = document.getElementById(`board-check-${r}-${c}`);
             sq.style.background = 'rgba(255,50,50,0.4)';
@@ -1141,26 +1091,19 @@ function checkStep(n) {
         });
     }
 }
-/* ══════════════════════════════════════════════
-   STALEMATE
-══════════════════════════════════════════════ */
+
 function initStalemate() {
     buildBoard('board-stale');
     place('board-stale', 0, 7, P.bK);
     place('board-stale', 1, 5, P.wQ);
     place('board-stale', 2, 7, P.wK);
-    // Black king has no legal moves but is NOT in check
     document.getElementById('board-stale-0-7').classList.add('hl');
 }
 
-/* ══════════════════════════════════════════════
-   PROMOTION STEPS
-══════════════════════════════════════════════ */
 function promoStep(n) {
     [0,1,2].forEach(i => document.getElementById('prostep-'+i).classList.remove('active'));
     document.getElementById('prostep-'+n).classList.add('active');
     buildBoard('board-promo');
-
     if (n === 0) {
         place('board-promo', 1, 4, P.wP);
         document.getElementById('board-promo-1-4').classList.add('last');
@@ -1169,12 +1112,10 @@ function promoStep(n) {
         place('board-promo', 0, 4, P.wP);
         document.getElementById('board-promo-0-4').classList.add('last');
     } else {
-        // Show all promotion choices
         place('board-promo', 0, 3, P.wN);
         place('board-promo', 0, 4, P.wQ);
         place('board-promo', 0, 5, P.wR);
         place('board-promo', 0, 6, P.wB);
-        
         [3, 4, 5, 6].forEach(c => {
             const sq = document.getElementById(`board-promo-0-${c}`);
             sq.style.background = 'rgba(255, 255, 255, 0.1)';
@@ -1186,6 +1127,7 @@ function promoStep(n) {
         });
     }
 }
+
 function toggleSidebar() {
     const sidebar = document.querySelector('.sidebar');
     const overlay = document.getElementById('sidebarOverlay');
@@ -1201,13 +1143,11 @@ function closeSidebar() {
     document.getElementById('menuToggle').setAttribute('aria-expanded', 'false');
     document.getElementById('sidebarOverlay').setAttribute('aria-hidden', 'true');
 }
+
 document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape') closeSidebar();
 });
 
-/* ══════════════════════════════════════════════
-   INIT ALL
-══════════════════════════════════════════════ */
 window.onload = () => {
     initBasics();
     buildBoard('board-pieces'); showPieceMove('king');
@@ -1218,30 +1158,26 @@ window.onload = () => {
     initStalemate();
     buildBoard('board-promo'); promoStep(0);
 };
+
 document.addEventListener('DOMContentLoaded', () => {
     const backBtn = document.getElementById('dynamicBackBtn');
     if (!backBtn) return;
 
-    // Check if the rulebook is loaded inside an iframe (Game Modal)
     if (window !== window.parent) {
         backBtn.innerHTML = '← Back to Game';
         backBtn.href = '#';
         backBtn.onclick = (e) => {
             e.preventDefault();
             try {
-                // Securely tell the parent window (board.html) to hide the modal
                 const parentModal = window.parent.document.getElementById('rulebookModal');
-                if (parentModal) {
-                    parentModal.style.display = 'none';
-                }
+                if (parentModal) parentModal.style.display = 'none';
             } catch (err) {
                 console.error("Could not close modal", err);
             }
         };
     } else {
-        // Loaded as a standalone page (from the Landing Page Footer)
         backBtn.innerHTML = '← Back to Home';
-        backBtn.href = backBtn.getAttribute('href');// Forces the link to go to the home page
+        backBtn.href = backBtn.getAttribute('href');
     }
 });
 </script>

--- a/game/templates/game/rules.html
+++ b/game/templates/game/rules.html
@@ -84,12 +84,13 @@
         }
 
         .header-subtitle {
+            margin: 0;
             font-size: 0.82rem;
-            color: #4fc3f7;           /* bright blue — distinct from gold logo */
+            color: #4fc3f7;        
             font-weight: 700;
             letter-spacing: 0.14em;
             text-transform: uppercase;
-            border-left: 2px solid #2c3245;   /* thin divider between the two */
+            border-left: 2px solid #2c3245;   
             padding-left: 14px;
         }
 
@@ -527,12 +528,12 @@
 
     <header>
         <div class="header-left">
-            <a href="/" class="logo">
-                <img src="/static/game/checkora_icon_only.png" 
+            <a href="{% url 'landing' %}" class="logo">
+                <img src="{% static 'game/checkora_icon_only.png' %}" 
                     style="height: 2rem; width: auto; object-fit: contain;" alt="Checkora">
                 <span>Checkora</span>
             </a>
-            <span class="header-subtitle">Interactive Chess Rulebook</span>
+            <h1 class="header-subtitle">Interactive Chess Rulebook</h1>
         </div>
         <button id="menuToggle" type="button" onclick="toggleSidebar()" aria-label="Toggle navigation menu" aria-controls="sidebar" aria-expanded="false">☰ Menu</button>
     </header>
@@ -542,7 +543,7 @@
 
 <div class="layout">
     <!-- Sidebar -->
-    <nav class="sidebar">
+    <nav id="sidebar" class="sidebar">
         <div style="margin-bottom: 20px; margin-top: 10px; text-align: center; width: 50%;">
             <a href="{% url 'landing' %}" id="dynamicBackBtn" class="back-btn" style="color:#f0c040; display:inline-block;">
                ← Back to Home


### PR DESCRIPTION
## Description
Moved the "Chess Rulebook" page title and subtitle out of the main content area (where it repeated on every rule card view) and into the site header alongside the Checkora branding. Also restructured the header layout to display the logo and subtitle side by side with distinct color treatment.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #1236 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)
<img width="2476" height="1246" alt="image" src="https://github.com/user-attachments/assets/deb61207-1dc5-40f5-9fe3-ba34df89e5c8" />

