### PR TITLE
docs: clarify Windows venv activation and PowerShell bypass (#1224)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ cd Checkora
 **On Windows:**
 ```powershell
 python -m venv venv
-venv\Scripts\activate
+venv\Scripts\Activate.ps1
 ```
 
 If you see the error *"Script execution is disabled on this system"*, run the following command in PowerShell before activating:

--- a/README.md
+++ b/README.md
@@ -92,34 +92,51 @@ Join our Discord community for updates, support, and games: https://discord.gg/D
 
 ## Quick Start
 
+**1. Clone the repository**
 ```bash
-# 1. Clone the repository
 git clone https://github.com/Checkora/Checkora.git
 cd Checkora
+```
 
-# 2. Set up a virtual environment
+**2. Set up a virtual environment**
+
+> **Note:** Django 6.0 requires Python 3.12 or higher. If you have multiple versions on Windows, use a compatible installed version, for example: `py -3.12 -m venv venv`.
+
+**On Windows:**
+```powershell
 python -m venv venv
-venv\Scripts\activate        # Windows
-source venv/bin/activate     # macOS / Linux
+venv\Scripts\activate
+```
 
-# Note: Django 6.0 requires Python 3.12 or higher. If you have multiple
-# versions on Windows, use a compatible installed version, e.g.:
-# py -3.12 -m venv venv
+If you see the error *"Script execution is disabled on this system"*, run the following command in PowerShell before activating:
+```powershell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+```
+This temporarily allows script execution for the current session.
 
-# 3. Install dependencies
+**On macOS / Linux:**
+```bash
+python3 -m venv venv
+source venv/bin/activate
+```
+
+**3. Install dependencies**
+```bash
 pip install -r requirements.txt
+```
 
-# 4. Set up environment variables
-# Copy example env file
-# Windows (PowerShell)
-copy .env.example .env
+**4. Set up environment variables**
 
-# macOS / Linux
-cp .env.example .env
+Copy the example environment file:
+* **Windows (PowerShell):** `copy .env.example .env`
+* **macOS / Linux:** `cp .env.example .env`
 
-# Open `.env` and set SECRET_KEY if needed
-# Configure EMAIL_HOST_USER and EMAIL_HOST_PASSWORD for OTP and password reset emails
-# 5. Run migrations and start the server
+Open `.env` and configure:
+* `SECRET_KEY` if needed.
+* `EMAIL_HOST_USER` and `EMAIL_HOST_PASSWORD` for OTP and password reset emails.
+
+**5. Run migrations and start the server**
+```bash
 python manage.py migrate
 python manage.py runserver
 ```

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ If you see the error *"Script execution is disabled on this system"*, run the fo
 ```powershell
 Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
 ```
-This temporarily allows script execution for the current session.
+This temporarily allows script execution for the current session. For more details, see the [Troubleshooting Guide](#troubleshooting-guide).
 
 **On macOS / Linux:**
 ```bash


### PR DESCRIPTION
## Description

This PR improves the Windows virtual environment setup instructions in the README to prevent confusion for new contributors. 

Specifically, it:
- Fixes the formatting of the `venv\Scripts\activate` command (removing the errant spaces).
- Adds a direct note and solution for PowerShell users who encounter the common `Execution_Policy` restriction error, ensuring they can activate their environment smoothly without hunting for the solution later in the document.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Related Issue

Fixes #1224

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

## Screenshots (if applicable)

*(N/A - Documentation only)*

## Additional Notes

I understand that a maintainer must apply the `gssoc:approved` label for this PR to count for GSSoC points.