### PR TITLE
feat: add password reset request throttling

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -131,6 +131,10 @@ CACHES = {
     }
 }
 
+PASSWORD_RESET_EMAIL_COOLDOWN_SECONDS = 300
+PASSWORD_RESET_IP_WINDOW_SECONDS = 900
+PASSWORD_RESET_IP_MAX_REQUESTS = 3
+
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/6.0/howto/static-files/
 

--- a/game/templates/game/password_reset.html
+++ b/game/templates/game/password_reset.html
@@ -21,14 +21,8 @@
     </div>
 
     <div class="auth-card">
-        <p id="cooldownTimer"
-            style="
-                text-align:center;
-                color:#f0c040;
-                margin-bottom:1rem;
-                font-weight:600;
-            ">
-        </p>
+        {% include 'game/includes/messages.html' %}
+
         <form method="POST">
             {% csrf_token %}
 
@@ -99,38 +93,5 @@
             Remember your password? <a href="{% url 'login' %}">Sign In</a>
         </div>
     </div>
-
-<script>
-
-let remaining = 300;
-
-const timer = document.getElementById('cooldownTimer');
-
-{% if messages %}
-
-    timer.innerText =
-        `Cooldown: ${remaining}s`;
-
-    const interval = setInterval(() => {
-
-        remaining--;
-
-        timer.innerText =
-            `Cooldown: ${remaining}s`;
-
-        if (remaining <= 0) {
-
-            clearInterval(interval);
-
-            timer.innerText = '';
-
-        }
-
-    }, 1000);
-
-{% endif %}
-
-</script>
-
 </body>
 </html>

--- a/game/tests.py
+++ b/game/tests.py
@@ -7,6 +7,8 @@ from unittest import mock
 
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.core import mail
+from django.core.cache import cache
 from django.urls import reverse
 from django.test import (
     RequestFactory,
@@ -251,6 +253,83 @@ class CustomSetPasswordFormTest(TestCase):
         )
 
         self.assertTrue(form.is_valid(), form.errors)
+
+
+@override_settings(
+    EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend',
+    PASSWORD_RESET_EMAIL_COOLDOWN_SECONDS=300,
+    PASSWORD_RESET_IP_WINDOW_SECONDS=900,
+    PASSWORD_RESET_IP_MAX_REQUESTS=3,
+)
+class PasswordResetRateLimitTest(TestCase):
+    """Password reset requests should be throttled by email and IP."""
+
+    def setUp(self):
+        cache.clear()
+        self.reset_url = reverse('password_reset')
+        self.done_url = reverse('password_reset_done')
+        User.objects.create_user(
+            username='resetplayer',
+            email='reset@example.com',
+            password='StrongPass123!',
+        )
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_repeated_email_request_during_cooldown_is_blocked(self):
+        first_response = self.client.post(
+            self.reset_url,
+            data={'email': 'reset@example.com'},
+        )
+
+        self.assertRedirects(first_response, self.done_url)
+        self.assertEqual(len(mail.outbox), 1)
+
+        second_response = self.client.post(
+            self.reset_url,
+            data={'email': 'reset@example.com'},
+            follow=True,
+        )
+
+        self.assertRedirects(second_response, self.reset_url)
+        self.assertContains(
+            second_response,
+            'Please wait',
+        )
+        self.assertEqual(len(mail.outbox), 1)
+
+    @override_settings(PASSWORD_RESET_IP_MAX_REQUESTS=2)
+    def test_ip_throttle_blocks_excessive_reset_requests(self):
+        for index in range(3):
+            User.objects.create_user(
+                username=f'resetplayer{index}',
+                email=f'reset{index}@example.com',
+                password='StrongPass123!',
+            )
+
+        for index in range(2):
+            response = self.client.post(
+                self.reset_url,
+                data={'email': f'reset{index}@example.com'},
+                REMOTE_ADDR='203.0.113.20',
+            )
+            self.assertRedirects(response, self.done_url)
+
+        blocked_response = self.client.post(
+            self.reset_url,
+            data={'email': 'reset2@example.com'},
+            REMOTE_ADDR='203.0.113.20',
+            follow=True,
+        )
+
+        self.assertRedirects(blocked_response, self.reset_url)
+        self.assertContains(
+            blocked_response,
+            'Too many password reset requests',
+        )
+        self.assertEqual(len(mail.outbox), 2)
+
 
 class MoveValidationTest(TestCase):
     """Test move validation wrapper by mocking validate_move."""

--- a/game/tests.py
+++ b/game/tests.py
@@ -2,6 +2,7 @@
 
 import json
 import sys
+import time
 from smtplib import SMTPException
 from unittest import mock
 
@@ -19,6 +20,7 @@ from django.test import (
 
 from .engine import ChessGame
 from .forms import CustomSetPasswordForm
+from .views import CustomPasswordResetView
 
 class EnginePathResolutionTest(SimpleTestCase):
     """Engine path selection should work across local platforms."""
@@ -329,6 +331,34 @@ class PasswordResetRateLimitTest(TestCase):
             'Too many password reset requests',
         )
         self.assertEqual(len(mail.outbox), 2)
+
+    @override_settings(PASSWORD_RESET_IP_MAX_REQUESTS=2)
+    def test_ip_throttle_message_uses_remaining_window_time(self):
+        User.objects.create_user(
+            username='remainingplayer',
+            email='remaining@example.com',
+            password='StrongPass123!',
+        )
+        view = CustomPasswordResetView()
+        ip_key = view._cache_key('password-reset-ip', '203.0.113.30')
+        cache.set(ip_key, 2, timeout=900)
+        cache.set(
+            view._ip_expires_key(ip_key),
+            time.time() + 125,
+            timeout=900,
+        )
+
+        response = self.client.post(
+            self.reset_url,
+            data={'email': 'remaining@example.com'},
+            REMOTE_ADDR='203.0.113.30',
+            follow=True,
+        )
+
+        self.assertRedirects(response, self.reset_url)
+        self.assertContains(response, '2 minute(s)')
+        self.assertNotContains(response, '15 minute(s)')
+        self.assertEqual(len(mail.outbox), 0)
 
 
 class MoveValidationTest(TestCase):

--- a/game/views.py
+++ b/game/views.py
@@ -23,7 +23,7 @@ from django.utils.encoding import (
 )
 
 from django.contrib.auth.tokens import default_token_generator
-from django.contrib.auth.forms import AuthenticationForm
+from django.contrib.auth.forms import AuthenticationForm, PasswordResetForm
 from django.contrib.auth.views import PasswordResetView
 from smtplib import SMTPException
 from django.core.mail import (
@@ -850,10 +850,115 @@ def resend_otp(request):
     return redirect('verify_otp')
 
 class CustomPasswordResetView(PasswordResetView):
+    """Password reset view with email cooldown and IP-level throttling."""
+
+    form_class = PasswordResetForm
+    email_cooldown_message = (
+        'Please wait {duration} before requesting another password reset email.'
+    )
+    ip_throttle_message = (
+        'Too many password reset requests were sent from your network. '
+        'Please wait {duration} before trying again.'
+    )
+
+    def _cache_key(self, prefix, value):
+        normalized = (value or 'unknown').strip().lower()
+        digest = hashlib.sha256(normalized.encode('utf-8')).hexdigest()
+        return f'{prefix}:{digest}'
+
+    def _client_ip(self, request):
+        forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
+        if forwarded_for:
+            return forwarded_for.split(',')[0].strip()
+        return request.META.get('REMOTE_ADDR', 'unknown')
+
+    def _format_duration(self, seconds):
+        seconds = max(1, int(seconds))
+        minutes, remainder = divmod(seconds, 60)
+        if minutes and remainder:
+            return f'{minutes} minute(s) and {remainder} second(s)'
+        if minutes:
+            return f'{minutes} minute(s)'
+        return f'{remainder} second(s)'
+
+    def _cooldown_remaining(self, cache_key):
+        expires_at = cache.get(cache_key)
+        if not expires_at:
+            return 0
+        return max(0, int(expires_at - time.time()))
+
+    def _get_limited_response(self, request, email):
+        email_key = self._cache_key('password-reset-email', email)
+        remaining = self._cooldown_remaining(email_key)
+        if remaining:
+            messages.error(
+                request,
+                self.email_cooldown_message.format(
+                    duration=self._format_duration(remaining)
+                ),
+            )
+            return redirect('password_reset')
+
+        ip_key = self._cache_key(
+            'password-reset-ip',
+            self._client_ip(request),
+        )
+        ip_attempts = cache.get(ip_key, 0)
+        max_attempts = getattr(settings, 'PASSWORD_RESET_IP_MAX_REQUESTS', 3)
+        if ip_attempts >= max_attempts:
+            messages.error(
+                request,
+                self.ip_throttle_message.format(
+                    duration=self._format_duration(
+                        getattr(settings, 'PASSWORD_RESET_IP_WINDOW_SECONDS', 900)
+                    )
+                ),
+            )
+            return redirect('password_reset')
+
+        request._password_reset_email_key = email_key
+        request._password_reset_ip_key = ip_key
+        return None
+
+    def _record_password_reset_request(self, request):
+        email_timeout = getattr(
+            settings,
+            'PASSWORD_RESET_EMAIL_COOLDOWN_SECONDS',
+            300,
+        )
+        cache.set(
+            request._password_reset_email_key,
+            time.time() + email_timeout,
+            timeout=email_timeout,
+        )
+
+        ip_timeout = getattr(settings, 'PASSWORD_RESET_IP_WINDOW_SECONDS', 900)
+        if not cache.add(request._password_reset_ip_key, 1, timeout=ip_timeout):
+            cache.incr(request._password_reset_ip_key)
+
+    def _single_user_form(self, selected_user):
+        base_form = self.get_form_class()
+
+        class SingleUserPasswordResetForm(base_form):
+            def get_users(self, email):
+                if selected_user and selected_user.has_usable_password():
+                    return [selected_user]
+                return []
+
+        return SingleUserPasswordResetForm
+
     def post(self, request, *args, **kwargs):
 
         email = request.POST.get('email', '').strip().lower()
-        users = User.objects.filter(email=email)
+        if not email:
+            messages.error(
+                request,
+                'Please enter a valid email address.'
+            )
+
+            return redirect('password_reset')
+
+        users = User.objects.filter(email__iexact=email)
 
         if users.count() > 1 and not request.POST.get(
             'selected_username'
@@ -868,58 +973,43 @@ class CustomPasswordResetView(PasswordResetView):
                 request,
                 'game/password_reset.html',
                 {
-                    'form': self.form_class,
+                    'form': self.get_form(),
                     'usernames': usernames,
                     'email': email
                 }
             )
-        if not email:
-            messages.error(
-                request,
-                'Please enter a valid email address.'
-            )
-
-            return redirect('password_reset')
-        cache_key = (f"password_reset_cooldown_{email}")
-
-        if cache.get(cache_key):
-
-            messages.error(
-                request,
-                'Please wait 60 seconds before requesting another password reset email.',
-            )
-
-            return redirect('password_reset')
-        cache.set(cache_key, True, timeout=60)
         selected_username = request.POST.get(
             'selected_username'
         )
 
+        form_class = self.get_form_class()
         if selected_username:
 
             selected_user = User.objects.filter(
                 username=selected_username,
-                email=email
+                email__iexact=email
             ).first()
 
-            from django.contrib.auth.forms import (
-                PasswordResetForm
-            )
+            if not selected_user:
+                messages.error(
+                    request,
+                    'Please select a valid account for this email address.',
+                )
+                return redirect('password_reset')
 
-            class SingleUserPasswordResetForm(
-                PasswordResetForm
-            ):
+            form_class = self._single_user_form(selected_user)
 
-                def get_users(self, email):
+        form = form_class(**self.get_form_kwargs())
+        if not form.is_valid():
+            return self.form_invalid(form)
 
-                    return [selected_user]
+        limited_response = self._get_limited_response(request, email)
+        if limited_response:
+            return limited_response
 
-            self.form_class = (SingleUserPasswordResetForm)
-        return super().post(
-            request,
-            *args,
-            **kwargs
-        )
+        response = self.form_valid(form)
+        self._record_password_reset_request(request)
+        return response
 
 
 def login_view(request):

--- a/game/views.py
+++ b/game/views.py
@@ -866,6 +866,9 @@ class CustomPasswordResetView(PasswordResetView):
         digest = hashlib.sha256(normalized.encode('utf-8')).hexdigest()
         return f'{prefix}:{digest}'
 
+    def _ip_expires_key(self, ip_key):
+        return f'{ip_key}:expires'
+
     def _client_ip(self, request):
         forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
         if forwarded_for:
@@ -906,12 +909,13 @@ class CustomPasswordResetView(PasswordResetView):
         ip_attempts = cache.get(ip_key, 0)
         max_attempts = getattr(settings, 'PASSWORD_RESET_IP_MAX_REQUESTS', 3)
         if ip_attempts >= max_attempts:
+            remaining = self._cooldown_remaining(self._ip_expires_key(ip_key))
+            if not remaining:
+                remaining = getattr(settings, 'PASSWORD_RESET_IP_WINDOW_SECONDS', 900)
             messages.error(
                 request,
                 self.ip_throttle_message.format(
-                    duration=self._format_duration(
-                        getattr(settings, 'PASSWORD_RESET_IP_WINDOW_SECONDS', 900)
-                    )
+                    duration=self._format_duration(remaining)
                 ),
             )
             return redirect('password_reset')
@@ -933,8 +937,13 @@ class CustomPasswordResetView(PasswordResetView):
         )
 
         ip_timeout = getattr(settings, 'PASSWORD_RESET_IP_WINDOW_SECONDS', 900)
+        ip_expires_key = self._ip_expires_key(request._password_reset_ip_key)
         if not cache.add(request._password_reset_ip_key, 1, timeout=ip_timeout):
             cache.incr(request._password_reset_ip_key)
+            if not cache.get(ip_expires_key):
+                cache.set(ip_expires_key, time.time() + ip_timeout, timeout=ip_timeout)
+        else:
+            cache.set(ip_expires_key, time.time() + ip_timeout, timeout=ip_timeout)
 
     def _single_user_form(self, selected_user):
         base_form = self.get_form_class()


### PR DESCRIPTION
## Description

This PR adds rate limiting and cooldown protection to the password reset flow. It prevents repeated password reset requests from the same email address and adds IP-based throttling to reduce duplicate reset emails, email spam, and automated abuse.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #1151

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [x] No documentation update was required
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

No screenshots required because this is a backend/auth-flow enhancement. The PR reuses the existing auth message UI for cooldown and throttle feedback.

## Additional Notes

This is a focused security and usability improvement for password recovery only. It does not change login, OTP, registration, deployment configuration, or database models.