### PR TITLE
Previous game result issue resolved

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -854,7 +854,8 @@
                 // fix
                 // Removed static styling for AI clock so it displays the countdown timer.
 
-                if (data.game_status && data.game_status !== 'active' && data.game_status !== 'ok') {
+                const isOnWelcomeScreen = welcomeOverlay.classList.contains('active');
+                    if (!isOnWelcomeScreen && data.game_status && data.game_status !== 'active' && data.game_status !== 'ok') {
                     handleGameStatus(data.game_status, data.draw_reason);
                 }
                 if (!welcomeOverlay.classList.contains('active')) {

--- a/game/views.py
+++ b/game/views.py
@@ -53,9 +53,12 @@ def landing(request):
 @ensure_csrf_cookie
 def index(request):
     """Render the board and initialise a new game in the session."""
-    if 'game' not in request.session:
-        game = ChessGame()
-        request.session['game'] = game.to_dict()
+    game_data = request.session.get('game')
+    if game_data:
+        finished = {'checkmate', 'stalemate', 'draw', 'resignation', 'timeout'}
+        if isinstance(game_data, dict) and game_data.get('game_status') in finished:
+            del request.session['game']
+            request.session.modified = True
     return render(request, 'game/board.html')
 
 

--- a/game/views.py
+++ b/game/views.py
@@ -57,8 +57,9 @@ def index(request):
     if game_data:
         finished = {'checkmate', 'stalemate', 'draw', 'resignation', 'timeout'}
         if isinstance(game_data, dict) and game_data.get('game_status') in finished:
-            del request.session['game']
-            request.session.modified = True
+            request.session.pop('game', None)
+    if 'game' not in request.session:
+        request.session['game'] = ChessGame().to_dict()
     return render(request, 'game/board.html')
 
 

--- a/game/views.py
+++ b/game/views.py
@@ -58,8 +58,10 @@ def index(request):
         finished = {'checkmate', 'stalemate', 'draw', 'resignation', 'timeout'}
         if isinstance(game_data, dict) and game_data.get('game_status') in finished:
             request.session.pop('game', None)
+            request.session.modified = True
     if 'game' not in request.session:
         request.session['game'] = ChessGame().to_dict()
+        request.session.modified = True
     return render(request, 'game/board.html')
 
 


### PR DESCRIPTION
Fixes #1317 


## Problem After a game ends, returning to the home screen and starting a new game causes the previous game's result overlay to reappear with stale data.


## Fix 
- **`board.js`**: Skip `handleGameStatus()` if the welcome screen is currently active 
- **`views.py`**: Clear the session game on page load if its status is a finished state (checkmate, stalemate, draw, resignation, timeout)