### PR TITLE
Fix: prevent user enumeration in password reset flow

### DIFF
--- a/game/templates/game/password_reset_account_selection.html
+++ b/game/templates/game/password_reset_account_selection.html
@@ -1,0 +1,38 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Password Reset | Checkora</title>
+    <link rel="stylesheet" href="{% static 'game/css/landing.css' %}">
+    <style>
+        body {
+            min-height: 100vh;
+            background: radial-gradient(circle at top, #1e293b 0%, #0f172a 45%, #020617 100%);
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            padding: 30px;
+        }
+        .card {
+            background: rgba(15,23,42,0.92);
+            border: 1px solid rgba(255,255,255,0.08);
+            border-radius: 24px;
+            padding: 42px 36px;
+            max-width: 480px;
+            width: 100%;
+            text-align: center;
+        }
+        h1 { color: #fff; font-size: 28px; margin-bottom: 12px; }
+        p { color: #94a3b8; font-size: 15px; line-height: 1.6; }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <h1>Password Reset</h1>
+        <p>If an account exists for <strong>{{ email }}</strong>, you will receive a password reset link shortly.</p>
+        <p style="margin-top: 20px;"><a href="{% url 'password_reset' %}" style="color: #facc15;">Back to password reset</a></p>
+    </div>
+</body>
+</html>

--- a/game/views.py
+++ b/game/views.py
@@ -1138,18 +1138,11 @@ def cleanup_cron(request):
         }, status=500)
 
 def password_reset_account_selection(request):
-
-    email = request.GET.get('email')
-
-    users = User.objects.filter(email=email)
-
+    email = request.GET.get('email', '')
     return render(
         request,
         'game/password_reset_account_selection.html',
-        {
-            'users': users,
-            'email': email
-        }
+        {'email': email}
     )
 
 


### PR DESCRIPTION
## Related Issue
Closes #1587

## Changes Made
- Remove database query from `password_reset_account_selection` view
- Always return uniform response regardless of whether email exists
- Create `password_reset_account_selection.html` template with generic message
- Prevents user enumeration via email existence disclosure

## Testing
- Enter known email → shows "If an account exists, you will receive a reset link"
- Enter unknown email → same response, indistinguishable
