### PR TITLE
fix: remove hardcoded status bar height causing score box overflow on…

### DIFF
--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -353,7 +353,7 @@
                 </div>
             </div>
 
-            <div class="status-bar" id="statusBar" style="height: 22px; box-sizing: border-box;">
+            <div class="status-bar" id="statusBar">
                 <div id="replayControls" class="replay-controls hidden">
                     <button id="firstReplayBtn">⏮</button>
                     <button id="prevReplayBtn">◀</button>


### PR DESCRIPTION
Description:

## What
Fixed the White and Black score boxes that were overflowing underneath the status bar on mobile devices.

## Why
The status bar had a hardcoded inline height: 22px which was too small to contain the score panel. The .status-bar CSS also lacked flex layout so the score boxes had no room to sit inline.

## Changes
- game/templates/game/board.html — removed inline height: 22px from status bar element
- game/static/game/css/board.css — added flex layout to .status-bar so score boxes fit correctly

## Screenshot
[Attach screenshot]

## Files Changed
game/templates/game/board.html
game/static/game/css/board.css