### PR TITLE
Add missing autocomplete attributes to authentication form fields

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.urls import path, include
 from django.contrib.auth import views as auth_views
+from game.forms import CustomPasswordResetForm, CustomSetPasswordForm
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -10,7 +11,8 @@ urlpatterns = [
          auth_views.PasswordResetView.as_view(
              template_name='game/password_reset.html',
              email_template_name='game/password_reset_email.html',
-             subject_template_name='game/password_reset_subject.txt'
+             subject_template_name='game/password_reset_subject.txt',
+             form_class=CustomPasswordResetForm
          ),
          name='password_reset'),
 
@@ -22,7 +24,8 @@ urlpatterns = [
 
     path('password-reset-confirm/<uidb64>/<token>/',
          auth_views.PasswordResetConfirmView.as_view(
-             template_name='game/password_reset_confirm.html'
+             template_name='game/password_reset_confirm.html',
+             form_class=CustomSetPasswordForm
          ),
          name='password_reset_confirm'),
 

--- a/game/forms.py
+++ b/game/forms.py
@@ -1,8 +1,57 @@
 from django import forms
-from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth.forms import UserCreationForm, AuthenticationForm, SetPasswordForm, PasswordResetForm
 
 class CustomUserCreationForm(UserCreationForm):
     email = forms.EmailField(required=True)
 
     class Meta(UserCreationForm.Meta):
         fields = UserCreationForm.Meta.fields + ('email',)
+    
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Add autocomplete attributes for username field
+        if 'username' in self.fields:
+            self.fields['username'].widget.attrs['autocomplete'] = 'username'
+        # Add autocomplete attributes for password fields
+        if 'password1' in self.fields:
+            self.fields['password1'].widget.attrs['autocomplete'] = 'new-password'
+        if 'password2' in self.fields:
+            self.fields['password2'].widget.attrs['autocomplete'] = 'new-password'
+        # Add autocomplete attribute for email field
+        if 'email' in self.fields:
+            self.fields['email'].widget.attrs['autocomplete'] = 'email'
+
+
+class CustomAuthenticationForm(AuthenticationForm):
+    """Custom authentication form with autocomplete attributes."""
+    
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Add autocomplete attributes for login form
+        if 'username' in self.fields:
+            self.fields['username'].widget.attrs['autocomplete'] = 'username'
+        if 'password' in self.fields:
+            self.fields['password'].widget.attrs['autocomplete'] = 'current-password'
+
+
+class CustomSetPasswordForm(SetPasswordForm):
+    """Custom set password form with autocomplete attributes for password reset."""
+    
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Add autocomplete attributes for password reset form
+        if 'new_password1' in self.fields:
+            self.fields['new_password1'].widget.attrs['autocomplete'] = 'new-password'
+        if 'new_password2' in self.fields:
+            self.fields['new_password2'].widget.attrs['autocomplete'] = 'new-password'
+
+
+class CustomPasswordResetForm(PasswordResetForm):
+    """Custom password reset form with autocomplete attributes."""
+    
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Add autocomplete attribute for email field
+        if 'email' in self.fields:
+            self.fields['email'].widget.attrs['autocomplete'] = 'email'
+

--- a/game/views.py
+++ b/game/views.py
@@ -10,11 +10,10 @@ from django.http import JsonResponse
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth import login, logout
 from django.contrib.auth.models import User
-from django.contrib.auth.forms import AuthenticationForm
 from django.core.mail import send_mail
 from django.contrib import messages
 from django import forms
-from .forms import CustomUserCreationForm
+from .forms import CustomUserCreationForm, CustomAuthenticationForm
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_GET, require_POST
 
@@ -484,7 +483,7 @@ def login_view(request):
         return redirect('index')
 
     if request.method == 'POST':
-        form = AuthenticationForm(data=request.POST)
+        form = CustomAuthenticationForm(data=request.POST)
         if form.is_valid():
             user = form.get_user()
             login(request, user)
@@ -492,7 +491,7 @@ def login_view(request):
             return redirect('index')
         
     else:
-        form = AuthenticationForm()
+        form = CustomAuthenticationForm()
 
     return render(request, 'game/login.html', {'form': form})
 


### PR DESCRIPTION
## Description

This PR fixes missing `autocomplete` attributes in authentication-related form fields such as username, email, and password inputs.

Previously, browser developer tools displayed warnings like:

> "An element doesn't have an autocomplete attribute"

The fix improves:
- browser autofill support,
- password manager compatibility,
- accessibility,
- and overall user experience during sign in and account creation.

Implemented changes:
- Added `autocomplete="username"` to username fields
- Added `autocomplete="email"` to email fields
- Added `autocomplete="current-password"` to login password fields
- Added `autocomplete="new-password"` to signup password fields

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #574 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Additional Notes

This is a frontend usability/accessibility improvement and does not change authentication functionality.