### PR TITLE
ci: speed up Selenium job (cache staticfiles, use pre-installed Chrome) (#1584)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,12 +351,24 @@ jobs:
           pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: 🔧 Install Chrome
+      - name: 🔧 Install Chrome (use pre-installed or cache)
         run: |
-          sudo apt-get update
-          sudo apt-get install -y google-chrome-stable
+          if google-chrome-stable --version &>/dev/null; then
+            echo "Chrome already available: $(google-chrome-stable --version)"
+          else
+            sudo apt-get update
+            sudo apt-get install -y google-chrome-stable
+          fi
+
+      - name: 📦 Cache static files
+        id: cache-static
+        uses: actions/cache@v4
+        with:
+          path: staticfiles
+          key: staticfiles-${{ runner.os }}-${{ hashFiles('game/static/**/*', 'game/templates/**/*') }}
 
       - name: 📦 Collect static files
+        if: steps.cache-static.outputs.cache-hit != 'true'
         run: python manage.py collectstatic --noinput
 
       - name: 🧪 Run Selenium E2E Tests


### PR DESCRIPTION
﻿Fixes #1584

## Changes
1. **Chrome install** — Check if Chrome is pre-installed on runner first; only install if missing
2. **Static files cache** — Cache \staticfiles/\ directory keyed by hash of \game/static/\ and \game/templates/\; only run \collectstatic\ on cache miss

## Expected saving
~30–60s off the Selenium job per run (Chrome install ~20-40s, collectstatic ~10-20s, both skipped on cache hit).
