### PR TITLE
fix: decouple secure transport flags from debug (#1258)

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -15,6 +15,21 @@ import dj_database_url
 from pathlib import Path
 from dotenv import load_dotenv
 
+
+def env_bool(name, default=False):
+    """Parse common truthy environment values with an explicit default."""
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {'1', 'true', 'yes', 'on'}
+
+
+def default_secure_transport_enabled():
+    """Enable strict transport defaults only in explicitly production envs."""
+    django_env = os.environ.get('DJANGO_ENV', '').strip().lower()
+    vercel_env = os.environ.get('VERCEL_ENV', '').strip().lower()
+    return django_env == 'production' or vercel_env == 'production'
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -29,7 +44,7 @@ load_dotenv(BASE_DIR / '.env')
 SECRET_KEY = os.environ.get('SECRET_KEY', 'django-insecure-dev-key-for-local-testing')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get('DEBUG', 'True').lower() == 'true'
+DEBUG = env_bool('DEBUG', True)
 
 ALLOWED_HOSTS = ['.vercel.app', '*']
 
@@ -144,11 +159,17 @@ SESSION_ENGINE = 'django.contrib.sessions.backends.db'
 
 # Session Cookie Security
 SESSION_COOKIE_HTTPONLY = True
-SESSION_COOKIE_SECURE = not DEBUG
+SESSION_COOKIE_SECURE = env_bool(
+    'SESSION_COOKIE_SECURE',
+    default_secure_transport_enabled(),
+)
 SESSION_COOKIE_SAMESITE = 'Lax'
 
 # SSL Redirect
-SECURE_SSL_REDIRECT = not DEBUG
+SECURE_SSL_REDIRECT = env_bool(
+    'SECURE_SSL_REDIRECT',
+    default_secure_transport_enabled(),
+)
 
 
 # Email Configuration for OTP and Password Reset EMails

--- a/core/settings.py
+++ b/core/settings.py
@@ -30,6 +30,7 @@ def default_secure_transport_enabled():
     vercel_env = os.environ.get('VERCEL_ENV', '').strip().lower()
     return django_env == 'production' or vercel_env == 'production'
 
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 

--- a/game/tests.py
+++ b/game/tests.py
@@ -15,6 +15,7 @@ from django.test import (
     override_settings,
 )
 
+from core import settings as project_settings
 from .engine import ChessGame
 from .forms import CustomSetPasswordForm
 
@@ -105,6 +106,40 @@ class NotFoundPageTest(TestCase):
         self.assertContains(response, 'This move is illegal!', status_code=404)
         self.assertContains(response, 'Return to Main Menu', status_code=404)
         self.assertContains(response, reverse('landing'), status_code=404)
+
+
+class SecuritySettingsConfigTest(SimpleTestCase):
+    """Security transport defaults should be explicit and testable."""
+
+    def test_env_bool_uses_default_when_variable_missing(self):
+        with mock.patch.dict(project_settings.os.environ, {}, clear=True):
+            self.assertTrue(project_settings.env_bool('MISSING', True))
+            self.assertFalse(project_settings.env_bool('MISSING', False))
+
+    def test_env_bool_parses_common_truthy_and_falsey_values(self):
+        with mock.patch.dict(project_settings.os.environ, {'FLAG': 'yes'}, clear=True):
+            self.assertTrue(project_settings.env_bool('FLAG'))
+
+        with mock.patch.dict(project_settings.os.environ, {'FLAG': 'off'}, clear=True):
+            self.assertFalse(project_settings.env_bool('FLAG', True))
+
+    def test_secure_transport_defaults_only_enable_for_explicit_production_envs(self):
+        with mock.patch.dict(project_settings.os.environ, {}, clear=True):
+            self.assertFalse(project_settings.default_secure_transport_enabled())
+
+        with mock.patch.dict(
+            project_settings.os.environ,
+            {'DJANGO_ENV': 'production'},
+            clear=True,
+        ):
+            self.assertTrue(project_settings.default_secure_transport_enabled())
+
+        with mock.patch.dict(
+            project_settings.os.environ,
+            {'VERCEL_ENV': 'production'},
+            clear=True,
+        ):
+            self.assertTrue(project_settings.default_secure_transport_enabled())
 
 
 class ServerErrorPageTest(SimpleTestCase):


### PR DESCRIPTION
## Summary
- decouple `SESSION_COOKIE_SECURE` and `SECURE_SSL_REDIRECT` from `DEBUG`
- use explicit production-environment detection plus env overrides for secure transport defaults
- add focused config tests covering env parsing and production-only secure defaults

## Testing
- `python manage.py test game.tests.SecuritySettingsConfigTest`
- `python manage.py check`
- `git diff --check`

Closes #1258
