### PR TITLE
ui: Add light and dark color scheme toggle with persistence.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Join our Discord community for updates, support, and games: https://discord.gg/D
 | Material Score Panel | Live material advantage tracking that updates dynamically during gameplay                           |
 | REST API             | Clean JSON endpoints powering a decoupled frontend                                                  |
 | PvP & PvE Modes      | Play against a friend or challenge the AI                                                           |
+| Light / Dark Mode    | Site-wide appearance toggle with persistence (separate from board square themes on `/play/`)          |
 
 ---
 

--- a/game/selenium_tests/test_navigation.py
+++ b/game/selenium_tests/test_navigation.py
@@ -264,3 +264,43 @@ class NavigationTest(BaseE2ETest):
         )
         self.assertTrue(error_div.is_displayed())
         log_ok(f"Validation error shown: '{error_div.text}'")
+
+    # ───────────────────────────────────────────────────────────────
+    # Test 12: Site color scheme toggle
+    # ───────────────────────────────────────────────────────────────
+    def test_12_color_scheme_toggle_on_homepage(self):
+        """Color scheme toggle switches light/dark and persists."""
+        log_info("Testing color scheme toggle...")
+        self.driver.get(self.live_server_url + '/')
+
+        toggle = self.wait.until(
+            EC.presence_of_element_located((By.ID, 'colorSchemeToggle')),
+            message="Color scheme toggle not found on homepage"
+        )
+        self.assertTrue(toggle.is_displayed())
+        log_ok("Color scheme toggle visible")
+
+        html = self.driver.find_element(By.TAG_NAME, 'html')
+        self.assertEqual(
+            html.get_attribute('data-color-scheme'),
+            'dark',
+            "Default color scheme should be dark"
+        )
+
+        toggle.click()
+        self.wait.until(
+            lambda d: d.find_element(By.TAG_NAME, 'html').get_attribute(
+                'data-color-scheme'
+            ) == 'light',
+            message="Toggle did not switch to light mode"
+        )
+        log_ok("Switched to light mode")
+
+        self.driver.refresh()
+        self.wait.until(
+            lambda d: d.find_element(By.TAG_NAME, 'html').get_attribute(
+                'data-color-scheme'
+            ) == 'light',
+            message="Light mode did not persist after refresh"
+        )
+        log_ok("Light mode persisted after refresh")

--- a/game/static/game/css/404.css
+++ b/game/static/game/css/404.css
@@ -1,11 +1,11 @@
 :root {
-    --bg-dark: #0f0f1a;
-    --card-bg: #16162a;
-    --card-border: #252545;
-    --text-primary: #d0d0d0;
-    --text-secondary: #aaaaaa;
-    --text-title: #ffffff;
-    --accent-gold: #f0c040;
+    --bg-dark: var(--background);
+    --card-bg: var(--card);
+    --card-border: var(--border);
+    --text-primary: var(--foreground);
+    --text-secondary: var(--foreground-secondary);
+    --text-title: var(--title);
+    --accent-gold: var(--accent);
 }
 
 * {

--- a/game/static/game/css/500.css
+++ b/game/static/game/css/500.css
@@ -1,11 +1,11 @@
 :root {
-    --bg-dark: #0f0f1a;
-    --card-bg: #16162a;
-    --card-border: #252545;
-    --text-primary: #d0d0d0;
-    --text-secondary: #aaaaaa;
-    --text-title: #ffffff;
-    --accent-gold: #f0c040;
+    --bg-dark: var(--background);
+    --card-bg: var(--card);
+    --card-border: var(--border);
+    --text-primary: var(--foreground);
+    --text-secondary: var(--foreground-secondary);
+    --text-title: var(--title);
+    --accent-gold: var(--accent);
     --danger-red: #ff6b6b;
 }
 

--- a/game/static/game/css/auth.css
+++ b/game/static/game/css/auth.css
@@ -12,9 +12,10 @@ html, body {
 }
 
 body {
-    background-color: #0f0f1a;
-    color: #d0d0d0;
+    background-color: var(--background);
+    color: var(--foreground);
     font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+    position: relative;
 
     min-height: 100vh;
 
@@ -79,7 +80,7 @@ body {
     font-size: 28px;
     font-weight: 700;
     letter-spacing: 3px;
-    color: #f0c040;
+    color: var(--accent);
     text-transform: uppercase;
 }
 
@@ -95,8 +96,8 @@ body {
 
 
 .auth-card {
-    background: #16162a;
-    border: 1px solid #252545;
+    background: var(--card);
+    border: 1px solid var(--border);
     border-radius: 12px;
 
     width: min(90vw, 520px);
@@ -117,23 +118,23 @@ body {
 .form-group label {
     display: block;
     font-size: 1rem;
-    color: #8a8aaa;
+    color: var(--foreground-muted);
     margin-bottom: 8px;
     letter-spacing: 0.5px;
 }
 .form-group input {
     width: 100%;
     padding: 16px 18px;
-    background: #0f0f1a;
-    border: 1px solid #333;
+    background: var(--input-bg);
+    border: 1px solid var(--input-border);
     border-radius: 6px;
-    color: #fff;
+    color: var(--title);
     font-size: 1.1rem;
     transition: all 0.2s ease;
 }
 .form-group input:focus {
     outline: none;
-    border-color: #f0c040;
+    border-color: var(--accent);
     box-shadow: 0 0 0 2px rgba(240, 192, 64, 0.2);
 }
 

--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -9,8 +9,8 @@ html {
 }
 
 body {
-    background-color: #0f0f1a;
-    color: #d0d0d0;
+    background-color: var(--background);
+    color: var(--foreground);
     font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
     min-height: 100vh;
     display: flex;
@@ -74,7 +74,7 @@ body {
     font-size: 26px;
     font-weight: 700;
     letter-spacing: 2px;
-    color: #f0c040;
+    color: var(--accent);
 }
 
 /* Responsive logo sizes */
@@ -252,8 +252,8 @@ body {
 }
 
 .card {
-    background: #16162a;
-    border: 1px solid #252545;
+    background: var(--card);
+    border: 1px solid var(--border);
     border-radius: 8px;
     padding: 14px;
 }
@@ -451,7 +451,7 @@ body {
 }
 
 :root {
-    --page-bg: #0f0f1a;
+    --page-bg: var(--background);
     --layout-gap: clamp(8px, 1.1vw, 18px);
     --layout-padding-x: clamp(10px, 1.5vw, 20px);
     --layout-padding-y: clamp(12px, 1.5vw, 20px);

--- a/game/static/game/css/landing.css
+++ b/game/static/game/css/landing.css
@@ -1,13 +1,12 @@
 :root {
-    --bg-dark: #0f0f1a;
-    --nav-bg: #12121f;
-    --card-bg: #16162a;
-    --card-border: #252545;
-    --card-hover: #1a1a35;
-    --text-primary: #d0d0d0;
-    --text-title: #ffffff;
-    --text-secondary: #aaaaaa;
-    --accent-gold: #f0c040;
+    --bg-dark: var(--background);
+    --card-bg: var(--card);
+    --card-border: var(--border);
+    --card-hover: var(--card-hover);
+    --text-primary: var(--foreground);
+    --text-title: var(--title);
+    --text-secondary: var(--foreground-secondary);
+    --accent-gold: var(--accent);
 }
 
 * {
@@ -38,8 +37,8 @@ body {
     justify-content: space-between;
     align-items: center;
     padding: 1.5rem 5%;
-    background-color: rgba(15, 15, 26, 0.94);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    background-color: var(--nav-bg);
+    border-bottom: 1px solid var(--nav-border);
     position: sticky;
     top: 0;
     z-index: 1000;

--- a/game/static/game/css/theme.css
+++ b/game/static/game/css/theme.css
@@ -1,0 +1,108 @@
+/* Site-wide light / dark color scheme (separate from board square themes) */
+
+:root,
+[data-color-scheme="dark"] {
+    --background: #0f0f1a;
+    --foreground: #d0d0d0;
+    --foreground-muted: #8a8aaa;
+    --foreground-secondary: #aaaaaa;
+    --title: #ffffff;
+    --card: #16162a;
+    --card-hover: #1a1a35;
+    --border: #252545;
+    --input-bg: #1a1a2e;
+    --input-border: #444444;
+    --nav-bg: rgba(15, 15, 26, 0.94);
+    --nav-border: rgba(255, 255, 255, 0.05);
+    --accent: #f0c040;
+    --accent-hover: #ffeaa7;
+    --shadow: rgba(5, 8, 15, 0.22);
+    --overlay-bg: rgba(0, 0, 0, 0.85);
+    --focus-ring: #f0c040;
+}
+
+[data-color-scheme="light"] {
+    --background: #f4f4f8;
+    --foreground: #1e2230;
+    --foreground-muted: #5c6378;
+    --foreground-secondary: #4a5068;
+    --title: #0f1219;
+    --card: #ffffff;
+    --card-hover: #f0f1f6;
+    --border: #d8dce8;
+    --input-bg: #ffffff;
+    --input-border: #c5cad8;
+    --nav-bg: rgba(255, 255, 255, 0.94);
+    --nav-border: rgba(0, 0, 0, 0.08);
+    --accent: #c99b1a;
+    --accent-hover: #a67d10;
+    --shadow: rgba(15, 20, 40, 0.08);
+    --overlay-bg: rgba(15, 20, 40, 0.45);
+    --focus-ring: #c99b1a;
+}
+
+/* Toggle control */
+.color-scheme-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    padding: 0;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--card);
+    color: var(--accent);
+    cursor: pointer;
+    transition: background 0.2s, border-color 0.2s, color 0.2s;
+    flex-shrink: 0;
+}
+
+.color-scheme-toggle:hover {
+    background: var(--card-hover);
+    border-color: var(--accent);
+}
+
+.color-scheme-toggle:focus-visible {
+    outline: 2px solid var(--focus-ring);
+    outline-offset: 2px;
+}
+
+.color-scheme-toggle svg {
+    width: 20px;
+    height: 20px;
+    pointer-events: none;
+}
+
+.color-scheme-toggle .icon-sun,
+.color-scheme-toggle .icon-moon {
+    display: none;
+}
+
+[data-color-scheme="dark"] .color-scheme-toggle .icon-sun {
+    display: block;
+}
+
+[data-color-scheme="light"] .color-scheme-toggle .icon-moon {
+    display: block;
+}
+
+.auth-theme-bar {
+    position: absolute;
+    top: 2rem;
+    right: 2rem;
+    z-index: 10;
+}
+
+@media (max-width: 480px) {
+    .auth-theme-bar {
+        top: 1rem;
+        right: 1rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .color-scheme-toggle {
+        transition: none;
+    }
+}

--- a/game/static/game/js/theme.js
+++ b/game/static/game/js/theme.js
@@ -1,0 +1,72 @@
+(function () {
+    'use strict';
+
+    var STORAGE_KEY = 'checkoraColorScheme';
+    var VALID = ['light', 'dark'];
+
+    function getStored() {
+        try {
+            var value = localStorage.getItem(STORAGE_KEY);
+            if (value && VALID.indexOf(value) !== -1) {
+                return value;
+            }
+        } catch (e) { /* ignore */ }
+        return 'dark';
+    }
+
+    function apply(scheme) {
+        if (VALID.indexOf(scheme) === -1) {
+            scheme = 'dark';
+        }
+        document.documentElement.setAttribute('data-color-scheme', scheme);
+        try {
+            localStorage.setItem(STORAGE_KEY, scheme);
+        } catch (e) { /* ignore */ }
+        syncToggleButtons(scheme);
+    }
+
+    function syncToggleButtons(scheme) {
+        var next = scheme === 'dark' ? 'light' : 'dark';
+        var label = scheme === 'dark'
+            ? 'Switch to light mode'
+            : 'Switch to dark mode';
+
+        document.querySelectorAll('[data-color-scheme-toggle]').forEach(function (btn) {
+            btn.setAttribute('aria-label', label);
+            btn.setAttribute('aria-pressed', scheme === 'light' ? 'true' : 'false');
+            btn.setAttribute('title', label);
+            btn.dataset.nextScheme = next;
+        });
+    }
+
+    function initToggleButtons() {
+        var scheme = document.documentElement.getAttribute('data-color-scheme') || getStored();
+        syncToggleButtons(scheme);
+
+        document.querySelectorAll('[data-color-scheme-toggle]').forEach(function (btn) {
+            if (btn.dataset.themeBound === 'true') {
+                return;
+            }
+            btn.dataset.themeBound = 'true';
+            btn.addEventListener('click', function () {
+                var current = document.documentElement.getAttribute('data-color-scheme') || 'dark';
+                apply(current === 'dark' ? 'light' : 'dark');
+            });
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initToggleButtons);
+    } else {
+        initToggleButtons();
+    }
+
+    window.CheckoraTheme = {
+        get: getStored,
+        apply: apply,
+        toggle: function () {
+            var current = document.documentElement.getAttribute('data-color-scheme') || getStored();
+            apply(current === 'dark' ? 'light' : 'dark');
+        }
+    };
+})();

--- a/game/templates/404.html
+++ b/game/templates/404.html
@@ -2,14 +2,17 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    {% include 'game/includes/theme_init.html' %}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>404 | Checkora</title>
     <link rel="icon" type="image/jpeg" href="{% static 'game/favicon.jpeg' %}">
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{% static 'game/css/theme.css' %}">
     <link rel="stylesheet" href="{% static 'game/css/404.css' %}">
 </head>
 <body>
+    <div class="auth-theme-bar">{% include 'game/includes/theme_toggle.html' %}</div>
     <main class="error-stage">
         <section class="error-card" role="alert" aria-live="polite">
             <img src="{% static 'game/checkora_icon_only.png' %}" class="crest" alt="Checkora crest">
@@ -19,5 +22,6 @@
             <a class="home-btn" href="{% url 'landing' %}">Return to Main Menu</a>
         </section>
     </main>
+    <script src="{% static 'game/js/theme.js' %}"></script>
 </body>
 </html>

--- a/game/templates/500.html
+++ b/game/templates/500.html
@@ -2,14 +2,17 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    {% include 'game/includes/theme_init.html' %}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>500 | Checkora</title>
     <link rel="icon" type="image/jpeg" href="{% static 'game/favicon.jpeg' %}">
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{% static 'game/css/theme.css' %}">
     <link rel="stylesheet" href="{% static 'game/css/500.css' %}">
 </head>
 <body>
+    <div class="auth-theme-bar">{% include 'game/includes/theme_toggle.html' %}</div>
     <main class="error-stage">
         <section class="error-card server-error" role="alert" aria-live="assertive">
             <img src="{% static 'game/checkora_icon_only.png' %}" class="crest" alt="Checkora crest">
@@ -22,5 +25,6 @@
             <a class="home-btn" href="{% url 'landing' %}">Return to Main Menu</a>
         </section>
     </main>
+    <script src="{% static 'game/js/theme.js' %}"></script>
 </body>
 </html>

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -3,6 +3,7 @@
 <html lang="en">
 
 <head>
+    {% include 'game/includes/theme_init.html' %}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Play Chess | Checkora AI</title>
@@ -17,6 +18,7 @@
     </script>
     <script defer src="/_vercel/speed-insights/script.js"></script>
 
+    <link rel="stylesheet" href="{% static 'game/css/theme.css' %}">
     <link rel="stylesheet" href="{% static 'game/css/board.css' %}">
     <link rel="stylesheet" href="{% static 'game/css/toast.css' %}">
 
@@ -241,6 +243,7 @@
         </div>
         
         <div class="auth-buttons">
+            {% include 'game/includes/theme_toggle.html' %}
             {% if user.is_authenticated %}
 
             <div class="profile-dropdown">
@@ -740,6 +743,7 @@
         window.SOUND_BASE_URL = "{% static 'game/sounds/' %}";
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/chess.js/0.10.3/chess.min.js"></script>
+    <script src="{% static 'game/js/theme.js' %}"></script>
     <script src="{% static 'game/js/board.js' %}"></script>
 
     <script>

--- a/game/templates/game/includes/auth_theme_assets.html
+++ b/game/templates/game/includes/auth_theme_assets.html
@@ -1,0 +1,3 @@
+{% load static %}
+{% include 'game/includes/theme_init.html' %}
+<link rel="stylesheet" href="{% static 'game/css/theme.css' %}">

--- a/game/templates/game/includes/theme_init.html
+++ b/game/templates/game/includes/theme_init.html
@@ -1,0 +1,13 @@
+<script>
+(function () {
+    var VALID = ['light', 'dark'];
+    var saved = 'dark';
+    try {
+        saved = localStorage.getItem('checkoraColorScheme') || 'dark';
+    } catch (e) { /* ignore */ }
+    if (VALID.indexOf(saved) === -1) {
+        saved = 'dark';
+    }
+    document.documentElement.setAttribute('data-color-scheme', saved);
+})();
+</script>

--- a/game/templates/game/includes/theme_toggle.html
+++ b/game/templates/game/includes/theme_toggle.html
@@ -1,0 +1,18 @@
+{% load static %}
+<button
+    type="button"
+    id="colorSchemeToggle"
+    class="color-scheme-toggle"
+    data-color-scheme-toggle
+    aria-label="Switch to light mode"
+    aria-pressed="false"
+    title="Switch to light mode"
+>
+    <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+        <circle cx="12" cy="12" r="4"></circle>
+        <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"></path>
+    </svg>
+    <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+    </svg>
+</button>

--- a/game/templates/game/landing.html
+++ b/game/templates/game/landing.html
@@ -2,6 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    {% include 'game/includes/theme_init.html' %}
     <script>
       if (navigator.webdriver) {
         document.documentElement.style.setProperty('scroll-behavior', 'auto', 'important');
@@ -80,6 +81,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght=400;500;600;700&display=swap"
       rel="stylesheet"
     />
+    <link rel="stylesheet" href="{% static 'game/css/theme.css' %}" />
     <link rel="stylesheet" href="{% static 'game/css/landing.css' %}" />
   </head>
 
@@ -103,6 +105,7 @@
         </div>
       </div>
       <div class="nav-right">
+        {% include 'game/includes/theme_toggle.html' %}
         {% if user.is_authenticated %}
         <div class="profile-dropdown">
           <button type="button" class="profile-btn">{{ user.username }} <svg class="profile-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"></path></svg></button>
@@ -853,5 +856,6 @@
     });
   })();
   </script>
+  <script src="{% static 'game/js/theme.js' %}"></script>
   </body>
 </html>

--- a/game/templates/game/login.html
+++ b/game/templates/game/login.html
@@ -2,6 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    {% include 'game/includes/auth_theme_assets.html' %}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sign In | CHECKORA</title>
@@ -10,6 +11,7 @@
     <link rel="stylesheet" href="{% static 'game/css/toast.css' %}">
 </head>
 <body class="login-page">
+    <div class="auth-theme-bar">{% include 'game/includes/theme_toggle.html' %}</div>
     <!-- Upgraded Back-to-home Button -->
     <a href="{% url 'landing' %}" class="back-btn">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
@@ -62,6 +64,7 @@
         </div>
     </div>
 
+    <script src="{% static 'game/js/theme.js' %}"></script>
     <script src="{% static 'game/js/auth.js' %}?v=7"></script>
     <script src="{% static 'game/js/toast.js' %}"></script>
 </body>

--- a/game/templates/game/password_reset.html
+++ b/game/templates/game/password_reset.html
@@ -2,6 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    {% include 'game/includes/auth_theme_assets.html' %}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Forgot Password | Checkora</title>
@@ -9,6 +10,7 @@
     <link rel="icon" type="image/jpeg" href="{% static 'game/favicon.jpeg' %}">
 </head>
 <body>
+    <div class="auth-theme-bar">{% include 'game/includes/theme_toggle.html' %}</div>
     <!-- Back-to-home arrow -->
     <a href="{% url 'landing' %}" class="back-home" aria-label="Back to home">&larr; Home</a>
 
@@ -93,5 +95,6 @@
             Remember your password? <a href="{% url 'login' %}">Sign In</a>
         </div>
     </div>
+    <script src="{% static 'game/js/theme.js' %}"></script>
 </body>
 </html>

--- a/game/templates/game/password_reset_complete.html
+++ b/game/templates/game/password_reset_complete.html
@@ -2,6 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    {% include 'game/includes/auth_theme_assets.html' %}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Password Reset Complete | Checkora</title>
@@ -9,6 +10,7 @@
     <link rel="icon" type="image/jpeg" href="{% static 'game/favicon.jpeg' %}">
 </head>
 <body>
+    <div class="auth-theme-bar">{% include 'game/includes/theme_toggle.html' %}</div>
     <!-- Back-to-home arrow -->
     <a href="{% url 'landing' %}" class="back-home" aria-label="Back to home">&larr; Home</a>
 
@@ -30,6 +32,6 @@
             <a href="{% url 'login' %}">Sign In</a>
         </div>
     </div>
-
+    <script src="{% static 'game/js/theme.js' %}"></script>
 </body>
 </html>

--- a/game/templates/game/password_reset_confirm.html
+++ b/game/templates/game/password_reset_confirm.html
@@ -2,6 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    {% include 'game/includes/auth_theme_assets.html' %}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Set New Password | Checkora</title>
@@ -9,6 +10,7 @@
     <link rel="icon" type="image/jpeg" href="{% static 'game/favicon.jpeg' %}">
 </head>
 <body>
+    <div class="auth-theme-bar">{% include 'game/includes/theme_toggle.html' %}</div>
     <!-- Back-to-home arrow -->
     <a href="{% url 'landing' %}" class="back-home" aria-label="Back to home">&larr; Home</a>
 
@@ -60,6 +62,6 @@
             <a href="{% url 'login' %}">Back to Sign In</a>
         </div>
     </div>
-
+    <script src="{% static 'game/js/theme.js' %}"></script>
 </body>
 </html>

--- a/game/templates/game/password_reset_done.html
+++ b/game/templates/game/password_reset_done.html
@@ -2,6 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    {% include 'game/includes/auth_theme_assets.html' %}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Email Sent | Checkora</title>
@@ -9,6 +10,7 @@
     <link rel="icon" type="image/jpeg" href="{% static 'game/favicon.jpeg' %}">
 </head>
 <body>
+    <div class="auth-theme-bar">{% include 'game/includes/theme_toggle.html' %}</div>
     <!-- Back-to-home arrow -->
     <a href="{% url 'landing' %}" class="back-home" aria-label="Back to home">&larr; Home</a>
 
@@ -30,6 +32,6 @@
             <a href="{% url 'login' %}">Back to Sign In</a>
         </div>
     </div>
-
+    <script src="{% static 'game/js/theme.js' %}"></script>
 </body>
 </html>

--- a/game/templates/game/register.html
+++ b/game/templates/game/register.html
@@ -2,6 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    {% include 'game/includes/auth_theme_assets.html' %}
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Register | Checkora</title>
@@ -14,6 +15,7 @@
       <link rel="stylesheet" href="{% static 'game/css/toast.css' %}">
 </head>
   <body>
+    <div class="auth-theme-bar">{% include 'game/includes/theme_toggle.html' %}</div>
     <!-- Upgraded Back-to-home Button -->
     <a href="{% url 'landing' %}" class="back-btn">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
@@ -116,5 +118,6 @@
             });
         }
     </script>
+    <script src="{% static 'game/js/theme.js' %}"></script>
 </body>
 </html>

--- a/game/templates/game/rules.html
+++ b/game/templates/game/rules.html
@@ -2,21 +2,22 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    {% include 'game/includes/theme_init.html' %}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Chess Rulebook – Checkora</title>
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=DM+Sans:wght@300;400;500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{% static 'game/css/theme.css' %}">
     <style>
 
         :root {
-            --bg: #0a0b10;
-            --surface: #141722;
-            --surface2: #1e2230;
-            --border: #2c3245;
-            --gold: #f4c430;
-            --gold-dim: #c99b1a;
-            --text: #f0f0f5;
-            --muted: #8b92a5;
+            --bg: var(--background);
+            --surface: var(--card);
+            --surface2: var(--card-hover);
+            --gold: var(--accent);
+            --gold-dim: var(--accent-hover);
+            --text: var(--title);
+            --muted: var(--foreground-muted);
             --light-sq: #f0d9b5;
             --dark-sq: #b58863;
             --highlight: rgba(244, 196, 48, 0.5);
@@ -645,7 +646,10 @@
             </a>
             <h1 class="header-subtitle">Interactive Chess Rulebook</h1>
         </div>
-        <button id="menuToggle" type="button" onclick="toggleSidebar()" aria-label="Toggle navigation menu" aria-controls="sidebar" aria-expanded="false">☰ Menu</button>
+        <div style="display:flex;align-items:center;gap:0.75rem;">
+            {% include 'game/includes/theme_toggle.html' %}
+            <button id="menuToggle" type="button" onclick="toggleSidebar()" aria-label="Toggle navigation menu" aria-controls="sidebar" aria-expanded="false">☰ Menu</button>
+        </div>
     </header>
 
     <div class="sidebar-overlay" id="sidebarOverlay" onclick="closeSidebar()"
@@ -1354,5 +1358,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 });
 </script>
+<script src="{% static 'game/js/theme.js' %}"></script>
 </body>
 </html>

--- a/game/templates/game/stats.html
+++ b/game/templates/game/stats.html
@@ -1,29 +1,35 @@
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    {% include 'game/includes/theme_init.html' %}
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Checkora - Game Stats</title>
+    <link rel="icon" type="image/jpeg" href="{% static 'game/favicon.jpeg' %}">
+    <link rel="stylesheet" href="{% static 'game/css/theme.css' %}">
     <style>
-        body { background: #0f0f1a; color: #d0d0d0; font-family: Arial, sans-serif; padding: 40px; }
-        h1 { color: #f0c040; text-align: center; letter-spacing: 2px; }
-        h2 { color: #f0c040; margin-top: 40px; }
+        body { background: var(--background); color: var(--foreground); font-family: Arial, sans-serif; padding: 40px; }
+        .stats-top { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem; margin-bottom: 20px; }
+        h1 { color: var(--accent); text-align: center; letter-spacing: 2px; flex: 1; }
+        h2 { color: var(--accent); margin-top: 40px; }
         table { width: 100%; border-collapse: collapse; margin-top: 20px; }
-        th { background: #1a1a2e; color: #f0c040; padding: 12px; text-align: left; }
-        td { padding: 10px 12px; border-bottom: 1px solid #252545; }
-        tr:hover { background: #16162a; }
-        .summary { display: flex; gap: 20px; margin-top: 20px; }
-        .card { background: #16162a; border: 1px solid #252545; border-radius: 8px; padding: 20px; flex: 1; text-align: center; }
-        .card .num { font-size: 36px; color: #f0c040; font-weight: bold; }
-        .card .label { color: #8a8aaa; margin-top: 8px; }
-        .empty { text-align: center; color: #5a5a7a; padding: 40px; }
-        a { color: #f0c040; text-decoration: none; }
+        th { background: var(--card); color: var(--accent); padding: 12px; text-align: left; }
+        td { padding: 10px 12px; border-bottom: 1px solid var(--border); }
+        tr:hover { background: var(--card-hover); }
+        .summary { display: flex; gap: 20px; margin-top: 20px; flex-wrap: wrap; }
+        .card { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 20px; flex: 1; min-width: 140px; text-align: center; }
+        .card .num { font-size: 36px; color: var(--accent); font-weight: bold; }
+        .card .label { color: var(--foreground-muted); margin-top: 8px; }
+        .empty { text-align: center; color: var(--foreground-muted); padding: 40px; }
+        a { color: var(--accent); text-decoration: none; }
         a:hover { text-decoration: underline; }
-        .back { text-align: center; margin-top: 30px; }
     </style>
 </head>
 <body>
-    <div style="margin-bottom: 20px;">
+    <div class="stats-top">
         <a href="/" class="back-btn">← Back to Home</a>
+        {% include 'game/includes/theme_toggle.html' %}
     </div>
     <h1>CHECK<span>ORA</span> &mdash; Game Statistics</h1>
 
@@ -65,5 +71,6 @@
     </div>
     {% endif %}
 
+    <script src="{% static 'game/js/theme.js' %}"></script>
 </body>
 </html>

--- a/game/templates/game/verify_otp.html
+++ b/game/templates/game/verify_otp.html
@@ -2,6 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    {% include 'game/includes/auth_theme_assets.html' %}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Verify your Email | Checkora</title>
@@ -45,6 +46,7 @@
     </style>
 </head>
 <body>
+    <div class="auth-theme-bar">{% include 'game/includes/theme_toggle.html' %}</div>
 
     <div class="header">
         <h1>Verify your Email</h1>
@@ -95,5 +97,6 @@
     }
     updateTimer();
 </script>
+<script src="{% static 'game/js/theme.js' %}"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "jest --env=jsdom"
+    "test": "jest --env=jsdom",
+    "test:theme": "jest theme.test.js --env=jsdom"
   },
   "repository": {
     "type": "git",

--- a/theme.test.js
+++ b/theme.test.js
@@ -1,0 +1,35 @@
+/**
+ * @jest-environment jsdom
+ */
+
+describe('CheckoraTheme', () => {
+    beforeEach(() => {
+        document.documentElement.removeAttribute('data-color-scheme');
+        localStorage.clear();
+        jest.resetModules();
+        document.body.innerHTML =
+            '<button type="button" data-color-scheme-toggle id="colorSchemeToggle"></button>';
+    });
+
+    test('defaults to dark when storage is empty', () => {
+        require('./game/static/game/js/theme.js');
+        expect(document.documentElement.getAttribute('data-color-scheme')).toBeNull();
+        expect(window.CheckoraTheme.get()).toBe('dark');
+    });
+
+    test('apply persists light mode', () => {
+        require('./game/static/game/js/theme.js');
+        window.CheckoraTheme.apply('light');
+        expect(document.documentElement.getAttribute('data-color-scheme')).toBe('light');
+        expect(localStorage.getItem('checkoraColorScheme')).toBe('light');
+    });
+
+    test('toggle switches between light and dark', () => {
+        require('./game/static/game/js/theme.js');
+        window.CheckoraTheme.apply('dark');
+        window.CheckoraTheme.toggle();
+        expect(document.documentElement.getAttribute('data-color-scheme')).toBe('light');
+        window.CheckoraTheme.toggle();
+        expect(document.documentElement.getAttribute('data-color-scheme')).toBe('dark');
+    });
+});


### PR DESCRIPTION
## Description
Adds a site-wide light/dark color scheme toggle with localStorage persistence and FOUC-safe initialization. Existing board square theme switcher (`chessBoardTheme` / `data-theme`) is unchanged.

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Related Issue
Fixes #1526

## Architecture decision
- Vanilla JS + shared `theme.css` tokens on `html[data-color-scheme]`
- Separate from board square themes (`data-theme`) to avoid collisions
- Django `{% include %}` partials for init script and toggle markup

## Accessibility improvements
- Keyboard-accessible `<button>` with `aria-label` and `aria-pressed`
- Visible `:focus-visible` ring on toggle
- Light palette uses contrast-safe foreground/background tokens

## Testing performed
- [ ] Manual: toggle, refresh, cross-page navigation
- [ ] `python manage.py test game`
- [ ] `python manage.py test game.selenium_tests` (includes `test_12_color_scheme_toggle_on_homepage`)
- [ ] `npm test` / `npm run test:theme` (after `npm install`)

## Screenshots
- [ ] Landing — dark (default)
- [ ] Landing — light
- [ ] Play page — light
- [ ] Login — light