### PR TITLE
Icon repetition fixed

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1592,7 +1592,7 @@
                     if (resultState === 'victory') {
                         bannerEl.classList.add('banner-victory');
                         if (bannerIconEl) bannerIconEl.textContent = '🏆';
-                        gameOverTitle.textContent = gameMode === 'pvp' ? 'VICTORY' : 'VICTORY';
+                        gameOverTitle.textContent = 'VICTORY';
                     } else if (resultState === 'defeat') {
                         bannerEl.classList.add('banner-defeat');
                         if (bannerIconEl) bannerIconEl.textContent = '💀';

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1592,15 +1592,15 @@
                     if (resultState === 'victory') {
                         bannerEl.classList.add('banner-victory');
                         if (bannerIconEl) bannerIconEl.textContent = '🏆';
-                        gameOverTitle.textContent = gameMode === 'pvp' ? '🏆 VICTORY 🏆' : '🏆 VICTORY 🏆';
+                        gameOverTitle.textContent = gameMode === 'pvp' ? 'VICTORY' : 'VICTORY';
                     } else if (resultState === 'defeat') {
                         bannerEl.classList.add('banner-defeat');
                         if (bannerIconEl) bannerIconEl.textContent = '💀';
-                        gameOverTitle.textContent = '💀 DEFEAT 💀';
+                        gameOverTitle.textContent = 'DEFEAT';
                     } else {
                         bannerEl.classList.add('banner-draw');
                         if (bannerIconEl) bannerIconEl.textContent = '🤝';
-                        gameOverTitle.textContent = '🤝 DRAW 🤝';
+                        gameOverTitle.textContent = 'DRAW';
                     }
                 }
                 


### PR DESCRIPTION
There are no repeated icons for Draw, Defeat, or Victory now

<img width="870" height="568" alt="image" src="https://github.com/user-attachments/assets/a600dfb3-92a1-4b4d-bea3-9f2a2124129e" />
<img width="813" height="571" alt="image" src="https://github.com/user-attachments/assets/4e804676-9de5-41ce-93a4-8a59c8aa04dd" />
<img width="832" height="612" alt="image" src="https://github.com/user-attachments/assets/97bb965a-ea5f-437f-8456-47f82e4537ef" />
