### PR TITLE
enhace: update robots.txt to disallow more paths

### DIFF
--- a/game/templates/robots.txt
+++ b/game/templates/robots.txt
@@ -5,6 +5,7 @@ Disallow: /verify-otp/
 Disallow: /resend-otp/
 Disallow: /delete-account/
 Disallow: /confirm-delete/
+Disallow: /api
 Disallow: /api/
 Disallow: /password-reset-account-selection/
 

--- a/game/templates/robots.txt
+++ b/game/templates/robots.txt
@@ -2,5 +2,10 @@ User-agent: *
 Allow: /
 Disallow: /admin/
 Disallow: /verify-otp/
+Disallow: /resend-otp/
+Disallow: /delete-account/
+Disallow: /confirm-delete/
+Disallow: /api/
+Disallow: /password-reset-account-selection/
 
 Sitemap: https://checkora.vercel.app/sitemap.xml


### PR DESCRIPTION
## Description
Updated `robots.txt` to block sensitive and internal routes from web crawlers. Each disallow rule has been added deliberately to protect auth flows, account management, and internal API endpoints from being indexed or discovered by bots.

**Route-by-route reasoning:**

- `/admin/` — Django admin panel should never be crawlable or publicly discoverable
- `/verify-otp/` — OTP verification is a sensitive auth step, no SEO value and exposes auth flow structure
- `/resend-otp/` — Same as above, internal auth flow that bots have no business accessing
- `/delete-account/` — Account deletion is a destructive action route, must stay off crawlers
- `/confirm-delete/` — Contains `uidb64/token` in the URL, crawling these could expose deletion tokens
- `/api/` — Blocks all API endpoints in one rule; game logic, state, and AI endpoints are internal only
- `/password-reset-account-selection/` — Internal account recovery flow, no indexing needed

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Related Issue
Fixes #1429 

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

## Additional Notes
These changes have no impact on functionality, `robots.txt` is advisory only. However they improve security posture by not advertising internal route structure to crawlers and reducing the chance of sensitive endpoints being indexed or appearing in search results.