### PR TITLE
fix: make pause overlay clickable for resuming game

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -1508,10 +1508,17 @@ body {
 }
 
 /* ================= PAUSE STATE ================= */
+/* ================= PAUSE STATE ================= */
+.chessboard.paused {
+    pointer-events: auto;
+    cursor: pointer;
+}
+
 .chessboard.paused .square {
     pointer-events: none;
     filter: blur(15px);
 }
+
 
 .chessboard.paused::after {
     content: "Resume to Continue";
@@ -1531,7 +1538,17 @@ body {
     z-index: 9999;
     box-shadow: 0 8px 32px rgba(240, 192, 64, 0.4);
     filter: none;
-    pointer-events: none;
+    cursor: pointer;
+    pointer-events: auto;
+}
+@media (max-width: 768px) {
+    .chessboard.paused::after {
+        font-size: 1rem;
+        padding: 12px 20px;
+        white-space: normal;
+        text-align: center;
+        width: 70%;
+    }
 }
 
 #pauseBtn.paused {

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -2917,5 +2917,13 @@ if (leaveConfirmNo) leaveConfirmNo.addEventListener('click', () => {
 
             // Call picker init immediately
             initTimeControlPicker();
+            // Resume game by clicking the paused board overlay
+            boardEl.addEventListener('click', async () => {
+                if (!paused) return;
+                if (drawOverlay.classList.contains('active')) return;
+                if (confirmOverlay.classList.contains('active')) return;
+                if (gameOverOverlay.classList.contains('active')) return;
+                await resumeGame();
+            });
 
 })();

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1606,6 +1606,15 @@
                 pauseBtn.textContent = paused ? 'Resume' : 'Pause';
                 pauseBtn.classList.toggle('paused', paused);
                 boardEl.classList.toggle('paused', paused);
+                if (paused) {
+                    boardEl.setAttribute('aria-label', 'Game paused. Click board or press P to resume.');
+                    boardEl.style.cursor = 'pointer';
+                    boardEl.style.pointerEvents = 'auto';
+                } else {
+                    boardEl.removeAttribute('aria-label');
+                    boardEl.style.cursor = '';
+                    boardEl.style.pointerEvents = '';
+                }
             }
 
             function startTimer() {


### PR DESCRIPTION
Actual Behavior:
The "Resume to Continue" overlay appeared during pause state but was not clickable.

Expected Behavior:
Users should be able to click the overlay to resume the game directly.

Changes Made:

Made pause overlay interactive
Added clickable resume behavior
Improved pause/resume UX
Fixes #1120 issue

<img width="1362" height="888" alt="image" src="https://github.com/user-attachments/assets/f7882455-6d2e-422a-84cd-bbf7ff9713c9" />
