### PR TITLE
fix: removed terms and privacy from urls and views

### DIFF
--- a/game/urls.py
+++ b/game/urls.py
@@ -30,12 +30,6 @@ urlpatterns = [
     
     path('delete-account/', views.delete_account, name='delete_account'),
     path('confirm-delete/<uidb64>/<token>/', views.confirm_delete_account, name='confirm_delete_account'),
-
-    # Privacy Policy Fallback Router
-    path('privacy.html', views.privacy_view, name='privacy'),
-
-    # Terms and Conditions Fallback Router
-    path('terms.html', views.terms_view, name='terms'),
     
     path(
         'password-reset-account-selection/',

--- a/game/views.py
+++ b/game/views.py
@@ -1122,14 +1122,6 @@ def cleanup_cron(request):
             'message': str(e)
         }, status=500)
 
-def privacy_view(request):
-    """Directly serve the static privacy template page."""
-    return render(request, 'game/privacy.html')
-
-def terms_view(request):
-    """Directly serve the static terms and conditions template page."""
-    return render(request, 'game/terms.html')
-
 def password_reset_account_selection(request):
 
     email = request.GET.get('email')


### PR DESCRIPTION
## Description

Terms & conditions and privacy policy are implemetned as modals but there endpoints and views still existed in urls.py and views.py (references html files which are not there throwing 500 error). This PR removes those.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issue

Fixes #1522 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)
<img width="2879" height="353" alt="image" src="https://github.com/user-attachments/assets/cf426865-98d7-44cb-8635-6584d93c75bd" />
<img width="2879" height="367" alt="image" src="https://github.com/user-attachments/assets/ad6a6128-8c15-417e-901d-f5707a05742d" />


## Additional Notes
All endpoints (/terms, /privacy, /terms.html, /privacy.html) throw 404 error.
Locally it is showing django 404 page, but in production it will render 404.html