### PR TITLE
feat: add persistent board coordinates toggle

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -3301,6 +3301,31 @@
                 };
             }
 
+            const coordsToggleBtn = document.getElementById('coordsToggleBtn');
+            let coordsVisible = true;
+            try {
+                coordsVisible = localStorage.getItem('chessCoordsVisible') !== 'false';
+            } catch (e) {}
+
+            function updateCoordsUI() {
+                const ranks = document.getElementById('ranksLabels');
+                const files = document.getElementById('filesLabels');
+                if (ranks) ranks.style.display = coordsVisible ? 'flex' : 'none';
+                if (files) files.style.display = coordsVisible ? 'flex' : 'none';
+                if (coordsToggleBtn) coordsToggleBtn.textContent = 'Coordinates: ' + (coordsVisible ? 'ON' : 'OFF');
+            }
+
+            if (coordsToggleBtn) {
+                updateCoordsUI();
+                coordsToggleBtn.onclick = () => {
+                    coordsVisible = !coordsVisible;
+                    try {
+                        localStorage.setItem('chessCoordsVisible', coordsVisible);
+                    } catch (e) {}
+                    updateCoordsUI();
+                };
+            }
+
             if (resignBtn) resignBtn.onclick = () => {
                 if (!gameOver) {
                     showConfirm("Resign?", "Are you sure you want to resign?", async () => {

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -413,7 +413,8 @@
                 <div style="display: flex; flex-direction: column; gap: 8px;">
 
                     <button type="button" class="btn btn-gold" id="flipBtn" title="Shortcut: F">Flip Board<span class="btn-shortcut">F</span></button>
-                   <button class="btn btn-gold" id="blindfoldBtn">Blindfold: OFF</button>
+                    <button class="btn btn-gold" id="blindfoldBtn">Blindfold: OFF</button>
+                    <button class="btn btn-gold" id="coordsToggleBtn" type="button">Coordinates: ON</button>
                     <button class="btn btn-gold" id="newPvPBtn">Pass & Play (PvP)</button>
                     <button class="btn btn-gold" id="newAIBtn">Play vs AI</button>
                     <button type="button" class="btn btn-gold" id="dailyPuzzleBtn">Daily Puzzle</button>


### PR DESCRIPTION
Closes #1545 

# Summary
Adds a persistent coordinates toggle button under the Board Controls panel, allowing players to show or hide board rank and file labels.
# Changes Made
- Modified `game/templates/game/board.html` to add the `#coordsToggleBtn` interactive element.
- Modified `game/static/game/js/board.js` to handle click events, toggle visibility of coordinates, and persist the setting using `localStorage`.
# Testing
- Tested local clicks to verify coordinates disappear and reappear seamlessly.
- Reloaded page and verified that the setting is correctly restored from `localStorage`.
- Verified screen reader indicators and accessibility cues.
# Impact
Improves customization and lets players practice chess visualization easily.
# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered