### PR TITLE
Fix: Missing Referrer-Policy header in security settings

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -185,6 +185,7 @@ SECURE_CONTENT_TYPE_NOSNIFF = True
 SECURE_HSTS_SECONDS = 31536000  # 1 year
 SECURE_HSTS_INCLUDE_SUBDOMAINS = True
 SECURE_HSTS_PRELOAD = True
+SECURE_REFERRER_POLICY = 'strict-origin-when-cross-origin'
 
 # Secret token for authenticating Vercel cron job requests to /api/cron/cleanup-stale-games/
 CRON_SECRET = os.environ.get('CRON_SECRET')


### PR DESCRIPTION
Closes #1259

**Root cause**: \core/settings.py\ did not define \SECURE_REFERRER_POLICY\. Browsers default to sending the full URL (including query parameters, internal paths) in the \Referer\ header when navigating to external domains.

**Fix**: Added \SECURE_REFERRER_POLICY = 'strict-origin-when-cross-origin'\ — the browser sends the full URL as referrer for same-origin requests, but only the origin (scheme + host) for cross-origin requests.