### PR TITLE
Fix: Password reset link sent over unencrypted HTTP

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -14,6 +14,7 @@ import os
 import dj_database_url
 from pathlib import Path
 from dotenv import load_dotenv
+from django.core.exceptions import ImproperlyConfigured
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -26,7 +27,9 @@ load_dotenv(BASE_DIR / '.env')
 # See https://docs.djangoproject.com/en/6.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get('SECRET_KEY', 'django-insecure-dev-key-for-local-testing')
+SECRET_KEY = os.environ.get('SECRET_KEY')
+if not SECRET_KEY:
+    raise ImproperlyConfigured('SECRET_KEY environment variable must be set')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get('DEBUG', 'True').lower() == 'true'

--- a/game/templates/game/password_reset_email.html
+++ b/game/templates/game/password_reset_email.html
@@ -6,7 +6,7 @@ Username: {{ user.username }}
 
 Click the link below to set a new password:
 
-http://{{ domain }}/password-reset-confirm/{{ uid }}/{{ token }}/
+https://{{ domain }}/password-reset-confirm/{{ uid }}/{{ token }}/
 
 If you did not request this, please ignore this email.
 Your password will remain unchanged.


### PR DESCRIPTION
Closes #1407, Closes #1410

**Root cause**: `game/templates/game/password_reset_email.html:9` used `http://{{ domain }}` in the password reset link. An attacker with network access (same Wi-Fi, ISP level, compromised router) could intercept the reset token and take over the account.

**Fix**: Changed scheme from `http://` to `https://` to ensure the reset link is transmitted over an encrypted connection.
