### PR TITLE
Fix Pause Overlay Overlapping Draw Modal

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -695,25 +695,6 @@ body {
 /* ============================================================
    Move History
    ============================================================ */
-/* ==========================================
-   FIX: Pause overlay should not overlap modals
-   ========================================== */
-
-#drawOverlay {
-    z-index: 12000 !important;
-}
-
-.pause-overlay,
-#pauseOverlay,
-.resume-overlay {
-    z-index: 9000;
-}
-
-body.modal-open .pause-overlay,
-body.modal-open #pauseOverlay,
-body.modal-open .resume-overlay {
-    display: none !important;
-}
 /* ============================================================
    Replay Controls
    ============================================================ */

--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -695,6 +695,25 @@ body {
 /* ============================================================
    Move History
    ============================================================ */
+/* ==========================================
+   FIX: Pause overlay should not overlap modals
+   ========================================== */
+
+#drawOverlay {
+    z-index: 12000 !important;
+}
+
+.pause-overlay,
+#pauseOverlay,
+.resume-overlay {
+    z-index: 9000;
+}
+
+body.modal-open .pause-overlay,
+body.modal-open #pauseOverlay,
+body.modal-open .resume-overlay {
+    display: none !important;
+}
 /* ============================================================
    Replay Controls
    ============================================================ */

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -2813,6 +2813,7 @@
 
             async function offerDraw() {
                 if (paused || gameOver || gameMode !== 'pvp') return;
+
                 const offeringPlayer = turn === 'white' ? 'White' : 'Black';
                 const receivingPlayer = turn === 'white' ? 'Black' : 'White';
 
@@ -2820,18 +2821,18 @@
                     "Offer Draw?",
                     `As <b>${offeringPlayer}</b>, do you want to offer a draw to ${receivingPlayer}?`,
                     async () => {
-                        drawMessage.textContent = `${offeringPlayer} offers a draw. ${receivingPlayer}, do you accept?`;
+                        drawMessage.textContent =
+                            `${offeringPlayer} offers a draw. ${receivingPlayer}, do you accept?`;
+
                         drawOverlay.classList.add('active');
-                        const pauseOverlay = document.getElementById('pauseOverlay');
-                        if (pauseOverlay) {
-                            pauseOverlay.style.display = 'none';
-                        }
+
+                        boardEl?.classList.add('confirm-open');
+
                         await pauseGame();
                     },
                     '#f0c040'
                 );
             }
-    
             async function startNewGame(mode, pColor = 'white', difficulty = 'medium', fen = null, timeLimitMins = null, overrideNames = null, isPuzzle = false) {
                 evaluationCache = {};
                 if (!isPuzzle) {
@@ -3538,22 +3539,19 @@
             if (drawBtn) drawBtn.onclick = offerDraw;
             if (drawAcceptBtn) drawAcceptBtn.onclick = async () => {
                 drawOverlay.classList.remove('active');
-                document.body.classList.remove("modal-open");
-                document.body.classList.remove("modal-open");
-                if (pauseOverlay && paused) {
-                    pauseOverlay.style.display = 'flex';
-                }
+                boardEl?.classList.remove('confirm-open');
                 const data = await post('/api/draw/', { action: 'accept' });
                 if (data.success) {
-                    if (soundEnabled) { sounds.draw.currentTime = 0; sounds.draw.play().catch(() => {}); }
+                    if (soundEnabled) {
+                        sounds.draw.currentTime = 0;
+                        sounds.draw.play().catch(() => {});
+                    }
                     endGame('draw', turn, data.draw_reason);
                 }
             };
             if (drawDeclineBtn) drawDeclineBtn.onclick = () => {
                 drawOverlay.classList.remove('active');
-                if (pauseOverlay && paused) {
-                    pauseOverlay.style.display = 'flex';
-                }
+                boardEl?.classList.remove('confirm-open');
                 resumeGame();
             };
 

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -2822,6 +2822,10 @@
                     async () => {
                         drawMessage.textContent = `${offeringPlayer} offers a draw. ${receivingPlayer}, do you accept?`;
                         drawOverlay.classList.add('active');
+                        const pauseOverlay = document.getElementById('pauseOverlay');
+                        if (pauseOverlay) {
+                            pauseOverlay.style.display = 'none';
+                        }
                         await pauseGame();
                     },
                     '#f0c040'
@@ -3534,6 +3538,11 @@
             if (drawBtn) drawBtn.onclick = offerDraw;
             if (drawAcceptBtn) drawAcceptBtn.onclick = async () => {
                 drawOverlay.classList.remove('active');
+                document.body.classList.remove("modal-open");
+                document.body.classList.remove("modal-open");
+                if (pauseOverlay && paused) {
+                    pauseOverlay.style.display = 'flex';
+                }
                 const data = await post('/api/draw/', { action: 'accept' });
                 if (data.success) {
                     if (soundEnabled) { sounds.draw.currentTime = 0; sounds.draw.play().catch(() => {}); }
@@ -3542,6 +3551,9 @@
             };
             if (drawDeclineBtn) drawDeclineBtn.onclick = () => {
                 drawOverlay.classList.remove('active');
+                if (pauseOverlay && paused) {
+                    pauseOverlay.style.display = 'flex';
+                }
                 resumeGame();
             };
 


### PR DESCRIPTION
fixes #1133

### Problem

When the game was paused and a draw offer modal appeared, the “Resume to Continue” overlay overlapped with the draw modal, causing UI misalignment and visual clutter.

### Changes Made

* Added proper z-index management for overlays and modals
* Ensured the draw offer modal appears above the pause overlay
* Hid the pause overlay whenever a modal is active

### Result

The draw offer modal now appears clearly above the paused board without overlapping issues, improving the overall UI experience.



<img width="1897" height="908" alt="image" src="https://github.com/user-attachments/assets/a9b89913-6e00-4faf-9b0b-0f5ed134b1ad" />

@itsmeesnehaa 