### PR TITLE
Fix: Spaces around = in .env.example break email backend configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,6 @@ DATABASE_URL=sqlite:///db.sqlite3
 
 # Email Configuration for OTP and Password Reset Emails
 # Use Gmail App Passwords (not normal Gmail password)
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
 EMAIL_HOST_USER=your-email@gmail.com
 EMAIL_HOST_PASSWORD=your_16_digit_google_app_password


### PR DESCRIPTION
Closes #1326

**Root cause**: .env.example:14 had EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend' with spaces around \=\ and single-quote-wrapped values. When a contributor copies this to \.env\, \os.getenv()\ returns the value with leading whitespace, causing Django to fail importing the email backend class.

**Fix**: Removed spaces around \=\ and quotes from the value, matching the convention of all other variables in the file.