### PR TITLE
Fix: /resend-otp/ fails to update otp_created_at timestamp

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -847,6 +847,8 @@ def resend_otp(request):
     ).hexdigest()
 
     request.session['registration_otp_hash'] = otp_hash
+    request.session['otp_created_at'] = time.time()
+    request.session.modified = True
 
     try:
         send_mail(


### PR DESCRIPTION
Closes #1297

**Root cause**: \game/views.py:resend_otp\ updated \egistration_otp_hash\ in the session but did not update \otp_created_at\. Since \erify_otp\ calculates the 5-minute expiry window from \otp_created_at\, any OTP resent after the initial 5-minute window would arrive already expired.

**Fix**: Added \equest.session['otp_created_at'] = time.time()\ alongside the \egistration_otp_hash\ update, and set \session.modified = True\ to ensure the change is persisted.