### PR TITLE
Fix incorrect player name display when playing as black vs AI

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -517,7 +517,7 @@
                 
                 if (gameMode === 'ai'){
                     const diffLabel = (currentDifficulty || 'medium').toUpperCase();
-                    const humanName = currentWhiteName || document.getElementById('whiteNameInput')?.value?.trim() || 'Player';
+                    const humanName = currentWhiteName || document.getElementById('whiteNameInput')?.value?.trim()?.slice(0, 17) || 'Player';
                     if(playerColor === 'white'){
                         wName = humanName;
                         bName = `AI (Black)`;

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -517,14 +517,13 @@
                 
                 if (gameMode === 'ai'){
                     const diffLabel = (currentDifficulty || 'medium').toUpperCase();
-                    const player_name = playerColor === 'white' ? data.white_name : data.black_name;
+                    const humanName = currentWhiteName || document.getElementById('whiteNameInput')?.value?.trim() || 'Player';
                     if(playerColor === 'white'){
-                        wName = player_name;
+                        wName = humanName;
                         bName = `AI (Black)`;
                     }else{
-                        bName = player_name;
+                        bName = humanName;
                         wName = `AI (White)`;
-
                     }
                 
                     // Inject difficulty badge after names are set


### PR DESCRIPTION
## Description

Fixed an issue in AI mode where the player name container displayed `AI (You)` instead of the actual player name when the user selected Black pieces or was randomly assigned Black.

The issue occurred because the AI game flow internally stored the human player's name in `currentWhiteName` regardless of chosen side, while the UI rendering logic attempted to fetch the Black player's name from the AI-assigned data field.

Updated the player name rendering logic to consistently use the correct human player name source in AI mode.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

## Related Issue

Fixes #1050

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] I have commented my code where necessary
* [ ] I have updated the documentation if needed
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix/feature works
* [x] New and existing tests pass locally

## Screenshots:
BEFORE:

<img width="533" height="438" alt="597117269-c7b1a809-e77c-4bd6-90af-9cc45516e5fa" src="https://github.com/user-attachments/assets/726c4c1f-c767-4854-b6f3-018cbb43e54f" />

AFTER:

<img width="597" height="727" alt="image" src="https://github.com/user-attachments/assets/44a9b265-615b-4eae-a731-3a3abbd1dd14" />

## Additional Notes

Tested the fix in:

* Play vs AI mode
* Guest session
* White selection
* Black selection
* Random side assignment

The player metadata panel now correctly displays the human player's custom name with the `(YOU)` tag in all scenarios.
