### PR TITLE
fix: uniform gold glow on all about section bento cards on hover add

### DIFF
--- a/game/templates/game/landing.html
+++ b/game/templates/game/landing.html
@@ -155,13 +155,13 @@
                   <p>Powers intelligent AI gameplay. A custom high-performance engine calculates tactical configurations rapidly, challenging players at all skill levels.</p>
               </div>
 
-              <div class="about-bento-card">
+              <div class="about-bento-card highlight-accent">
                   <div class="about-card-icon">⚙️</div>
                   <h3>Hybrid Architecture</h3>
                   <p>Django and Python smoothly orchestrate core application routing, data states, and user sessions while handling real-time engine communication.</p>
               </div>
 
-              <div class="about-bento-card">
+              <div class="about-bento-card highlight-accent">
                   <div class="about-card-icon">📊</div>
                   <h3>Smooth Interactions</h3>
                   <p>Gain unhindered access to active statistics tracking, a responsive user layout, and synchronized match configurations natively built for seamless flow.</p>


### PR DESCRIPTION
## What
All three bento cards in the About section now show identical gold glow on hover.

## Why
Only the first card (C++ Minimax Engine) had the `highlight-accent` class which applied the gold glow. The other two cards were missing it, causing inconsistent UI.

## Changes
- `game/static/game/css/landing.css` — updated `.about-bento-card:hover` to use `var(--accent-gold)` border and matching box-shadow glow

## Screenshot
[Attach screenshot]

Closes #1351 