### PR TITLE
feat: add opening selection

### DIFF
--- a/game/engine/opening_book.json
+++ b/game/engine/opening_book.json
@@ -200,5 +200,53 @@
     [3, 3, 4, 4],
     [1, 4, 3, 4],
     [0, 6, 2, 5]
-  ]
+  ],
+"_named_lines": {
+  "_named_lines_comment": "Sequences for opening trainer. Alternating white/black moves. Format: [from_row, from_col, to_row, to_col]",
+
+  "italian_game": {
+    "display_name": "Italian Game",
+    "player_color": "white",
+    "moves": [
+      [6, 4, 4, 4],
+      [1, 4, 3, 4],
+      [7, 6, 5, 5],
+      [0, 1, 2, 2],
+      [7, 5, 4, 2],
+      [0, 5, 2, 3],
+      [7, 4, 7, 6],
+      [0, 4, 0, 6]
+    ]
+  },
+
+  "sicilian_defense": {
+    "display_name": "Sicilian Defense",
+    "player_color": "black",
+    "moves": [
+      [6, 4, 4, 4],
+      [1, 2, 3, 2],
+      [7, 6, 5, 5],
+      [1, 3, 2, 3],
+      [6, 3, 4, 3],
+      [3, 2, 4, 3],
+      [5, 5, 4, 3],
+      [0, 6, 2, 5]
+    ]
+  },
+
+  "queens_gambit": {
+    "display_name": "Queen's Gambit",
+    "player_color": "white",
+    "moves": [
+      [6, 3, 4, 3],
+      [1, 3, 3, 3],
+      [6, 2, 4, 2],
+      [1, 4, 2, 4],
+      [7, 1, 5, 2],
+      [0, 6, 2, 5],
+      [7, 2, 5, 4],
+      [0, 5, 1, 4]
+    ]
+  }
+}
 }

--- a/game/services.py
+++ b/game/services.py
@@ -1,10 +1,13 @@
-import time, json, os
+import time
+import json
+import os
 from django.contrib.sessions.models import Session
 from django.db import transaction
 from django.contrib.auth import get_user_model
 from game.models import GameResult
 
 User = get_user_model()
+
 
 def cleanup_stale_games():
     """
@@ -15,27 +18,27 @@ def cleanup_stale_games():
     """
     # 48 hours in seconds
     stale_threshold = time.time() - (48 * 3600)
-    
+
     deleted_count = 0
     resigned_count = 0
-    
+
     # Iterate over all sessions
     for session in Session.objects.iterator():
         try:
             session_data = session.get_decoded()
         except Exception:
             continue
-            
+
         game_data = session_data.get('game')
         if not game_data or game_data.get('game_status') != 'active':
             continue
-            
+
         last_ts = game_data.get('last_ts', 0)
         if last_ts > stale_threshold:
             continue
-            
+
         moves_count = len(game_data.get('move_history', []))
-        
+
         with transaction.atomic():
             if moves_count < 5:
                 # Rule A: Hard deletion
@@ -48,23 +51,23 @@ def cleanup_stale_games():
                 current_turn = game_data.get('current_turn', 'white')
                 player_color = game_data.get('player_color', 'white')
                 mode = game_data.get('mode', 'pvp')
-                
+
                 # In AI mode, the human (player_color) is the inactive one
                 # In PvP mode, the player whose turn it is is inactive
                 if mode == 'ai':
                     winner = 'black' if player_color == 'white' else 'white'
                 else:
                     winner = 'black' if current_turn == 'white' else 'white'
-                
+
                 game_data['game_status'] = 'resignation'
                 session_data['game'] = game_data
                 session.session_data = Session.objects.encode(session_data)
                 session.save()
-                
+
                 # Create a GameResult historically linking to the user if auth is known
                 user_id = session_data.get('_auth_user_id')
                 user = User.objects.filter(pk=user_id).first() if user_id else None
-                
+
                 result = GameResult(
                     user=user,
                     mode=mode,
@@ -75,12 +78,14 @@ def cleanup_stale_games():
                 )
                 result.full_clean()
                 result.save()
-                
+
                 resigned_count += 1
-                
+
     return deleted_count, resigned_count
 
+
 _NAMED_LINES_CACHE = None
+
 
 def _load_named_lines():
     global _NAMED_LINES_CACHE
@@ -93,11 +98,12 @@ def _load_named_lines():
             _NAMED_LINES_CACHE = {}
     return _NAMED_LINES_CACHE
 
+
 def get_opening_line(name):
     """return full move list for a named opening, or empty list if not found"""
     lines = _load_named_lines()
     opening = lines.get(name, {})
-    return opening.get('moves', [])
+    return opening.get('moves', [])[:]
 
 
 def get_opening_reply(name, move_index):
@@ -107,6 +113,6 @@ def get_opening_reply(name, move_index):
     returns None if out of book.
     """
     moves = get_opening_line(name)
-    if move_index < len(moves):
+    if 0 <= move_index < len(moves):
         return moves[move_index]
     return None

--- a/game/services.py
+++ b/game/services.py
@@ -1,4 +1,4 @@
-import time
+import time, json, os
 from django.contrib.sessions.models import Session
 from django.db import transaction
 from django.contrib.auth import get_user_model
@@ -79,3 +79,34 @@ def cleanup_stale_games():
                 resigned_count += 1
                 
     return deleted_count, resigned_count
+
+_NAMED_LINES_CACHE = None
+
+def _load_named_lines():
+    global _NAMED_LINES_CACHE
+    if _NAMED_LINES_CACHE is None:
+        book_path = os.path.join(os.path.dirname(__file__), 'engine', 'opening_book.json')
+        try:
+            with open(book_path) as f:
+                _NAMED_LINES_CACHE = json.load(f).get('_named_lines', {})
+        except (OSError, json.JSONDecodeError):
+            _NAMED_LINES_CACHE = {}
+    return _NAMED_LINES_CACHE
+
+def get_opening_line(name):
+    """return full move list for a named opening, or empty list if not found"""
+    lines = _load_named_lines()
+    opening = lines.get(name, {})
+    return opening.get('moves', [])
+
+
+def get_opening_reply(name, move_index):
+    """
+    return the theory reply at move_index.
+    move_index is the index of the AI's next move in the sequence.
+    returns None if out of book.
+    """
+    moves = get_opening_line(name)
+    if move_index < len(moves):
+        return moves[move_index]
+    return None

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -2924,7 +2924,8 @@
                     black_name: bName,
                     difficulty: difficulty,
                     time_limit: timeLimit,
-                    increment: increment
+                    increment: increment,
+                    opening: document.getElementById('welcomeOpeningSelect')?.value || '',
                 };
 
                 const fenValue = (fen && fen.trim()) ? fen.trim() : null;

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -66,7 +66,7 @@
             <div style="margin-bottom: 20px; color:#f0c040;">
                 <a href="/" class="back-btn">← Back to Home</a>
             </div>
-            <div class="promo-title"
+            <div class="promo-title"git sta
                 style="font-size: 1.6rem; margin-bottom: 10px; display: flex; align-items: center; justify-content: center; gap: 8px;">
                 <div class="promo-title promo-logo">
     <img src="{% static 'game/checkora_icon_only.png' %}"
@@ -224,7 +224,7 @@
 
                 <!-- Inside #pveOptions div, before startAIBtn -->
                 <div id="aiOpeningContainer" style="margin-bottom: 10px;">
-                    <label style="color: #ccc; display: block; margin-bottom: 5px; font-size: 0.9rem; text-align: center;">
+                    <label for="welcomeOpeningSelect" style="color: #ccc; display: block; margin-bottom: 5px; font-size: 0.9rem; text-align: center;">
                         Opening (optional)
                     </label>
                     <select id="welcomeOpeningSelect"

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -221,6 +221,21 @@
                         <option value="hard">Hard</option>
                     </select>
                 </div>
+
+                <!-- Inside #pveOptions div, before startAIBtn -->
+                <div id="aiOpeningContainer" style="margin-bottom: 10px;">
+                    <label style="color: #ccc; display: block; margin-bottom: 5px; font-size: 0.9rem; text-align: center;">
+                        Opening (optional)
+                    </label>
+                    <select id="welcomeOpeningSelect"
+                        style="width: 100%; padding: 10px; border-radius: 5px; border: 1px solid #444; background: #1a1a2e; color: #fff;">
+                        <option value="">— No preference (AI decides) —</option>
+                        <option value="italian_game">Italian Game</option>
+                        <option value="sicilian_defense">Sicilian Defense</option>
+                        <option value="queens_gambit">Queen's Gambit</option>
+                    </select>
+                </div>
+
                 <button class="btn btn-gold" id="startAIBtn" style="padding: 12px; font-size: 1.05rem;">Start
                     Game</button>
                 <button class="btn" id="backToModes"

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -66,7 +66,7 @@
             <div style="margin-bottom: 20px; color:#f0c040;">
                 <a href="/" class="back-btn">← Back to Home</a>
             </div>
-            <div class="promo-title"git sta
+            <div class="promo-title"
                 style="font-size: 1.6rem; margin-bottom: 10px; display: flex; align-items: center; justify-content: center; gap: 8px;">
                 <div class="promo-title promo-logo">
     <img src="{% static 'game/checkora_icon_only.png' %}"

--- a/game/views.py
+++ b/game/views.py
@@ -45,6 +45,7 @@ from .models import GameResult
 logger = logging.getLogger(__name__)
 from game.services import cleanup_stale_games, get_opening_reply
 from .analysis import build_summary
+VALID_OPENINGS = {'italian_game', 'sicilian_defense', 'queens_gambit'}
 
 def landing(request):
     """Render the landing page introduction to Checkora."""
@@ -231,7 +232,6 @@ def new_game(request):
     request.session['difficulty'] = difficulty
     request.session['player_color'] = player_color
 
-    VALID_OPENINGS = {'italian_game', 'sicilian_defense', 'queens_gambit'}
     raw_opening = data.get('opening', '') if mode == 'ai' else ''
     opening = raw_opening if raw_opening in VALID_OPENINGS else ''
     request.session['opening'] = opening
@@ -437,8 +437,11 @@ def ai_move(request):
     opening = request.session.get('opening', '')
     book_move = None
     if opening:
-        ai_half_moves = len(game.move_history)
-        book_move = get_opening_reply(opening, ai_half_moves)
+        try:
+            ai_half_moves = len(game.move_history)
+            book_move = get_opening_reply(opening, ai_half_moves)
+        except Exception:
+            book_move = None
 
     if book_move:
         best = {
@@ -448,7 +451,7 @@ def ai_move(request):
             'to_col':   book_move[3],
         }
         valid = game.get_valid_moves(best['from_row'], best['from_col'])
-        if [best['to_row'], best['to_col']] not in valid:
+        if not any(m['row'] == best['to_row'] and m['col'] == best['to_col'] for m in valid):
             request.session['opening'] = ''
             request.session.modified = True
             best = game.get_ai_move(depth=depth)

--- a/game/views.py
+++ b/game/views.py
@@ -43,7 +43,7 @@ from django.contrib.auth.decorators import login_required
 from .engine import ChessGame
 from .models import GameResult
 logger = logging.getLogger(__name__)
-from game.services import cleanup_stale_games
+from game.services import cleanup_stale_games, get_opening_reply
 from .analysis import build_summary
 
 def landing(request):
@@ -231,6 +231,11 @@ def new_game(request):
     request.session['difficulty'] = difficulty
     request.session['player_color'] = player_color
 
+    VALID_OPENINGS = {'italian_game', 'sicilian_defense', 'queens_gambit'}
+    raw_opening = data.get('opening', '') if mode == 'ai' else ''
+    opening = raw_opening if raw_opening in VALID_OPENINGS else ''
+    request.session['opening'] = opening
+
     fen = fen.strip() if isinstance(fen, str) else None
     if fen:
         try:
@@ -267,6 +272,7 @@ def new_game(request):
         'pgn': game.generate_pgn(request.session.get('white_name', 'White'), request.session.get('black_name', 'Black')),
         'game_status': game.game_status,
         'draw_reason': game.draw_reason,
+        'opening': opening,
     })
 
 
@@ -428,7 +434,26 @@ def ai_move(request):
     depth_map = {'easy': 1, 'medium': 2, 'hard': 3}
     depth = depth_map.get(difficulty, 2)
 
-    best = game.get_ai_move(depth=depth)
+    opening = request.session.get('opening', '')
+    book_move = None
+    if opening:
+        ai_half_moves = len(game.move_history)
+        book_move = get_opening_reply(opening, ai_half_moves)
+
+    if book_move:
+        best = {
+            'from_row': book_move[0],
+            'from_col': book_move[1],
+            'to_row':   book_move[2],
+            'to_col':   book_move[3],
+        }
+        valid = game.get_valid_moves(best['from_row'], best['from_col'])
+        if [best['to_row'], best['to_col']] not in valid:
+            request.session['opening'] = ''
+            request.session.modified = True
+            best = game.get_ai_move(depth=depth)
+    else:
+        best = game.get_ai_move(depth=depth)
 
     if not best:
         if game.game_status == 'checkmate':
@@ -489,6 +514,7 @@ def ai_move(request):
         'pgn': game.generate_pgn(request.session.get('white_name', 'White'), request.session.get('black_name', 'Black')),
         'white_name': request.session.get('white_name', 'White'),
         'black_name': request.session.get('black_name', 'Black'),
+        'opening': request.session.get('opening', ''),
     })
 
 @require_POST


### PR DESCRIPTION
## Description
Adds opening selection for PvE games. Players can choose an opening before starting, and the AI will follow book moves for that line before automatically switching to normal minimax play when the line ends or the position deviates.

Supported openings:
- Italian Game
- Sicilian Defense
- Queen's Gambit

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Related Issue
Fixes #1574

## Changes
- Added opening book support with predefined move sequences.
- Added backend helpers for loading and serving opening lines.
- Added optional `opening` parameter to game creation API.
- Integrated opening-book moves into AI move generation before minimax.
- Added opening selection dropdown to the PvE start menu.
- Updated frontend game initialization to send the selected opening.

## Notes
- Opening selection is optional.
- Once the opening line is exhausted or deviated from, the AI permanently falls back to minimax for that game.
- Works for both White and Black player colors.