### PR TITLE
enhance(ui): refine board theme selection indicator styling

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -1257,8 +1257,8 @@ body {
 
 .theme-btn.active {
     border-color: #f0c040;
-    box-shadow: 0 0 0 3px #f0c040, 0 0 8px rgba(240, 192, 64, 0.5);
-    transform: scale(1.25);
+    box-shadow: 0 0 6px rgba(240, 192, 64, 0.35);
+    transform: scale(1.1);
     opacity: 1;
 }
 


### PR DESCRIPTION
## Description

This PR improves the visual appearance of the Board Theme selector by refining the selected-theme indicator styling.

The previous selected state used a prominent yellow ring and a larger scaling effect, which could draw excessive attention away from the theme previews. This update makes the active selection more visually balanced while keeping it clearly identifiable.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #1492 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

<img width="1402" height="268" alt="Screenshot 2026-05-31 at 9 42 58 PM" src="https://github.com/user-attachments/assets/3935bdd2-7366-46a0-ae2c-3164b33b2115" />


## Additional Notes

This change only affects the visual styling of the Board Theme selector and does not modify any board theme functionality.
