### PR TITLE
fix: add active state indicator to board theme buttons (closes #1278)

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -917,15 +917,19 @@ body {
     cursor: pointer;
     transition: all 0.2s ease;
     padding: 0;
+    opacity: 0.75;
 }
 
 .theme-btn:hover {
     transform: scale(1.15);
+    opacity: 1;
 }
 
 .theme-btn.active {
     border-color: #f0c040;
-    box-shadow: 0 0 8px rgba(240, 192, 64, 0.4);
+    box-shadow: 0 0 0 3px #f0c040, 0 0 8px rgba(240, 192, 64, 0.5);
+    transform: scale(1.25);
+    opacity: 1;
 }
 
 .theme-btn[data-theme="classic"] { background-color: #facc15; }


### PR DESCRIPTION
## Summary
Closes #1278

Improves visual clarity of the board theme selector so players can 
instantly see which theme is currently active.

## Changes Made
`game/static/game/css/board.css` only — no JS, HTML, or backend changes.

| Property | Before | After |
|---|---|---|
| Inactive buttons | Full opacity, same size | opacity: 0.75 (dimmed) |
| Active button | Only gold border | scale(1.25) + double gold ring |
| Hover state | scale(1.15) only | scale(1.15) + opacity: 1 |

## How to Test
1. Open the game → start a match
2. Board Theme section — Classic is active by default
3. Classic button should be **larger** with gold ring, others slightly dimmed
4. Click Dark theme — it becomes large with gold ring
5. Classic shrinks back and dims to 0.75 opacity

## Screenshots
<img width="1853" height="873" alt="Screenshot 2026-05-30 165900" src="https://github.com/user-attachments/assets/fde4abb1-370c-4cfb-bd89-b93c40ee3be3" />




Uploading Screen Recording 2026-05-30 163601.mp4…

