### PR TITLE
fix: button text overflow on small screen devices

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -574,6 +574,9 @@ body {
     cursor: pointer;
     letter-spacing: 0.5px;
     transition: all 0.2s ease;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 .btn-gold {
     background: linear-gradient(135deg, #f0c040, #d4a020);

--- a/game/static/game/css/landing.css
+++ b/game/static/game/css/landing.css
@@ -125,6 +125,9 @@ body {
     background: transparent;
     border: 1px solid rgba(240, 192, 64, 0.35);
     transition: all 0.2s ease;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .btn-signin:hover,
@@ -219,6 +222,9 @@ body {
     font-size: 1.05rem;
     border: 1px solid rgba(255, 255, 255, 0.1);
     transition: background-color 0.2s, border-color 0.2s;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .btn-secondary:hover {


### PR DESCRIPTION
## Description

Fixes button text overflow on small screen devices by adding text truncation via CSS.

### Changes:
- Added overflow: hidden, text-overflow: ellipsis, and white-space: nowrap to .btn class in board.css
- Added same overflow protection to landing page buttons (.btn-signin, .btn-register, .btn-secondary)
- Prevents long button text like 'Pass \& Play (PvP)' from breaking layout on narrow viewports

Closes #914