### PR TITLE
engine: Implement adaptive king position tables.

### DIFF
--- a/game/engine/main.cpp
+++ b/game/engine/main.cpp
@@ -461,13 +461,24 @@ static const int kingMiddleTable[8][8] = {
     { 20, 20,  0,  0,  0,  0, 20, 20},
     { 20, 30, 10,  0,  0, 10, 30, 20}
 };
+
+static const int kingEndgameTable[8][8] = {
+    {-50,-30,-30,-30,-30,-30,-30,-50},
+    {-30,-10,-10,-10,-10,-10,-10,-30},
+    {-30,-10, 20, 30, 30, 20,-10,-30},
+    {-30,-10, 30, 40, 40, 30,-10,-30},
+    {-30,-10, 30, 40, 40, 30,-10,-30},
+    {-30,-10, 20, 30, 30, 20,-10,-30},
+    {-30,-20,-10,  0,  0,-10,-20,-30},
+    {-50,-40,-30,-20,-20,-30,-40,-50}
+};
 // clang-format on
 
 /**
  * Positional bonus for a single piece at (row, col).
  * White reads the table top-down; black mirrors it.
  */
-int positionalBonus(char piece, int row, int col) {
+int positionalBonus(char piece, int row, int col, bool isEndgame) {
     char type = static_cast<char>(tolower(static_cast<unsigned char>(piece)));
     int r = isWhite(piece) ? row : (7 - row);
 
@@ -477,7 +488,7 @@ int positionalBonus(char piece, int row, int col) {
         case 'b': return bishopTable[r][col];
         case 'r': return rookTable[r][col];
         case 'q': return queenTable[r][col];
-        case 'k': return kingMiddleTable[r][col];
+        case 'k': return isEndgame ? kingEndgameTable[r][col] : kingMiddleTable[r][col];
         default:  return 0;
     }
 }
@@ -488,12 +499,30 @@ int positionalBonus(char piece, int row, int col) {
  */
 int evaluate() {
     int score = 0;
+    int queenCount = 0;
+    int minorCount = 0;
+
+    for (int r = 0; r < 8; r++) {
+        for (int c = 0; c < 8; c++) {
+            char p = board[r][c];
+            if (isEmpty(p)) continue;
+            char type = tolower(static_cast<unsigned char>(p));
+            if (type == 'q') {
+                queenCount++;
+            } else if (type == 'n' || type == 'b') {
+                minorCount++;
+            }
+        }
+    }
+
+    bool isEndgame = (queenCount == 0 || minorCount <= 6);
+
     for (int r = 0; r < 8; r++) {
         for (int c = 0; c < 8; c++) {
             char p = board[r][c];
             if (isEmpty(p)) continue;
 
-            int val = pieceValue(p) + positionalBonus(p, r, c);
+            int val = pieceValue(p) + positionalBonus(p, r, c, isEndgame);
             score += isWhite(p) ? val : -val;
         }
     }

--- a/game/engine/main.py
+++ b/game/engine/main.py
@@ -428,16 +428,26 @@ KING_MIDDLE_TABLE = (
     (20, 20, 0, 0, 0, 0, 20, 20),
     (20, 30, 10, 0, 0, 10, 30, 20),
 )
+KING_ENDGAME_TABLE = (
+    (-50, -30, -30, -30, -30, -30, -30, -50),
+    (-30, -10, -10, -10, -10, -10, -10, -30),
+    (-30, -10, 20, 30, 30, 20, -10, -30),
+    (-30, -10, 30, 40, 40, 30, -10, -30),
+    (-30, -10, 30, 40, 40, 30, -10, -30),
+    (-30, -10, 20, 30, 30, 20, -10, -30),
+    (-30, -20, -10, 0, 0, -10, -20, -30),
+    (-50, -40, -30, -20, -20, -30, -40, -50),
+)
 
 
-def positional_bonus(piece, row, col):
+def positional_bonus(piece, row, col, is_endgame=False):
     lookup = {
         'p': PAWN_TABLE,
         'n': KNIGHT_TABLE,
         'b': BISHOP_TABLE,
         'r': ROOK_TABLE,
         'q': QUEEN_TABLE,
-        'k': KING_MIDDLE_TABLE,
+        'k': KING_ENDGAME_TABLE if is_endgame else KING_MIDDLE_TABLE,
     }
     mirrored_row = row if is_white(piece) else 7 - row
     table = lookup.get(piece.lower())
@@ -446,12 +456,28 @@ def positional_bonus(piece, row, col):
 
 def evaluate():
     score = 0
+    queen_count = 0
+    minor_count = 0
+
     for row in range(8):
         for col in range(8):
             piece = BOARD[row][col]
             if is_empty(piece):
                 continue
-            value = piece_value(piece) + positional_bonus(piece, row, col)
+            type_ = piece.lower()
+            if type_ == 'q':
+                queen_count += 1
+            elif type_ in ('n', 'b'):
+                minor_count += 1
+
+    is_endgame = (queen_count == 0 or minor_count <= 6)
+
+    for row in range(8):
+        for col in range(8):
+            piece = BOARD[row][col]
+            if is_empty(piece):
+                continue
+            value = piece_value(piece) + positional_bonus(piece, row, col, is_endgame)
             score += value if is_white(piece) else -value
     return score
 


### PR DESCRIPTION
## 🐛 Problem Statement

Currently, the C++ and Python minimax engines evaluate king position using a **static middle-game Piece-Square Table (PST)** for the entire duration of the game. The `kingMiddleTable` heavily penalizes the king for leaving the back rank or corners (e.g., assigning scores like `-50` in the center).

While this is correct behavior during the middle game to keep the king safe, it becomes a **major evaluation blunder in the endgame** where an active, centralized king is critical for escorting passed pawns and restricting the opponent's king.

---

Fixes #1291

## ✅ Proposed Solution

This PR implements a **dynamic transition** for the King's PST based on detected board state:

1. **Active Piece Material Tracking**: Tracks active piece material during the static evaluation phase.
2. **Endgame Detection**: Detects the endgame phase if **queens have been traded off** (`queenCount == 0`) *or* **$\le 6$ minor pieces** (knights/bishops) remain on the board.
3. **Endgame King PST**: When the endgame phase is detected, switches the king's PST from the restrictive middle-game table to a new `kingEndgameTable` that rewards central king activity:

```cpp
static const int kingEndgameTable[8][8] = {
    {-50,-30,-30,-30,-30,-30,-30,-50},
    {-30,-10,-10,-10,-10,-10,-10,-30},
    {-30,-10, 20, 30, 30, 20,-10,-30},
    {-30,-10, 30, 40, 40, 30,-10,-30},
    {-30,-10, 30, 40, 40, 30,-10,-30},
    {-30,-10, 20, 30, 30, 20,-10,-30},
    {-30,-20,-10,  0,  0,-10,-20,-30},
    {-50,-40,-30,-20,-20,-30,-40,-50}
};

