### PR TITLE
feat: add floating Back to Top button on landing page

### DIFF
--- a/game/static/game/css/landing.css
+++ b/game/static/game/css/landing.css
@@ -730,6 +730,82 @@ body {
     border-color: rgba(240, 192, 64, 0.3);
     transform: translateY(-3px);
 }
+/*BACK TO TOP BUTTON*/
+
+#backToTopWrapper {
+    position: fixed;
+    bottom: 2rem;
+    right: 2rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+    z-index: 999;
+}
+
+#backToTopWrapper.visible {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+#backToTopTooltip {
+    background: rgba(15, 15, 26, 0.9);
+    color: var(--accent-gold);
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 4px 10px;
+    border-radius: 20px;
+    border: 1px solid rgba(240, 192, 64, 0.3);
+    letter-spacing: 0.5px;
+    opacity: 0;
+    transform: translateY(4px);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    white-space: nowrap;
+    pointer-events: none;
+}
+
+#backToTopWrapper:hover #backToTopTooltip {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+#backToTopBtn {
+    width: 52px;
+    height: 52px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #f0c040, #d4a020);
+    color: #0f0f1a;
+    border: 1.5px solid rgba(0, 0, 0, 0.4);
+    font-size: 1.3rem;
+    font-weight: 800;
+    cursor: pointer;
+    transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+    box-shadow: 0 4px 20px rgba(240, 192, 64, 0.35);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#backToTopBtn:hover {
+    background: linear-gradient(135deg, #f5cc55, #e0b030);
+    box-shadow: 0 6px 24px rgba(240, 192, 64, 0.6);
+}
+
+#backToTopBtn:hover .btn-arrow {
+    animation: arrow-bounce 0.6s ease infinite;
+}
+
+#backToTopBtn:active {
+    transform: scale(0.92);
+}
+
+@keyframes arrow-bounce {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-4px); }
+}
 
 /* ==========================================================================
    Platform Capabilities Section
@@ -836,6 +912,17 @@ body {
         text-align: center;
         box-sizing: border-box;
     }
+    #backToTopBtn {
+        width: 42px;
+        height: 42px;
+        bottom: 1.2rem;
+        right: 1.2rem;
+        font-size: 1rem;
+    }
+
+    #backToTopBtn:hover {
+        width: 120px;
+    }
 
     .footer {
         padding: 3rem 2rem 2rem;
@@ -894,6 +981,14 @@ body {
         flex-direction: column;
         gap: 1.5rem;
         text-align: center;
+    }
+
+    #backToTopBtn {
+        width: 42px;
+        height: 42px;
+        bottom: 1.2rem;
+        right: 1.2rem;
+        font-size: 1rem;
     }
 }
 

--- a/game/templates/game/landing.html
+++ b/game/templates/game/landing.html
@@ -447,5 +447,18 @@
         </div>
       </div>
     </footer>
+    <div id="backToTopWrapper">
+      <span id="backToTopTooltip">Back to Top</span>
+      <button id="backToTopBtn" aria-label="Back to top" onclick="window.scrollTo({top:0,behavior:'smooth'})">
+        <span class="btn-arrow">^</span>
+      </button>
+  </div>
+  
+  <script>
+      const backToTopWrapper = document.getElementById('backToTopWrapper');
+      window.addEventListener('scroll', () => {
+          backToTopWrapper.classList.toggle('visible', window.scrollY > 300);
+      });
+  </script>
   </body>
 </html>


### PR DESCRIPTION
Description:

## What
Added a floating circular Back to Top button on the landing page that appears after scrolling 300px down and smoothly scrolls back to the top on click.

## Why
The landing page has multiple sections and no way to quickly return to the top without manually scrolling. This improves UX especially on mobile.

## Changes
- game/templates/game/landing.html — added button element and scroll listener script
- game/static/game/css/landing.css — added fixed positioning, gold styling, hover and fade transition

## Files Changed
game/templates/game/landing.html
game/static/game/css/landing.css