### PR TITLE
Fix: dashboard dropdown options not clickable on hover (hover gap)

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -170,7 +170,8 @@ body {
     display: none;
     position: absolute;
     right: 0;
-    top: 48px;
+    top: 100%;
+    margin-top: -2px;
     min-width: 220px;
     background: #111827;
     border-radius: 14px;

--- a/game/static/game/css/landing.css
+++ b/game/static/game/css/landing.css
@@ -177,7 +177,8 @@ body {
     display: none;
     position: absolute;
     right: 0;
-    top: 55px;
+    top: 100%;
+    margin-top: -2px;
     min-width: 220px;
     background: #111827;
     border-radius: 14px;


### PR DESCRIPTION
### Description
The dashboard/profile dropdown menu closes before users can click menu options. This happens because the dropdown content is positioned with a hardcoded 	op: 48px (board.css) / 	op: 55px (landing.css), creating a 10-14px gap between the profile button and the dropdown menu. When the cursor crosses this gap, the :hover state on the parent container is lost, causing the dropdown to disappear.

### Fix
Changed 	op from fixed pixel values to 	op: 100% with margin-top: -2px, so the dropdown always sits flush against the bottom of the profile button regardless of button size. The slight negative margin overlap eliminates any rendering gap while overflow: hidden on the dropdown clips the overlap cleanly.

### Related Issue
Fixes #1411

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

program: gssoc