### PR TITLE
Fix: Remove spaces around = in EMAIL_BACKEND config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,6 @@ DATABASE_URL=sqlite:///db.sqlite3
 
 # Email Configuration for OTP and Password Reset Emails
 # Use Gmail App Passwords (not normal Gmail password)
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
 EMAIL_HOST_USER=your-email@gmail.com
 EMAIL_HOST_PASSWORD=your_16_digit_google_app_password


### PR DESCRIPTION
﻿## Description
Removed inconsistent spaces around = in EMAIL_BACKEND setting. All other env vars use KEY=value format without spaces.

## Related Issue
Fixes #1326

## Type of Change
- [x] Bug fix

program: gssoc
