### PR TITLE
Fix: Add null guard for shareResultBtn to prevent crash

### DIFF
--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -736,7 +736,9 @@
     <script src="{% static 'game/js/board.js' %}"></script>
 
     <script>
-document.getElementById('shareResultBtn').addEventListener('click', function () {
+const shareResultBtn = document.getElementById('shareResultBtn');
+if (shareResultBtn) {
+shareResultBtn.addEventListener('click', function () {
     const title = document.getElementById('gameOverTitle').innerText.trim();
     const message = document.getElementById('gameOverMessage').innerText.trim();
     const whiteName = document.getElementById('whiteNameLabel').innerText.trim();
@@ -788,6 +790,7 @@ ${message}
         modal.style.display = 'none';
     };
 });
+}
 </script>
 
 </body>


### PR DESCRIPTION
﻿## Description
Added null guard around shareResultBtn click handler. Previously, document.getElementById('shareResultBtn').addEventListener(...) would throw Cannot read properties of null if the button element was missing from the DOM.

## Related Issue
Fixes #1382

## Type of Change
- [x] Bug fix

program: gssoc
