### PR TITLE
ci: replace Chrome apt install with setup-chrome action and cache collectstatic output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,6 +357,7 @@ jobs:
           chrome-version: stable
 
       - name: 📦 Cache static files
+        id: static-cache
         uses: actions/cache@v4
         with:
           path: staticfiles/
@@ -365,6 +366,7 @@ jobs:
             static-${{ runner.os }}-
 
       - name: 📦 Collect static files
+        if: steps.static-cache.outputs.cache-hit != 'true'
         run: python manage.py collectstatic --noinput
 
       - name: 🧪 Run Selenium E2E Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,8 +362,6 @@ jobs:
         with:
           path: staticfiles/
           key: static-${{ runner.os }}-${{ hashFiles('game/static/**', 'templates/**') }}
-          restore-keys: |
-            static-${{ runner.os }}-
 
       - name: 📦 Collect static files
         if: steps.static-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,10 +351,18 @@ jobs:
           pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: 🔧 Install Chrome
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y google-chrome-stable
+      - name: 🔧 Set up Chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: stable
+
+      - name: 📦 Cache static files
+        uses: actions/cache@v4
+        with:
+          path: staticfiles/
+          key: static-${{ runner.os }}-${{ hashFiles('game/static/**', 'templates/**') }}
+          restore-keys: |
+            static-${{ runner.os }}-
 
       - name: 📦 Collect static files
         run: python manage.py collectstatic --noinput


### PR DESCRIPTION
## Description
Two steps in the `selenium-tests` job were running slow on every CI run:

- `apt-get install google-chrome-stable` hit the Ubuntu package mirror over the network on every run with no caching (~20–40s)
- `collectstatic` reprocessed all static files unconditionally even when nothing changed (~10–20s)

**Changes:**
- Replaced apt-get Chrome install with `browser-actions/setup-chrome@v1` which caches the Chrome binary in Actions cache, only re-downloading when a new stable version is released
- Added `actions/cache@v4` step before `collectstatic` keyed on `hashFiles('game/static/**', 'templates/**')` so the step is fully skipped when no static files have changed 
- Added `id: static-cache` and `if: steps.static-cache.outputs.cache-hit != 'true'` to truly skip collectstatic on cache hit rather than running and finding nothing to do

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue
Fixes #1584 

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Additional Notes
Expected saving is ~30–60s off the Selenium job per run. Chrome cache will miss once per stable Chrome release (currently ~every 4 weeks) and re-download automatically : no manual intervention needed.