### PR TITLE
fix: allow retry registration for unverified accounts

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -593,16 +593,8 @@ def register_view(request):
                     deleted = True
                 else:
                     # 2. Username conflict (Free up unverified, abandoned usernames)
-                    if User.objects.filter(
-                        username=username, 
-                        email=email,
-                        is_active=False
-                    ).exists():
-                        User.objects.filter(
-                            username=username, 
-                            email=email,
-                            is_active=False
-                        ).delete()
+                    if User.objects.filter(username=username, is_active=False).exists():
+                        User.objects.filter(username=username, is_active=False).delete()
                         deleted = True
                     # 3. Email conflict (Free up unverified, abandoned emails)
                     if User.objects.filter(email=email, is_active=False).exists():
@@ -711,10 +703,7 @@ def verify_otp(request):
         if otp_created_at:
             if time.time() - otp_created_at > 300:
                 try:
-                    user = User.objects.get(
-                    id=user_id,
-                    is_active=False
-                    )
+                    user = User.objects.get(id=user_id, is_active=False)
                     user.delete()
                 except User.DoesNotExist:
                     pass
@@ -761,7 +750,7 @@ def verify_otp(request):
                         from_email=settings.EMAIL_HOST_USER,
                         to=[user.email],
                     )
-                    email.attach_alternative(html_content,"text/html")
+                    email.attach_alternative(html_content, "text/html")
                     email.send(fail_silently=True)
                 
                 except Exception as e:

--- a/game/views.py
+++ b/game/views.py
@@ -565,7 +565,10 @@ def check_username(request):
     username = request.GET.get('username', '').strip()
     if not username:
         return JsonResponse({'available': False, 'error': 'No username provided'}, status=400)
-    exists = User.objects.filter(username__iexact=username).exists()
+    exists = User.objects.filter(
+        username__iexact=username,
+        is_active=True
+    ).exists()
     return JsonResponse({'available': not exists})
 
 
@@ -590,8 +593,16 @@ def register_view(request):
                     deleted = True
                 else:
                     # 2. Username conflict (Free up unverified, abandoned usernames)
-                    if User.objects.filter(username=username, is_active=False).exists():
-                        User.objects.filter(username=username, is_active=False).delete()
+                    if User.objects.filter(
+                        username=username, 
+                        email=email,
+                        is_active=False
+                    ).exists():
+                        User.objects.filter(
+                            username=username, 
+                            email=email,
+                            is_active=False
+                        ).delete()
                         deleted = True
                     # 3. Email conflict (Free up unverified, abandoned emails)
                     if User.objects.filter(email=email, is_active=False).exists():
@@ -699,7 +710,14 @@ def verify_otp(request):
 
         if otp_created_at:
             if time.time() - otp_created_at > 300:
-
+                try:
+                    user = User.objects.get(
+                    id=user_id,
+                    is_active=False
+                    )
+                    user.delete()
+                except User.DoesNotExist:
+                    pass
                 messages.error(
                     request,
                     'OTP has expired. Please register again.',


### PR DESCRIPTION
This PR fixes an issue where usernames and emails could remain blocked by incomplete registrations that never completed OTP verification.

### Problem

When a user registers, an inactive account is created before OTP verification. If the user leaves the OTP page and attempts to register again using the same credentials, the registration flow may incorrectly treat the username/email as unavailable.

### Changes Made

* Updated username availability checks to only consider active accounts.
* Added cleanup for inactive accounts when OTP verification expires.
* Improved handling of abandoned registrations so users can retry registration with the same credentials.
* Preserved protection for verified accounts while preventing stale unverified accounts from blocking new registrations.

### Testing

* Registered a new account and reached the OTP verification page.
* Left the OTP flow without verifying.
* Attempted registration again with the same username and email.
* Verified that registration could proceed successfully.
* Confirmed that active/verified accounts are still reported as unavailable.
* Verified OTP expiry cleanup removes inactive unverified accounts.

### Issue

Closes #1440
