### PR TITLE
fix(ui): hide pause overlay while resign confirmation modal is active

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -1640,7 +1640,7 @@ body {
 }
 
 
-.chessboard.paused::after {
+.chessboard.paused:not(.confirm-open)::after {
     content: "Resume to Continue";
     position: absolute;
     top: 50%;

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -2455,6 +2455,7 @@
                 }
                 if (confirmMessage) confirmMessage.innerHTML = msg;
                 confirmCallback = callback;
+                boardEl.classList.add('confirm-open');
                 confirmOverlay.classList.add('active');
             }
 
@@ -3033,14 +3034,21 @@
             };
 
             if (confirmYesBtn) confirmYesBtn.onclick = () => {
-                confirmOverlay.classList.remove('active');
-                if (confirmCallback) confirmCallback();
-                confirmCallback = null;
-            };
+    boardEl.classList.remove('confirm-open');
+
+    confirmOverlay.classList.remove('active');
+
+    if (confirmCallback) confirmCallback();
+
+    confirmCallback = null;
+};
             if (confirmNoBtn) confirmNoBtn.onclick = () => {
-                confirmOverlay.classList.remove('active');
-                confirmCallback = null;
-            };
+    boardEl.classList.remove('confirm-open');
+
+    confirmOverlay.classList.remove('active');
+
+    confirmCallback = null;
+};
 
             if (newPvPBtn) newPvPBtn.onclick = () => {
                 // Clear any lingering celebration effects


### PR DESCRIPTION
## Description

This PR fixes a UI issue where the "Resume to Continue" pause overlay remained visible when the Resign confirmation modal was opened from a paused game.
The pause overlay is now temporarily hidden while the confirmation modal is active, preventing overlapping UI elements and improving the user experience.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #1484 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)


https://github.com/user-attachments/assets/65240412-06a6-4fbf-9750-b61390d34d13



## Additional Notes

This fix only affects the visual pause overlay during confirmation dialogs and does not modify the underlying pause/resume game logic.
