### PR TITLE
Fix: Update page title dynamically based on game outcome

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1562,7 +1562,8 @@
                     : `Game over. Draw by ${reason || 'stalemate'}.`;
                 announceMove(cleanMsg);
                 
-                document.title = 'Game Over - Checkora';
+                const titleMap = { checkmate: 'Checkmate', stalemate: 'Stalemate', draw: 'Draw', resign: 'Resignation', timeout: 'Timeout' };
+                document.title = `${titleMap[reason] || 'Game Over'} - Checkora`;
             }
 
             /* ==========================================================


### PR DESCRIPTION
﻿## Description
Updated document.title to reflect the actual game outcome (Checkmate, Stalemate, Draw, Resignation, Timeout) instead of always showing 'Game Over'.

## Related Issue
Fixes #1214

## Type of Change
- [x] Bug fix

program: gssoc
