### PR TITLE
Fix: prevent account deletion via GET request — add confirmation step

### DIFF
--- a/game/templates/game/confirm_delete.html
+++ b/game/templates/game/confirm_delete.html
@@ -1,0 +1,69 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Confirm Deletion | Checkora</title>
+    <link rel="stylesheet" href="{% static 'game/css/landing.css' %}">
+    <style>
+        body {
+            min-height: 100vh;
+            background: radial-gradient(circle at top, #1e293b 0%, #0f172a 45%, #020617 100%);
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            padding: 30px;
+        }
+        .card {
+            background: rgba(15,23,42,0.92);
+            border: 1px solid rgba(255,255,255,0.08);
+            border-radius: 24px;
+            padding: 42px 36px;
+            max-width: 460px;
+            width: 100%;
+            text-align: center;
+        }
+        h1 { color: #fff; font-size: 28px; margin-bottom: 12px; }
+        p { color: #94a3b8; font-size: 15px; line-height: 1.6; margin-bottom: 28px; }
+        .btn {
+            display: inline-block;
+            padding: 14px 36px;
+            border-radius: 14px;
+            border: none;
+            font-size: 16px;
+            font-weight: 700;
+            cursor: pointer;
+            transition: 0.3s;
+        }
+        .btn-danger {
+            background: linear-gradient(135deg, #dc2626, #991b1b);
+            color: #fff;
+        }
+        .btn-danger:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 10px 25px rgba(220,38,38,0.35);
+        }
+        .btn-cancel {
+            background: rgba(255,255,255,0.06);
+            color: #94a3b8;
+            margin-left: 12px;
+            text-decoration: none;
+        }
+        .btn-cancel:hover { color: #fff; }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <h1>Confirm Account Deletion</h1>
+        <p>This action is permanent and cannot be undone. All your account data will be permanently removed from Checkora.</p>
+        <form method="POST" style="display: inline;">
+            {% csrf_token %}
+            <input type="hidden" name="uidb64" value="{{ uidb64 }}">
+            <input type="hidden" name="token" value="{{ token }}">
+            <button type="submit" class="btn btn-danger">Delete My Account</button>
+        </form>
+        <a href="{% url 'landing' %}" class="btn btn-cancel">Cancel</a>
+    </div>
+</body>
+</html>

--- a/game/views.py
+++ b/game/views.py
@@ -1204,109 +1204,58 @@ def password_reset_account_selection(request):
 
 
 @login_required
+@require_POST
 def delete_account(request):
+    username = request.POST.get('username')
+    password = request.POST.get('password')
 
-    if request.method == 'POST':
+    user = authenticate(username=username, password=password)
 
-        username = request.POST.get('username')
-        password = request.POST.get('password')
-
-        user = authenticate(
-            username=username,
-            password=password
+    if user and user == request.user:
+        uid = urlsafe_base64_encode(force_bytes(user.pk))
+        token = default_token_generator.make_token(user)
+        delete_link = request.build_absolute_uri(
+            reverse('confirm_delete_account', kwargs={'uidb64': uid, 'token': token})
         )
 
-        if user and user == request.user:
-
-            uid = urlsafe_base64_encode(
-                force_bytes(user.pk)
-            )
-
-            token = default_token_generator.make_token(user)
-            delete_link = request.build_absolute_uri(
-                reverse(
-                    'confirm_delete_account',
-                    kwargs={
-                        'uidb64': uid,
-                        'token': token
-                    }
-                )
-            )
-
-            try:
-
-                send_mail(
-                    subject='Confirm Account Deletion',
-                    message=f"""
-Click the link below to permanently delete your account:
+        try:
+            send_mail(
+                subject='Confirm Account Deletion',
+                message=f"""Click the link below to permanently delete your account:
 
 {delete_link}
 
-If this wasn't you, ignore this email.
-""",
-                    from_email=settings.EMAIL_HOST_USER,
-                    recipient_list=[user.email],
-                    fail_silently=False,
-                )
+If this wasn't you, ignore this email.""",
+                from_email=settings.EMAIL_HOST_USER,
+                recipient_list=[user.email],
+                fail_silently=False,
+            )
+            messages.success(request, 'Confirmation email sent to your registered email.')
+        except Exception:
+            messages.error(request, 'Failed to send confirmation email.')
 
-                messages.success(
-                    request,
-                    'Confirmation email sent to your registered email.'
-                )
+        return redirect('index')
 
-            except Exception:
-                messages.error(
-                    request,
-                    'Failed to send confirmation email.'
-                )
-
-            return redirect('index')
-
-        messages.error(
-            request,
-            'Invalid username or password.'
-        )
-
-    return render(
-        request,
-        'game/delete_account.html'
-    )
-
+    messages.error(request, 'Invalid username or password.')
+    return render(request, 'game/delete_account.html')
 
 def confirm_delete_account(request, uidb64, token):
-
     try:
-
-        uid = force_str(
-            urlsafe_base64_decode(uidb64)
-        )
-
+        uid = force_str(urlsafe_base64_decode(uidb64))
         user = User.objects.get(pk=uid)
-
     except Exception:
-
         user = None
 
-    if user and default_token_generator.check_token(
-        user,
-        token
-    ):
+    if not user or not default_token_generator.check_token(user, token):
+        messages.error(request, 'Invalid or expired deletion link.')
+        return redirect('landing')
 
+    if request.method == 'POST':
         logout(request)
-
         user.delete()
+        return render(request, 'game/delete_success.html')
 
-        return render(
-            request,
-            'game/delete_success.html'
-        )
-
-    messages.error(
-        request,
-        'Invalid or expired deletion link.'
-    )
-
-    return redirect('landing')
+    return render(request, 'game/confirm_delete.html', {'uidb64': uidb64, 'token': token})
 @csrf_exempt
 @require_POST
 def analyze_game_view(request):


### PR DESCRIPTION
## Related Issue
Closes #1586

## Changes Made
- Add `@require_POST` to `delete_account` view to reject GET requests
- Change `confirm_delete_account` to require POST for actual deletion
- GET on confirm link shows a confirmation form instead of immediately deleting
- Prevents email scanners from auto-deleting accounts by following GET links

## Testing
- GET to `/delete-account/` → 405 Method Not Allowed
- POST to `/delete-account/` → email sent with confirmation link
- GET to confirmation link → shows confirmation page (no deletion)
- POST to confirmation form → account deleted
