### PR TITLE
fix: prevent duplicate game records on post-completion resignation

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -542,6 +542,9 @@ def resign_game(request):
 
     game = ChessGame.from_dict(game_data)
 
+    if game.game_status != 'active':
+        return JsonResponse({'valid': False, 'message': 'Game is already over.'}, status=400)
+
     resigning_player = game.player_color if game.mode == 'ai' else game.current_turn
     winner = 'black' if resigning_player == 'white' else 'white'
     game_status = 'resignation'


### PR DESCRIPTION
## Related Issue
Closes #1595

## Changes Made
- Add guard in `resign_game` view to check `game.game_status != 'active'`
- Returns `400 Bad Request` with `'Game is already over.'` if game is not active
- Prevents session state override and duplicate GameResult records

## Testing
- Complete a game via checkmate → submit POST to /api/resign/ → receive 400 error
- Active game → submit POST to /api/resign/ → resignation proceeds as normal
