### PR TITLE
fix: make board theme labels responsive

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -931,6 +931,11 @@ body {
         gap: 6px;
     }
 
+    .theme-labels {
+        gap: 3px 6px;
+        font-size: 0.65rem;
+    }
+
     .theme-btn {
         width: 24px;
         height: 24px;
@@ -1267,6 +1272,23 @@ body {
 .theme-btn[data-theme="green"]   { background-color: #2e5a31; }
 .theme-btn[data-theme="blue"]    { background-color: #2e4a5a; }
 .theme-btn[data-theme="pastel"]  { background-color: #a55cc7; }
+
+.theme-labels {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 4px 8px;
+    max-width: 100%;
+    margin-top: 8px;
+    color: rgba(255, 255, 255, 0.5);
+    font-size: clamp(0.62rem, 0.58rem + 0.2vw, 0.72rem);
+    line-height: 1.25;
+    text-align: center;
+}
+
+.theme-labels span {
+    white-space: nowrap;
+}
 
 /* ================= PROMOTION MODAL ================= */
 
@@ -2491,4 +2513,3 @@ body.blindfold-mode .capture-ring {
         transform: none !important;
     }
 }
-

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -403,8 +403,12 @@
                     <button class="theme-btn" data-theme="pastel" title="Pastel" aria-label="Pastel theme"
                         aria-pressed="false" type="button"></button>
                 </div>
-                <div style="margin-top: 8px; font-size: 11px; color: rgba(255,255,255,0.5); text-align: center;">
-                    Classic · Dark · Green · Blue · Pastel
+                <div class="theme-labels" aria-hidden="true">
+                    <span>Classic</span>
+                    <span>Dark</span>
+                    <span>Green</span>
+                    <span>Blue</span>
+                    <span>Pastel</span>
                 </div>
             </div>
             <div class="card">


### PR DESCRIPTION
## Summary
- replace the inline board theme label text with a wrapping label group
- add responsive CSS so theme names stay aligned inside the panel on smaller screens

Closes #1128

## Testing
- npm test -- --runInBand