### PR TITLE
Fix: Add missing @media query for mobile FAB controls

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -1260,7 +1260,7 @@ body {
   display: none; 
 }
 
- {
+@media (max-width: 768px) {
   .m-fab {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
﻿## Description
Added missing @media (max-width: 768px) wrapper around the mobile FAB controls CSS block. The bare { ... } block was invalid CSS, so .m-fab was never overridden from display: none; on mobile viewports.

## Related Issue
Fixes #1350

## Type of Change
- [x] Bug fix

program: gssoc
