### PR TITLE
docs: clean up some drifting docs and formatting quirks

### DIFF
--- a/API.md
+++ b/API.md
@@ -200,3 +200,40 @@ Allows players to offer or accept a draw agreement in PvP mode.
       "game_status": "draw_agreement" // Only present if action was "accept"
     }
     ```
+
+---
+
+## 9. Check Username Availability
+Checks whether a username already exists in the system. Used during registration to provide live feedback before form submission.
+
+- **URL:** `/api/check-username/`
+- **Method:** `GET`
+- **Auth Required:** No
+- **Request Params:** `?username=your_username`
+
+- **Success Response (username is free):**
+
+```json
+  {
+    "available": true
+  }
+```
+
+- **Username Taken Response:**
+
+```json
+  {
+    "available": false
+  }
+```
+
+- **Error Response (no username provided):**
+
+```json
+  {
+    "available": false,
+    "error": "No username provided"
+  }
+```
+
+  - **Status Code:** `400 Bad Request`

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -106,7 +106,7 @@ Violating these terms may lead to a permanent ban.
 ### 4. Permanent Ban
 
 **Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
+standards, including sustained inappropriate behavior, harassment of an
 individual, or aggression toward or disparagement of classes of individuals.
 
 **Consequence**: A permanent ban from any sort of public interaction within

--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ python -m venv venv
 venv\Scripts\activate        # Windows
 source venv/bin/activate     # macOS / Linux
 
-Note: Django 6.0 requires Python 3.12 or higher. If you have multiple versions on Windows, use a compatible installed version, for example: py -3.12 -m venv venv
+# Note: Django 6.0 requires Python 3.12 or higher. If you have multiple
+# versions on Windows, use a compatible installed version, e.g.:
+# py -3.12 -m venv venv
 
 # 3. Install dependencies
 pip install -r requirements.txt
@@ -301,6 +303,10 @@ Checkora features a decoupled API layer. Below is the endpoint catalog accompani
 | `GET` | `/api/check-promotion/` | Check if a pawn reaches the promotion rank | `/api/check-promotion/?from_row=1&from_col=0&to_row=0` |
 | `POST` | `/api/ai-move/` | Request the engine to compute the best move | `/api/ai-move/` |
 | `POST` | `/api/pause/` | Pause/Resume game timer countdown | `/api/pause/` |
+| `POST` | `/api/resume/` | Resume a previously saved game | `/api/resume/` |
+| `POST` | `/api/resign/` | Resign the current game | `/api/resign/` |
+| `POST` | `/api/draw/` | Offer or accept a draw in PvP mode | `/api/draw/` |
+| `GET` | `/api/check-username/` | Check if a username is available | `/api/check-username/?username=player1` |
 
 ---
 

--- a/docs/engine_architecture.md
+++ b/docs/engine_architecture.md
@@ -87,18 +87,18 @@ For the first few moves, the engine uses a pre-built opening book:
 - Values: List of valid moves `[from_row, from_col, to_row, to_col]`
 
 ## Move Flow
-1.Player clicks piece
-2.Django calls get_valid_moves()
-3.ChessGame checks DP cache
-4.If not cached → sends MOVES command to C++ engine
-5.C++ returns valid moves
-6.Player selects destination
-7.Django calls make_move()
-8.Move validated and applied
-9.If AI turn → get_ai_move() called
-10.Opening book checked first
-11.If not in book → BESTMOVE sent to C++ engine
-12.AI move returned and applied
+1. Player clicks piece
+2. Django calls `get_valid_moves()`
+3. ChessGame checks DP cache
+4. If not cached → sends `MOVES` command to C++ engine
+5. C++ returns valid moves
+6. Player selects destination
+7. Django calls `make_move()`
+8. Move validated and applied
+9. If AI turn → `get_ai_move()` called
+10. Opening book checked first
+11. If not in book → `BESTMOVE` sent to C++ engine
+12. AI move returned and applied
 
 ## Engine Fallback
 


### PR DESCRIPTION
Just some quick housekeeping to sync the missing endpoints in the API docs and update the readme table to actually match urls.py. 

Also fixed a bash block that was breaking copy/paste, plus a few rogue markdown formatting quirks.
