### PR TITLE
Fix: Hardcoded SECRET_KEY fallback allows session hijacking

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -14,6 +14,7 @@ import os
 import dj_database_url
 from pathlib import Path
 from dotenv import load_dotenv
+from django.core.exceptions import ImproperlyConfigured
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -26,7 +27,9 @@ load_dotenv(BASE_DIR / '.env')
 # See https://docs.djangoproject.com/en/6.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get('SECRET_KEY', 'django-insecure-dev-key-for-local-testing')
+SECRET_KEY = os.environ.get('SECRET_KEY')
+if not SECRET_KEY:
+    raise ImproperlyConfigured('SECRET_KEY environment variable must be set')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get('DEBUG', 'False').lower() == 'true'


### PR DESCRIPTION
Closes #1405, Closes #1408

**Root cause**: `core/settings.py:29` had `SECRET_KEY = os.environ.get('SECRET_KEY', 'django-insecure-dev-key-for-local-testing')`. If the env var wasn't set in production, Django fell back to a well-known hardcoded key, allowing full session hijacking, CSRF token forgery, and signed data decryption.

**Fix**: Removed the hardcoded fallback. Now raises `ImproperlyConfigured` if `SECRET_KEY` is not set, ensuring deployments fail loudly rather than silently using an insecure key.
