### PR TITLE
fix(ui): resolve mobile click/tap double event causing immediate piec…

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -3366,6 +3366,7 @@ if (leaveConfirmNo) leaveConfirmNo.addEventListener('click', () => {
                 } else {
                     // Quick tap -> trigger default click/tap behavior
                     onClick(touchDragSrc.r, touchDragSrc.c);
+                    e.preventDefault();
                 }
 
                 // Reset state


### PR DESCRIPTION
fixes #1336 
Under GSSoC 2026

This a bug where this function is working on pc but not working on the mobile devices.


Before : 
<img width="400" height="225" alt="2026-05-29 08-32-51" src="https://github.com/user-attachments/assets/154e08a9-40b4-4c6b-8220-1a0ee7f630f9" />

After : 
<img width="400" height="225" alt="2026-05-29 08-48-59" src="https://github.com/user-attachments/assets/c3096c7f-4e63-4956-b727-233b17ad3ede" />
