### PR TITLE
# 🐛 Fix: Allow Sub-Minute Custom Time Controls

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -2282,10 +2282,10 @@
                     const strVal = String(timeLimitMins);
                     if (strVal.includes('|')) {
                         const parts = strVal.split('|');
-                        currentMins = parseInt(parts[0], 10) || 10;
+                        currentMins = parseFloat(parts[0]) || 10;
                         currentInc = parseInt(parts[1], 10) || 0;
                     } else {
-                        currentMins = parseInt(strVal, 10) || 10;
+                        currentMins = parseFloat(strVal) || 10;
                         currentInc = 0;
                     }
                 }
@@ -3457,37 +3457,60 @@ if (leaveConfirmNo) leaveConfirmNo.addEventListener('click', () => {
                     applyCustomBtn.addEventListener('click', (e) => {
                         e.stopPropagation();
                         const minsInput = document.getElementById('customMinsInput');
+                        const secsInput = document.getElementById('customSecsInput');
                         const incInput = document.getElementById('customIncInput');
 
                         if (minsInput && incInput) {
                             let mins = parseInt(minsInput.value, 10);
+                            let secs = secsInput ? parseInt(secsInput.value, 10) : 0;
                             let inc = parseInt(incInput.value, 10);
 
-                            if (isNaN(mins) || mins < 1) mins = 10;
+                            if (isNaN(mins) || mins < 0) mins = 0;
                             if (mins > 300) mins = 300;
+                            if (isNaN(secs) || secs < 0) secs = 0;
+                            if (secs > 59) secs = 59;
                             if (isNaN(inc) || inc < 0) inc = 0;
                             if (inc > 180) inc = 180;
 
+                            const totalSecs = mins * 60 + secs;
+                            if (totalSecs <= 0) {
+                                // Require at least 1 second of game time
+                                if (secsInput) secsInput.value = 30;
+                                secs = 30;
+                            }
+
                             minsInput.value = mins;
+                            if (secsInput) secsInput.value = secs;
                             incInput.value = inc;
 
-                            selectedMins = mins;
+                            // selectedMins stores total minutes as a decimal (e.g. 0.5 for 30s)
+                            selectedMins = (mins * 60 + secs) / 60;
                             selectedIncrement = inc;
 
                             // Update active preset styling
                             presetBtns.forEach(b => b.classList.remove('active'));
 
-                            if (inc > 0) {
-                                display.textContent = `${mins} | ${inc}`;
+                            // Build a human-readable display string
+                            let displayText;
+                            const finalTotalSecs = mins * 60 + secs;
+                            if (mins === 0) {
+                                displayText = `${secs}s`;
+                            } else if (secs === 0) {
+                                displayText = `${mins} min`;
                             } else {
-                                display.textContent = `${mins} min`;
+                                displayText = `${mins}:${String(secs).padStart(2, '0')} min`;
                             }
+                            if (inc > 0) {
+                                displayText += ` | ${inc}`;
+                            }
+                            display.textContent = displayText;
 
                             // Close popover
                             popover.style.display = 'none';
                         }
                     });
                 }
+
 
                 // Close popover when clicking anywhere else
                 document.addEventListener('click', (e) => {

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -153,7 +153,11 @@
                             <div class="tc-custom-inputs" style="display: flex; gap: 8px; margin-bottom: 10px; text-align: left;">
                                 <div class="tc-input-field" style="flex: 1; display: flex; flex-direction: column; gap: 4px;">
                                     <label for="customMinsInput" style="color: #8a8aaa; font-size: 0.75rem;">Minutes</label>
-                                    <input type="number" id="customMinsInput" min="1" max="300" value="10" style="padding: 8px; border-radius: 4px; border: 1px solid #444; background: #0f0f1a; color: #fff; width: 100%; font-size: 0.85rem;">
+                                    <input type="number" id="customMinsInput" min="0" max="300" value="0" style="padding: 8px; border-radius: 4px; border: 1px solid #444; background: #0f0f1a; color: #fff; width: 100%; font-size: 0.85rem;">
+                                </div>
+                                <div class="tc-input-field" style="flex: 1; display: flex; flex-direction: column; gap: 4px;">
+                                    <label for="customSecsInput" style="color: #8a8aaa; font-size: 0.75rem;">Seconds</label>
+                                    <input type="number" id="customSecsInput" min="0" max="59" value="30" style="padding: 8px; border-radius: 4px; border: 1px solid #444; background: #0f0f1a; color: #fff; width: 100%; font-size: 0.85rem;">
                                 </div>
                                 <div class="tc-input-field" style="flex: 1; display: flex; flex-direction: column; gap: 4px;">
                                     <label for="customIncInput" style="color: #8a8aaa; font-size: 0.75rem;">Increment (s)</label>


### PR DESCRIPTION
## 📋 Overview

This PR fixes the custom time control configuration by allowing users to create games with durations below one minute, such as **30-second**, **45-second**, and other ultra-fast time controls.

Closes #1313

## ✨ Changes Made

### 🎨 UI Updates (`board.html`)

* Changed the minimum value for the **Minutes** input from `1` to `0`.
* Added a dedicated **Seconds** input field (`customSecsInput`).
* Updated default values to better support sub-minute game creation.

### ⚙️ Logic Updates (`board.js`)

* Added support for reading and validating the new **Seconds** input.
* Calculated total game duration using:

  * `minutes × 60 + seconds`
* Allowed `0` minutes as a valid input.
* Added validation to prevent a total game time of `0` seconds.
* Improved custom time display formatting for:

  * Sub-minute games (e.g., `30s`)
  * Mixed formats (e.g., `1:30 min`)
  * Standard minute controls

### 🔄 Rematch Compatibility

* Replaced `parseInt()` with `parseFloat()` when parsing rematch time controls.
* Preserves sub-minute configurations during rematches.

## ✅ Examples Supported

Users can now create:

* ⏱️ `0 min 30 sec` → **30-second game**
* ⏱️ `0 min 45 sec` → **45-second game**
* ⏱️ `1 min 30 sec` → **90-second game**
* ⏱️ Any other valid custom time control below one minute

## 🧪 Testing

* ✅ Verified custom games can be created with less than 1 minute.
* ✅ Verified game timers initialize correctly.
* ✅ Verified rematches preserve sub-minute time controls.
* ✅ Verified existing time control modes remain unaffected.

## 📸 Result

Players can now create ultra-fast chess formats commonly available on other chess platforms, improving flexibility and gameplay options.
<img width="1909" height="902" alt="image" src="https://github.com/user-attachments/assets/e9982991-aff6-49ed-8026-84a80fbacb24" />

