### PR TITLE
fix: added styling to restart puzzle button

### DIFF
--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -417,7 +417,7 @@
                     <button class="btn btn-gold" id="newPvPBtn">Pass & Play (PvP)</button>
                     <button class="btn btn-gold" id="newAIBtn">Play vs AI</button>
                     <button type="button" class="btn btn-gold" id="dailyPuzzleBtn">Daily Puzzle</button>
-                    <button type="button" id="restartPuzzleBtn" style="display:none;">Restart Puzzle</button>
+                    <button type="button" class="btn btn-gold" id="restartPuzzleBtn" style="display:none;">Restart Puzzle</button>
                     <button class="btn btn-gold" id="copyFenBtn">Copy FEN</button>
                     <button class="btn btn-gold" id="muteBtn" type="button" aria-pressed="true">🔊 Sound On</button>
                     <button class="btn btn-gold" id="newFenBtn">Load Game</button>


### PR DESCRIPTION
## Description
Added the class "btn btn-gold" to the restart puzzle button to match with aesthetic of other buttons

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issue

Fixes #1507 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)
<img width="645" height="448" alt="image" src="https://github.com/user-attachments/assets/612f1bef-6a58-4425-9d58-bc57b4be6d61" />

