### PR TITLE
fix: add consistent navbar and footer to contact page fixes #1210

### DIFF
--- a/game/templates/game/base.html
+++ b/game/templates/game/base.html
@@ -1,0 +1,115 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script>
+    if (navigator.webdriver) {
+      document.documentElement.style.setProperty('scroll-behavior', 'auto', 'important');
+    }
+  </script>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{% block title %}Checkora{% endblock %}</title>
+  <link rel="icon" type="image/jpeg" href="{% static 'game/favicon.jpeg' %}" />
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="{% static 'game/css/landing.css' %}" />
+  {% block extra_css %}{% endblock %}
+</head>
+<body>
+
+<nav class="navbar">
+  <div class="nav-left">
+    <a href="{% url 'landing' %}" class="logo-link">
+      <img src="{% static 'game/checkora_icon_only.png' %}" alt="Checkora Logo" class="logo-img" />
+      <span class="logo-text">CHECK<span class="logo-accent">ORA</span></span>
+    </a>
+    <div class="nav-links">
+      <a href="{% url 'landing' %}#about">About</a>
+      <a href="{% url 'landing' %}#features">Features</a>
+      <a href="{% url 'landing' %}#faq">FAQ</a>
+    </div>
+  </div>
+  <div class="nav-right">
+    {% if user.is_authenticated %}
+    <div class="profile-dropdown">
+      <button type="button" class="profile-btn">{{ user.username }}
+        <svg class="profile-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M6 9l6 6 6-6"></path>
+        </svg>
+      </button>
+      <div class="dropdown-content">
+        <a href="/play/">Dashboard</a>
+        <a href="/stats/">Stats</a>
+        <a href="{% url 'delete_account' %}" class="delete-option">Delete Account</a>
+        <form method="post" action="{% url 'logout' %}" style="margin:0;">
+          {% csrf_token %}
+          <button type="submit" class="logout-option">Logout</button>
+        </form>
+      </div>
+    </div>
+    {% else %}
+    <a href="{% url 'login' %}" class="btn-signin">Sign In</a>
+    <a href="{% url 'register' %}" class="btn-register">Register</a>
+    {% endif %}
+  </div>
+</nav>
+
+{% block content %}{% endblock %}
+
+<footer class="footer">
+  <div class="footer-container">
+    <div class="footer-col brand-column">
+      <a href="{% url 'landing' %}" class="logo-link">
+        <img src="{% static 'game/checkora_icon_only.png' %}" alt="Checkora Logo" class="logo-img" />
+        <span class="logo-text">CHECK<span class="logo-accent">ORA</span></span>
+      </a>
+      <p class="brand-desc">Experience high-performance chess with Checkora's hybrid C++ engine. Challenge the AI, track your stats, and master the board.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Platform</h4>
+      <ul class="footer-nav-list">
+        <li><a href="{% url 'index' %}" class="footer-link">Play Game</a></li>
+        <li><a href="{% url 'stats' %}" class="footer-link">Statistics</a></li>
+        <li><a href="{% url 'rules' %}" class="footer-link">Rulebook</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Community</h4>
+      <ul class="footer-nav-list">
+        <li><a href="https://github.com/Checkora" target="_blank" rel="noopener noreferrer" class="footer-link">GitHub Organization</a></li>
+        <li><a href="https://discord.gg/WfrpMuNZn" target="_blank" rel="noopener noreferrer" class="footer-link">Discord Community</a></li>
+        <li class="maintainer-item">
+          <span class="footer-meta-text">
+            Maintainers:
+            <a href="https://github.com/triemerge" target="_blank" rel="noopener noreferrer">@triemerge</a> &amp;
+            <a href="https://github.com/EDWARD-012" target="_blank" rel="noopener noreferrer">@EDWARD-012</a>
+          </span>
+        </li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Legal</h4>
+      <ul class="footer-nav-list">
+        <li><a href="{% url 'landing' %}" class="footer-link">Privacy Policy</a></li>
+        <li><a href="{% url 'landing' %}" class="footer-link">Terms &amp; Conditions</a></li>
+        <li><a href="{% url 'contact' %}" class="footer-link">Contact Us</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span class="footer-copy">&copy; {% now "Y" %} Checkora Hybrid Engine. All rights reserved.</span>
+    <div class="footer-socials">
+      <a href="https://github.com/Checkora" target="_blank" rel="noopener noreferrer" aria-label="GitHub Link">
+        <svg width="20" height="20" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" fill="currentColor"/></svg>
+      </a>
+      <a href="https://discord.gg/WfrpMuNZn" target="_blank" rel="noopener noreferrer" aria-label="Discord Link">
+        <svg width="20" height="20" viewBox="0 0 24 24"><path d="M19.27 5.33C17.94 4.71 16.5 4.26 15 4a.09.09 0 0 0-.07.03c-.18.33-.39.76-.53 1.09a16.09 16.09 0 0 0-4.8 0c-.14-.34-.35-.76-.54-1.09c-.01-.02-.04-.03-.07-.03c-1.5.26-2.93.71-4.27 1.33c-.01 0-.02.01-.03.02c-2.72 4.07-3.47 8.03-3.1 11.95c0 .02.02.04.03.05c1.8 1.32 3.53 2.12 5.24 2.65c.03.01.06 0 .07-.02c.4-.55.76-1.13 1.07-1.74c.02-.04 0-.08-.04-.09c-.57-.22-1.11-.48-1.64-.78c-.04-.02-.04-.08-.01-.11c.11-.08.22-.17.33-.25c.02-.02.05-.02.07-.01c3.44 1.57 7.15 1.57 10.55 0c.02-.01.05-.01.07.01c.11.09.22.17.33.26c.04.03.04.09-.01.11c-.52.31-1.07.56-1.64.78c-.04.01-.05.06-.04.09c.32.61.68 1.19 1.07 1.74c.03.01.06 0 .09.01c1.72-.53 3.45-1.33 5.25-2.65c.02-.01.03-.03.03-.05.44-4.53-.73-8.46-3.1-11.95c-.01-.01-.02-.02-.04-.02zM8.52 14.91c-1.03 0-1.89-.95-1.89-2.12s.84-2.12 1.89-2.12c1.06 0 1.9.96 1.89 2.12c0 1.17-.84 2.12-1.89 2.12zm6.97 0c-1.03 0-1.89-.95-1.89-2.12s.84-2.12 1.89-2.12c1.06 0 1.9.96 1.89 2.12c0 1.17-.83 2.12-1.89 2.12z" fill="currentColor"/></svg>
+      </a>
+    </div>
+  </div>
+</footer>
+
+{% block extra_js %}{% endblock %}
+</body>
+</html>

--- a/game/templates/game/contact.html
+++ b/game/templates/game/contact.html
@@ -1,312 +1,91 @@
+{% extends "game/base.html" %}
 {% load static %}
 
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+{% block title %}Contact Us - Checkora{% endblock %}
 
-    <title>Contact Us - Checkora</title>
+{% block extra_css %}
+<style>
+  :root {
+    --bg-color: #0d0e15; --card-bg: #131522; --text-main: #ffffff;
+    --text-muted: #9fa3b9; --accent-color: #ffc107;
+    --input-bg: #1a1d30; --input-border: #2b2f4a;
+  }
+  body {
+    background: radial-gradient(circle at 50% -20%, #1a1c2e 0%, #0d0e15 60%);
+    background-attachment: fixed;
+    padding: 0 20px;
+    display: flex; flex-direction: column; min-height: 100vh;
+  }
+  .contact-wrapper {
+    max-width: 1000px; width: 100%;
+    margin: 40px auto 60px auto;
+    background-color: var(--card-bg);
+    padding: 50px; border-radius: 16px;
+    box-shadow: 0 20px 50px rgba(0,0,0,0.7); flex: 1;
+  }
+  h1 { color: #fff; font-size: 2.6rem; font-weight: 700; margin-bottom: 10px; letter-spacing: -0.5px; }
+  .subtitle-desc { color: var(--text-muted); font-size: 1.05rem; margin-bottom: 40px; border-bottom: 1px solid rgba(255,255,255,0.06); padding-bottom: 25px; }
+  .contact-grid { display: grid; grid-template-columns: 0.8fr 1.5fr; gap: 60px; }
+  .info-col { display: flex; flex-direction: column; gap: 35px; }
+  .info-card h3 { color: #fff; font-size: 1.25rem; font-weight: 600; margin-bottom: 10px; }
+  .info-card p { color: var(--text-muted); font-size: 0.95rem; line-height: 1.6; }
+  .info-card a { color: var(--accent-color); text-decoration: none; font-weight: 500; }
+  .info-card a:hover { color: #fff; text-decoration: underline; }
+  .form-col form { display: flex; flex-direction: column; gap: 24px; }
+  .form-group { display: flex; flex-direction: column; gap: 10px; }
+  .form-group label { color: #fff; font-size: 0.9rem; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase; opacity: 0.9; }
+  .form-control { background-color: var(--input-bg); border: 1px solid var(--input-border); border-radius: 8px; padding: 14px 18px; color: #fff; font-family: inherit; font-size: 0.95rem; width: 100%; transition: border-color 0.25s ease, box-shadow 0.25s ease; }
+  .form-control:hover { border-color: rgba(255,255,255,0.15); }
+  .form-control:focus { outline: none; background-color: #1e213a; border-color: var(--accent-color); box-shadow: 0 0 0 4px rgba(240,192,64,0.12); }
+  textarea.form-control { resize: vertical; min-height: 150px; }
+  .btn-submit { background: linear-gradient(135deg, var(--accent-color), #d4a020); color: #1a1a2e; border: none; padding: 15px 32px; font-size: 1rem; font-weight: 700; border-radius: 8px; cursor: pointer; transition: all 0.25s ease; align-self: flex-start; box-shadow: 0 4px 15px rgba(240,192,64,0.2); }
+  .btn-submit:hover { transform: translateY(-2px); box-shadow: 0 8px 24px rgba(240,192,64,0.35); }
+  @media (max-width: 768px) {
+    .contact-wrapper { padding: 35px 25px; }
+    .contact-grid { grid-template-columns: 1fr; gap: 45px; }
+    h1 { font-size: 2.1rem; }
+    .btn-submit { width: 100%; text-align: center; }
+  }
+</style>
+{% endblock %}
 
-    <style>
-        /* Base Reset & Variables */
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-
-        :root {
-            --bg-color: #0d0e15;
-            --card-bg: #131522;
-            --text-main: #ffffff;
-            --text-muted: #9fa3b9;
-            --accent-color: #ffc107;
-            --line-height: 1.7;
-            --input-bg: #1a1d30;
-            --input-border: #2b2f4a;
-        }
-
-        body {
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-            background: radial-gradient(circle at 50% -20%, #1a1c2e 0%, #0d0e15 60%);
-            background-attachment: fixed;
-            color: var(--text-main);
-            line-height: var(--line-height);
-            padding: 0 20px;
-            display: flex;
-            flex-direction: column;
-            min-height: 100vh;
-        }
-
-        /* Header / Navigation */
-        header {
-            max-width: 1000px; /* Increased to allow wider layout tracking */
-            width: 100%;
-            margin: 0 auto;
-            padding: 40px 0 10px 0;
-        }
-
-        .back-link {
-            color: var(--accent-color);
-            text-decoration: none;
-            font-weight: 600;
-            font-size: 0.95rem;
-            transition: opacity 0.2s ease, transform 0.2s ease;
-            display: inline-block;
-        }
-
-        .back-link:hover {
-            opacity: 0.9;
-            transform: translateX(-3px);
-        }
-
-        /* Main Content Container */
-        .container {
-            max-width: 1000px; /* Expanded from 900px to expand general card boundary */
-            width: 100%;
-            margin: 30px auto 60px auto;
-            background-color: var(--card-bg);
-            padding: 50px;
-            border-radius: 16px;
-            border: none;
-            box-shadow: 0 20px 50px rgba(0, 0, 0, 0.7);
-            flex: 1;
-        }
-
-        h1 {
-            color: #ffffff;
-            font-size: 2.6rem;
-            font-weight: 700;
-            margin-bottom: 10px;
-            letter-spacing: -0.5px;
-        }
-
-        .subtitle-desc {
-            color: var(--text-muted);
-            font-size: 1.05rem;
-            margin-bottom: 40px;
-            border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-            padding-bottom: 25px;
-        }
-
-        /* Contact Grid Split Layout - Form area widened */
-        .contact-grid {
-            display: grid;
-            grid-template-columns: 0.8fr 1.5fr; /* Shifted from 1fr 1.3fr to widen the form panel */
-            gap: 60px;
-        }
-
-        /* Information Column */
-        .info-col {
-            display: flex;
-            flex-direction: column;
-            gap: 35px;
-        }
-
-        .info-card h3 {
-            color: #ffffff;
-            font-size: 1.25rem;
-            font-weight: 600;
-            margin-bottom: 10px;
-            display: flex;
-            align-items: center;
-            gap: 10px;
-        }
-
-        .info-card p {
-            color: var(--text-muted);
-            font-size: 0.95rem;
-            line-height: 1.6;
-        }
-
-        .info-card a {
-            color: var(--accent-color);
-            text-decoration: none;
-            font-weight: 500;
-            transition: color 0.2s ease;
-        }
-
-        .info-card a:hover {
-            color: #ffffff;
-            text-decoration: underline;
-        }
-
-        /* Interactive Form Fields */
-        .form-col form {
-            display: flex;
-            flex-direction: column;
-            gap: 24px;
-        }
-
-        .form-group {
-            display: flex;
-            flex-direction: column;
-            gap: 10px;
-        }
-
-        .form-group label {
-            color: #ffffff;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.5px;
-            text-transform: uppercase;
-            opacity: 0.9;
-        }
-
-        .form-control {
-            background-color: var(--input-bg);
-            border: 1px solid var(--input-border);
-            border-radius: 8px;
-            padding: 14px 18px;
-            color: #ffffff;
-            font-family: inherit;
-            font-size: 0.95rem;
-            transition: border-color 0.25s ease, box-shadow 0.25s ease, background-color 0.25s ease;
-            width: 100%;
-        }
-
-        .form-control:hover {
-            border-color: rgba(255, 255, 255, 0.15);
-        }
-
-        .form-control:focus {
-            outline: none;
-            background-color: #1e213a;
-            border-color: var(--accent-color);
-            box-shadow: 0 0 0 4px rgba(240, 192, 64, 0.12);
-        }
-
-        textarea.form-control {
-            resize: vertical;
-            min-height: 150px;
-        }
-
-        /* Premium Accent Action Button */
-        .btn-submit {
-            background: linear-gradient(135deg, var(--accent-color), #d4a020);
-            color: #1a1a2e;
-            border: none;
-            padding: 15px 32px;
-            font-size: 1rem;
-            font-weight: 700;
-            border-radius: 8px;
-            cursor: pointer;
-            transition: all 0.25s ease;
-            align-self: flex-start;
-            box-shadow: 0 4px 15px rgba(240, 192, 64, 0.2);
-        }
-
-        .btn-submit:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 8px 24px rgba(240, 192, 64, 0.35);
-        }
-
-        .btn-submit:active {
-            transform: translateY(0);
-        }
-
-        /* Footer Settings */
-        footer {
-            max-width: 1000px;
-            width: 100%;
-            margin: 0 auto;
-            padding: 40px 0;
-            text-align: center;
-            border-top: 1px solid rgba(255, 255, 255, 0.05);
-        }
-
-        .footer-copy {
-            color: var(--text-muted);
-            font-size: 0.9rem;
-        }
-
-        /* Responsive Configuration for Small Viewports */
-        @media (max-width: 768px) {
-            .container {
-                padding: 35px 25px;
-                margin-top: 20px;
-            }
-
-            .contact-grid {
-                grid-template-columns: 1fr;
-                gap: 45px;
-            }
-
-            h1 {
-                font-size: 2.1rem;
-            }
-            
-            .btn-submit {
-                width: 100%;
-                text-align: center;
-            }
-        }
-    </style>
-</head>
-
-<body>
-
-    <header>
-        <a href="{% url 'landing' %}" class="back-link">&larr; Back to Home</a>
-    </header>
-
-    <div class="container">
-
-        <h1>Contact Us</h1>
-        <p class="subtitle-desc">Have questions about the C++ platform integration or found a glitch? Reach out to the maintainers.</p>
-
-        <div class="contact-grid">
-            
-            <div class="info-col">
-                <div class="info-card">
-                    <h3>Community Support</h3>
-                    <p>For instant technical coordination, join our active development spaces on the <a href="https://discord.gg/WfrpMuNZn" target="_blank" rel="noopener noreferrer">Discord Server</a>.</p>
-                </div>
-
-                <div class="info-card">
-                    <h3>Open Source &amp; Bugs</h3>
-                    <p>Found a calculation variant failure or a move validation flaw? Open an inspection thread on our <a href="https://github.com/Checkora" target="_blank" rel="noopener noreferrer">GitHub Issue Tracker</a>.</p>
-                </div>
-
-                <div class="info-card">
-                    <h3>Maintainer Reach</h3>
-                    <p>Email: <a href="mailto:support@checkora.example.com">support@checkora.example.com</a></p>
-                </div>
-            </div>
-
-            <div class="form-col">
-                <form action="#" method="POST" onsubmit="alert('Message logged locally inside development environment container loop.'); return false;">
-                    {% csrf_token %}
-                    
-                    <div class="form-group">
-                        <label for="name">Name</label>
-                        <input type="text" id="name" name="name" class="form-control" placeholder="Your name" required />
-                    </div>
-
-                    <div class="form-group">
-                        <label for="email">Email Address</label>
-                        <input type="email" id="email" name="email" class="form-control" placeholder="username@example.com" required />
-                    </div>
-
-                    <div class="form-group">
-                        <label for="message">Message</label>
-                        <textarea id="message" name="message" class="form-control" placeholder="Type your query regarding engine or interface states..." required></textarea>
-                    </div>
-
-                    <button type="submit" class="btn-submit">Send Message</button>
-                </form>
-            </div>
-
-        </div>
-
+{% block content %}
+<div class="contact-wrapper">
+  <h1>Contact Us</h1>
+  <p class="subtitle-desc">Have questions about the C++ platform integration or found a glitch? Reach out to the maintainers.</p>
+  <div class="contact-grid">
+    <div class="info-col">
+      <div class="info-card">
+        <h3>Community Support</h3>
+        <p>For instant technical coordination, join our active development spaces on the <a href="https://discord.gg/WfrpMuNZn" target="_blank" rel="noopener noreferrer">Discord Server</a>.</p>
+      </div>
+      <div class="info-card">
+        <h3>Open Source &amp; Bugs</h3>
+        <p>Found a calculation variant failure or a move validation flaw? Open an inspection thread on our <a href="https://github.com/Checkora" target="_blank" rel="noopener noreferrer">GitHub Issue Tracker</a>.</p>
+      </div>
+      <div class="info-card">
+        <h3>Maintainer Reach</h3>
+        <p>Email: <a href="mailto:support@checkora.example.com">support@checkora.example.com</a></p>
+      </div>
     </div>
-
-    <footer>
-        <span class="footer-copy">
-            &copy; {% now "Y" %} Checkora Hybrid Engine. All rights reserved.
-        </span>
-    </footer>
-
-</body>
-</html>
+    <div class="form-col">
+      <form action="#" method="POST" onsubmit="alert('Message logged locally inside development environment container loop.'); return false;">
+        {% csrf_token %}
+        <div class="form-group">
+          <label for="name">Name</label>
+          <input type="text" id="name" name="name" class="form-control" placeholder="Your name" required />
+        </div>
+        <div class="form-group">
+          <label for="email">Email Address</label>
+          <input type="email" id="email" name="email" class="form-control" placeholder="username@example.com" required />
+        </div>
+        <div class="form-group">
+          <label for="message">Message</label>
+          <textarea id="message" name="message" class="form-control" placeholder="Type your query regarding engine or interface states..." required></textarea>
+        </div>
+        <button type="submit" class="btn-submit">Send Message</button>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Problem
The Contact Us page (/contact.html) was missing the site's standard navbar and footer, showing only a plain "← Back to Home" link instead.

## Solution
- Created a shared `base.html` template with the standard navbar and footer extracted from `landing.html`
- Refactored `contact.html` to extend `base.html`, removing the isolated back link

## Changes
- Added `game/templates/game/base.html` — shared navbar, footer, and head tags
- Updated `game/templates/game/contact.html` to extend `base.html`

## What was preserved
- All original contact page content fully intact (form fields, info cards, CSS)
- No layout or functionality removed

## What was NOT changed
- `board.html` — has its own custom header
- `rules.html` — has custom header/sidebar and is loaded inside an iframe on the board page
- `login.html`, `register.html` — minimal auth layout, no navbar needed
- `privacy.html`, `terms.html` — already handled as modals on landing page

## Testing
- Verified `/contact.html` now renders with full navbar and footer
- All form fields intact
- Responsive layout preserved

Fixes #1210

now the layout is [
<img width="1828" height="485" alt="image" src="https://github.com/user-attachments/assets/9733572e-8091-4c69-b1e1-e38e10661f6c" />
]
[
<img width="1736" height="771" alt="image" src="https://github.com/user-attachments/assets/8f98451c-8112-4d7d-a11a-f240f96c45d8" />
]