### PR TITLE
fix: correct en passant capture handling in minimax search and move generation

### DIFF
--- a/game/engine/main.cpp
+++ b/game/engine/main.cpp
@@ -318,7 +318,8 @@ void handleMoves(const string &turn, int row, int col) {
                     ? (isWhite(piece) ? 'Q' : 'q') : '\0';
                 if (leavesKingInCheck(m, turn)) continue;
 
-                int cap   = isEmpty(board[tr][tc]) ? 0 : 1;
+                bool isEP = (tolower(piece) == 'p' && col != tc && isEmpty(board[tr][tc]));
+                int cap = (!isEmpty(board[tr][tc]) || isEP) ? 1 : 0;
                 int promo = isPromotionMove(piece, tr) ? 1 : 0;
                 cout << " " << tr << " " << tc << " " << cap << " " << promo;
             }
@@ -694,6 +695,14 @@ int minimax(int depth, int alpha, int beta, bool maximizing) {
             board[m.tr][m.tc] = m.promoPiece ? m.promoPiece : src;
             board[m.fr][m.fc] = '.';
 
+            int ep_r = -1, ep_c = -1;
+            char ep_captured = '.';
+            if (tolower(src) == 'p' && m.fc != m.tc && dst == '.') {
+                ep_r = m.fr; ep_c = m.tc;
+                ep_captured = board[ep_r][ep_c];
+                board[ep_r][ep_c] = '.';
+            }
+
             int rook_fr = -1, rook_fc = -1, rook_tr = -1, rook_tc = -1;
             if (tolower(src) == 'k' && abs(m.tc - m.fc) == 2) {
                 if (m.tc == 6) { rook_fr = m.fr; rook_fc = 7; rook_tr = m.tr; rook_tc = 5; }
@@ -716,6 +725,7 @@ int minimax(int depth, int alpha, int beta, bool maximizing) {
 
             W_K_CASTLE = old_wk; W_Q_CASTLE = old_wq; B_K_CASTLE = old_bk; B_Q_CASTLE = old_bq;
 
+            if (ep_r != -1) board[ep_r][ep_c] = ep_captured;
             board[m.fr][m.fc] = src;
             board[m.tr][m.tc] = dst;
             if (rook_fr != -1) {
@@ -735,6 +745,14 @@ int minimax(int depth, int alpha, int beta, bool maximizing) {
             char dst = board[m.tr][m.tc];
             board[m.tr][m.tc] = m.promoPiece ? m.promoPiece : src;
             board[m.fr][m.fc] = '.';
+
+            int ep_r = -1, ep_c = -1;
+            char ep_captured = '.';
+            if (tolower(src) == 'p' && m.fc != m.tc && dst == '.') {
+                ep_r = m.fr; ep_c = m.tc;
+                ep_captured = board[ep_r][ep_c];
+                board[ep_r][ep_c] = '.';
+            }
 
             int rook_fr = -1, rook_fc = -1, rook_tr = -1, rook_tc = -1;
             if (tolower(src) == 'k' && abs(m.tc - m.fc) == 2) {
@@ -758,6 +776,7 @@ int minimax(int depth, int alpha, int beta, bool maximizing) {
 
             W_K_CASTLE = old_wk; W_Q_CASTLE = old_wq; B_K_CASTLE = old_bk; B_Q_CASTLE = old_bq;
 
+            if (ep_r != -1) board[ep_r][ep_c] = ep_captured;
             board[m.fr][m.fc] = src;
             board[m.tr][m.tc] = dst;
             if (rook_fr != -1) {
@@ -974,6 +993,14 @@ void handleBestMove(const string &turn, int depth) {
         board[m.tr][m.tc] = m.promoPiece ? m.promoPiece : src;
         board[m.fr][m.fc] = '.';
 
+        int ep_r = -1, ep_c = -1;
+        char ep_captured = '.';
+        if (tolower(src) == 'p' && m.fc != m.tc && dst == '.') {
+            ep_r = m.fr; ep_c = m.tc;
+            ep_captured = board[ep_r][ep_c];
+            board[ep_r][ep_c] = '.';
+        }
+
         int rook_fr = -1, rook_fc = -1, rook_tr = -1, rook_tc = -1;
         if (tolower(src) == 'k' && abs(m.tc - m.fc) == 2) {
             if (m.tc == 6) { rook_fr = m.fr; rook_fc = 7; rook_tr = m.tr; rook_tc = 5; }
@@ -996,6 +1023,7 @@ void handleBestMove(const string &turn, int depth) {
 
         W_K_CASTLE = old_wk; W_Q_CASTLE = old_wq; B_K_CASTLE = old_bk; B_Q_CASTLE = old_bq;
 
+        if (ep_r != -1) board[ep_r][ep_c] = ep_captured;
         board[m.fr][m.fc] = src;
         board[m.tr][m.tc] = dst;
         if (rook_fr != -1) {

--- a/game/engine/main.py
+++ b/game/engine/main.py
@@ -541,6 +541,12 @@ def minimax(depth, alpha, beta, maximizing):
             BOARD[move.tr][move.tc] = move.promo_piece if move.promo_piece != NO_PROMOTION else src_piece
             BOARD[move.fr][move.fc] = '.'
 
+            ep_r, ep_c, ep_cap = -1, -1, '.'
+            if src_piece.lower() == 'p' and move.fc != move.tc and dst_piece == '.':
+                ep_r, ep_c = move.fr, move.tc
+                ep_cap = BOARD[ep_r][ep_c]
+                BOARD[ep_r][ep_c] = '.'
+
             rook_fr, rook_fc, rook_tr, rook_tc = -1, -1, -1, -1
             if src_piece.lower() == 'k' and abs(move.tc - move.fc) == 2:
                 if move.tc == 6:
@@ -574,6 +580,9 @@ def minimax(depth, alpha, beta, maximizing):
             W_K_CASTLE, W_Q_CASTLE = old_wk, old_wq
             B_K_CASTLE, B_Q_CASTLE = old_bk, old_bq
 
+            if ep_r != -1:
+                BOARD[ep_r][ep_c] = ep_cap
+
             BOARD[move.fr][move.fc] = src_piece
             BOARD[move.tr][move.tc] = dst_piece
             if rook_fr != -1:
@@ -592,6 +601,12 @@ def minimax(depth, alpha, beta, maximizing):
         dst_piece = BOARD[move.tr][move.tc]
         BOARD[move.tr][move.tc] = move.promo_piece if move.promo_piece != NO_PROMOTION else src_piece
         BOARD[move.fr][move.fc] = '.'
+
+        ep_r, ep_c, ep_cap = -1, -1, '.'
+        if src_piece.lower() == 'p' and move.fc != move.tc and dst_piece == '.':
+            ep_r, ep_c = move.fr, move.tc
+            ep_cap = BOARD[ep_r][ep_c]
+            BOARD[ep_r][ep_c] = '.'
 
         rook_fr, rook_fc, rook_tr, rook_tc = -1, -1, -1, -1
         if src_piece.lower() == 'k' and abs(move.tc - move.fc) == 2:
@@ -625,6 +640,9 @@ def minimax(depth, alpha, beta, maximizing):
 
         W_K_CASTLE, W_Q_CASTLE = old_wk, old_wq
         B_K_CASTLE, B_Q_CASTLE = old_bk, old_bq
+
+        if ep_r != -1:
+            BOARD[ep_r][ep_c] = ep_cap
 
         BOARD[move.fr][move.fc] = src_piece
         BOARD[move.tr][move.tc] = dst_piece
@@ -703,6 +721,12 @@ def handle_bestmove(turn, depth):
         BOARD[move.tr][move.tc] = move.promo_piece if move.promo_piece != NO_PROMOTION else src_piece
         BOARD[move.fr][move.fc] = '.'
 
+        ep_r, ep_c, ep_cap = -1, -1, '.'
+        if src_piece.lower() == 'p' and move.fc != move.tc and dst_piece == '.':
+            ep_r, ep_c = move.fr, move.tc
+            ep_cap = BOARD[ep_r][ep_c]
+            BOARD[ep_r][ep_c] = '.'
+
         rook_fr, rook_fc, rook_tr, rook_tc = -1, -1, -1, -1
         if src_piece.lower() == 'k' and abs(move.tc - move.fc) == 2:
             if move.tc == 6:
@@ -735,6 +759,9 @@ def handle_bestmove(turn, depth):
 
         W_K_CASTLE, W_Q_CASTLE = old_wk, old_wq
         B_K_CASTLE, B_Q_CASTLE = old_bk, old_bq
+
+        if ep_r != -1:
+            BOARD[ep_r][ep_c] = ep_cap
 
         BOARD[move.fr][move.fc] = src_piece
         BOARD[move.tr][move.tc] = dst_piece


### PR DESCRIPTION
## Description
En passant captures were silently broken in the AI search. When the engine evaluated an en passant move, it moved the capturing pawn to the destination square but never removed the captured pawn from the board. Since the captured pawn remained visible to `evaluate()`, the AI scored the position as if no capture had occurred — making en passant appear worthless and causing the engine to actively avoid or misplay it.

This affected every node in the search tree where en passant was possible, corrupting evaluations at all depths.

The same bug existed in both `main.cpp` and `main.py` across three locations each:
- `minimax` maximizing branch
- `minimax` minimizing branch
- `handleBestMove` / `handle_bestmove`

Additionally, `handleMoves` / `handle_moves` was reporting en passant moves as non-captures (`is_capture = 0`) since the destination square is empty, which could cause incorrect frontend behaviour.

All locations now correctly remove the captured pawn during move application and restore it during undo.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issue
Closes #1566 

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally

## Screenshots (if applicable)
N/A - engine logic fix with no visual changes.

## Additional Notes
`leavesKingInCheck` already handled en passant correctly and was not modified. Fix applied symmetrically to both the C++ engine (`main.cpp`) and Python fallback (`main.py`) to keep them in sync.