### PR TITLE
fix: resolve infinite post-game summary modal loop in dashboard

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -53,6 +53,11 @@ def landing(request):
 @ensure_csrf_cookie
 def index(request):
     """Render the board and initialise a new game in the session."""
+    if 'game' in request.session:
+        game_data = request.session['game']
+        status = game_data.get('game_status', 'active')
+        if status in ['checkmate', 'draw', 'resign', 'stalemate', 'timeout']:
+            del request.session['game']
     if 'game' not in request.session:
         game = ChessGame()
         request.session['game'] = game.to_dict()


### PR DESCRIPTION
## Description

Fixed an issue where navigating to dashboard or even starting a new game after a match was already over continuously rendered a post game summary modal from the most recently completed match. 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #1458

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
