### PR TITLE
fix: responsive Board Theme color labels

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -929,6 +929,11 @@ body {
         height: 24px;
     }
 
+    .theme-label {
+        font-size: 0.7rem;
+        max-width: 45px;
+    }
+
     .keyboard-hints {
         font-size: 0.72rem !important;
         line-height: 1.35;
@@ -1134,6 +1139,19 @@ body {
         padding: 6px 12px;
         font-size: 0.8rem;
     }
+
+    .theme-switcher {
+        gap: 8px;
+    }
+
+    .theme-option {
+        gap: 6px;
+    }
+
+    .theme-label {
+        font-size: 0.68rem;
+        max-width: 50px;
+    }
 }
 
 /* ================= CLOCKS ================= */
@@ -1227,6 +1245,30 @@ body {
     gap: 10px;
     justify-content: center;
     margin-top: 4px;
+    flex-wrap: wrap;
+}
+
+.theme-option {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+}
+
+.theme-label {
+    font-size: clamp(0.65rem, 1.5vw, 0.75rem);
+    color: rgba(255, 255, 255, 0.5);
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 50px;
+    transition: color 0.2s ease;
+}
+
+.theme-btn:hover + .theme-label,
+.theme-option:hover .theme-label {
+    color: rgba(255, 255, 255, 0.8);
 }
 
 .theme-btn {

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -383,19 +383,31 @@
             <div class="card">
                 <div class="card-title">Board Theme</div>
                 <div class="theme-switcher">
-                    <button class="theme-btn active" data-theme="classic" title="Classic" aria-label="Classic theme"
-                        aria-pressed="true" type="button"></button>
-                    <button class="theme-btn" data-theme="dark" title="Dark" aria-label="Dark theme"
-                        aria-pressed="false" type="button"></button>
-                    <button class="theme-btn" data-theme="green" title="Green" aria-label="Green theme"
-                        aria-pressed="false" type="button"></button>
-                    <button class="theme-btn" data-theme="blue" title="Blue" aria-label="Blue theme"
-                        aria-pressed="false" type="button"></button>
-                    <button class="theme-btn" data-theme="pastel" title="Pastel" aria-label="Pastel theme"
-                        aria-pressed="false" type="button"></button>
-                </div>
-                <div style="margin-top: 8px; font-size: 11px; color: rgba(255,255,255,0.5); text-align: center;">
-                    Classic · Dark · Green · Blue · Pastel
+                    <div class="theme-option">
+                        <button class="theme-btn active" data-theme="classic" title="Classic" aria-label="Classic theme"
+                            aria-pressed="true" type="button"></button>
+                        <span class="theme-label">Classic</span>
+                    </div>
+                    <div class="theme-option">
+                        <button class="theme-btn" data-theme="dark" title="Dark" aria-label="Dark theme"
+                            aria-pressed="false" type="button"></button>
+                        <span class="theme-label">Dark</span>
+                    </div>
+                    <div class="theme-option">
+                        <button class="theme-btn" data-theme="green" title="Green" aria-label="Green theme"
+                            aria-pressed="false" type="button"></button>
+                        <span class="theme-label">Green</span>
+                    </div>
+                    <div class="theme-option">
+                        <button class="theme-btn" data-theme="blue" title="Blue" aria-label="Blue theme"
+                            aria-pressed="false" type="button"></button>
+                        <span class="theme-label">Blue</span>
+                    </div>
+                    <div class="theme-option">
+                        <button class="theme-btn" data-theme="pastel" title="Pastel" aria-label="Pastel theme"
+                            aria-pressed="false" type="button"></button>
+                        <span class="theme-label">Pastel</span>
+                    </div>
                 </div>
             </div>
             <div class="card">


### PR DESCRIPTION
## Summary
Restructure Board Theme labels with responsive styling to prevent overflow on mobile/tablet viewports. Labels now use flexbox layout with proper wrapping and responsive font sizing.

## Changes
- Refactored theme selector HTML to display individual labels per button
- Added responsive CSS with clamp() for scaling
- Implemented text truncation for smaller screens

Fixes #1128