### PR TITLE
fix: insecure session and SSL flags tied to DEBUG state

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -148,15 +148,15 @@ SESSION_ENGINE = 'django.contrib.sessions.backends.db'
 
 # Session Cookie Security
 SESSION_COOKIE_HTTPONLY = True
-SESSION_COOKIE_SECURE = not DEBUG
+SESSION_COOKIE_SECURE = os.environ.get('SESSION_COOKIE_SECURE', 'True').lower() in ('true', '1')
 SESSION_COOKIE_SAMESITE = 'Lax'
 
 CSRF_COOKIE_HTTPONLY = True
-CSRF_COOKIE_SECURE = not DEBUG
+CSRF_COOKIE_SECURE = os.environ.get('CSRF_COOKIE_SECURE', 'True').lower() in ('true', '1')
 CSRF_COOKIE_SAMESITE = 'Lax'
 
 # SSL Redirect
-SECURE_SSL_REDIRECT = not DEBUG and not os.environ.get('CI')
+SECURE_SSL_REDIRECT = os.environ.get('SECURE_SSL_REDIRECT', 'True').lower() in ('true', '1') and not os.environ.get('CI')
 
 
 # Email Configuration for OTP and Password Reset EMails


### PR DESCRIPTION
Closes #1258

**Root cause**: \SESSION_COOKIE_SECURE\ and \SECURE_SSL_REDIRECT\ were bound to \
ot DEBUG\. A \DEBUG=True\ in production would disable HTTPS redirect and transmit session cookies over unencrypted HTTP.

**Fix**: Replaced \
ot DEBUG\ with environment variable checks defaulting to \True\. Settings can now be overridden per environment via \SESSION_COOKIE_SECURE\ and \SECURE_SSL_REDIRECT\ env vars, completely decoupled from \DEBUG\.