### PR TITLE
fix: add structural validation for opening book loading

### DIFF
--- a/game/engine.py
+++ b/game/engine.py
@@ -829,12 +829,32 @@ DP cache is intentionally excluded to save cookie space."""
     # ------------------------------------------------------------------
 
     @classmethod
+    def _is_valid_opening_book(cls, data) -> bool:
+        """Validate opening book structure: dict of FEN \u2192 list of 4-int moves."""
+        if not isinstance(data, dict):
+            return False
+        for fen_key, move_list in data.items():
+            if not isinstance(fen_key, str) or not fen_key.strip():
+                return False
+            if not isinstance(move_list, (list, tuple)):
+                return False
+            for move in move_list:
+                if (
+                    not isinstance(move, (list, tuple))
+                    or len(move) != 4
+                    or not all(isinstance(c, int) and 0 <= c <= 7 for c in move)
+                ):
+                    return False
+        return True
+
+    @classmethod
     def _load_opening_book(cls) -> dict:
         """Load the opening book JSON from disk (cached after first load)."""
         if cls._opening_book is None:
             try:
                 with open(cls.OPENING_BOOK_PATH, encoding='utf-8') as fh:
-                    cls._opening_book = json.load(fh)
+                    raw = json.load(fh)
+                cls._opening_book = raw if cls._is_valid_opening_book(raw) else {}
             except (OSError, json.JSONDecodeError):
                 cls._opening_book = {}  # Graceful fallback: no book
         return cls._opening_book

--- a/game/tests.py
+++ b/game/tests.py
@@ -1180,6 +1180,75 @@ class OpeningBookTest(SimpleTestCase):
         self.assertEqual(move['to_row'], 4)
         ChessGame._opening_book = None
 
+    # ------------------------------------------------------------------
+    # Structural validation (_is_valid_opening_book)
+    # ------------------------------------------------------------------
+
+    def test_validation_rejects_non_dict(self):
+        """List root must be rejected."""
+        self.assertFalse(ChessGame._is_valid_opening_book([]))
+
+    def test_validation_rejects_non_string_key(self):
+        """Integer keys must be rejected."""
+        self.assertFalse(ChessGame._is_valid_opening_book({1: [[6, 4, 4, 4]]}))
+
+    def test_validation_rejects_non_list_value(self):
+        """String value instead of move list must be rejected."""
+        self.assertFalse(ChessGame._is_valid_opening_book(
+            {'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq': 'invalid'}
+        ))
+
+    def test_validation_rejects_wrong_length_move(self):
+        """A move with 2 coordinates must be rejected."""
+        fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq'
+        self.assertFalse(ChessGame._is_valid_opening_book({fen: [[6, 4]]}))
+
+    def test_validation_rejects_out_of_range_move(self):
+        """A move with coordinate 8 must be rejected."""
+        fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq'
+        self.assertFalse(ChessGame._is_valid_opening_book({fen: [[8, 4, 4, 4]]}))
+
+    def test_validation_accepts_valid_book(self):
+        """A well-formed dict must pass validation."""
+        fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq'
+        self.assertTrue(ChessGame._is_valid_opening_book({fen: [[6, 4, 4, 4], [6, 3, 4, 3]]}))
+
+    def test_validation_accepts_empty_dict(self):
+        """An empty dict is a valid (trivial) book."""
+        self.assertTrue(ChessGame._is_valid_opening_book({}))
+
+    def test_validation_rejects_tuple_value(self):
+        """Top-level tuple must be rejected (not a dict)."""
+        self.assertFalse(ChessGame._is_valid_opening_book(()))
+
+    def test_validation_rejects_empty_string_key(self):
+        """Empty string as FEN key must be rejected."""
+        self.assertFalse(ChessGame._is_valid_opening_book({'': [[6, 4, 4, 4]]}))
+
+    def test_validation_rejects_mixed_type_list(self):
+        """A list with a non-int element must be rejected."""
+        fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq'
+        self.assertFalse(ChessGame._is_valid_opening_book({fen: [[6, 4, 'x', 4]]}))
+
+    def test_load_rejects_invalid_book_file(self):
+        """Corrupt JSON that loads as invalid structure must produce empty dict."""
+        ChessGame._opening_book = None
+        with mock.patch.object(ChessGame, 'OPENING_BOOK_PATH', '/nonexistent/bogus.json'):
+            with mock.patch('builtins.open', mock.mock_open(read_data='[]')):
+                book = ChessGame._load_opening_book()
+        self.assertEqual(book, {})
+        ChessGame._opening_book = None
+
+    def test_load_rejects_list_root_file(self):
+        """A JSON file containing a list (not dict) must produce empty dict."""
+        ChessGame._opening_book = None
+        with mock.patch('builtins.open', mock.mock_open(read_data='[]')):
+            with mock.patch.object(ChessGame, 'OPENING_BOOK_PATH', '/fake/book.json'):
+                book = ChessGame._load_opening_book()
+        self.assertEqual(book, {})
+        ChessGame._opening_book = None
+
+
 class MoveHistoryColorTest(TestCase):
     """Test that move_history records the correct player color."""
 


### PR DESCRIPTION
Fixes #1430

## Problem
The opening book could be loaded without structural validation. A corrupted or malformed JSON file (list root, non-dict, non-FEN keys, or out-of-range move coordinates) could pass silently, risking inconsistent game state or crashes during move selection.

## Changes

### `game/engine.py`
- Added `ChessGame._is_valid_opening_book()` — validates the book is a `dict[str, list[list[int]]]` with FEN keys, 4-int move sequences, and all coordinates in 0..7
- Updated `_load_opening_book()` to call the validator after parsing JSON — invalid structures fall back to `{}` gracefully

### `game/tests.py`
- Added 12 unit tests in `OpeningBookTest` covering:
  * Rejection of non-dict, non-string-key, non-list-value structures
  * Rejection of wrong-length, out-of-range, mixed-type moves
  * Acceptance of valid and empty books
  * Rejection of invalid JSON root (list instead of dict)

## Testing
All 12 new tests plus all existing OpeningBookTest tests pass.