### PR TITLE
feat: add Google OAuth 2.0 sign-in via django-allauth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,12 @@ DATABASE_URL=sqlite:///db.sqlite3
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST_USER=your-email@gmail.com
 EMAIL_HOST_PASSWORD=your_16_digit_google_app_password
+
+# Google OAuth 2.0 (for "Sign in with Google")
+# 1. Go to https://console.cloud.google.com/
+# 2. Create a project, enable the Google+ API or Google Identity service
+# 3. Under "Credentials", create an OAuth 2.0 Client ID (Web application)
+# 4. Add your redirect URI: http://localhost:8000/accounts/google/login/callback/
+# 5. Paste the Client ID and Secret below
+GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=your-google-client-secret

--- a/core/settings.py
+++ b/core/settings.py
@@ -47,6 +47,11 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.sites',
+    'allauth',
+    'allauth.account',
+    'allauth.socialaccount',
+    'allauth.socialaccount.providers.google',
     'game',
 ]
 
@@ -59,6 +64,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'allauth.account.middleware.AccountMiddleware',
 ]
 
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
@@ -82,6 +88,44 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = 'core.wsgi.application'
+
+# Required by django.contrib.sites and django-allauth
+SITE_ID = 1
+
+# Authentication backends - required for allauth
+AUTHENTICATION_BACKENDS = [
+    # Needed to login by username in Django admin
+    'django.contrib.auth.backends.ModelBackend',
+    # allauth specific authentication methods (e.g. login by email)
+    'allauth.account.auth_backends.AuthenticationBackend',
+]
+
+# Google OAuth 2.0 Configuration
+SOCIALACCOUNT_PROVIDERS = {
+    'google': {
+        'APP': {
+            'client_id': os.environ.get('GOOGLE_CLIENT_ID', ''),
+            'secret': os.environ.get('GOOGLE_CLIENT_SECRET', ''),
+            'key': '',
+        },
+        'SCOPE': [
+            'profile',
+            'email',
+        ],
+        'AUTH_PARAMS': {
+            'access_type': 'online',
+        },
+        'OAUTH_PKCE_ENABLED': True,
+    }
+}
+
+# django-allauth settings
+SOCIALACCOUNT_AUTO_SIGNUP = True
+# Trust the email provided by Google (skip extra verification)
+SOCIALACCOUNT_EMAIL_VERIFICATION = 'none'
+ACCOUNT_EMAIL_VERIFICATION = 'none'
+# After Google login, redirect to the landing page
+SOCIALACCOUNT_LOGIN_ON_GET = True
 
 
 # Database

--- a/core/urls.py
+++ b/core/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('robots.txt', TemplateView.as_view(template_name="robots.txt", content_type="text/plain")),
     path('sitemap.xml', TemplateView.as_view(template_name="sitemap.xml", content_type="application/xml")),
+    path('accounts/', include('allauth.urls')),
     path('', include('game.urls')),
 
     path(

--- a/game/static/game/css/auth.css
+++ b/game/static/game/css/auth.css
@@ -489,3 +489,53 @@ body.login-page .helptext {
   transform: translateX(-3px);
   box-shadow: 0 6px 24px rgba(0, 0, 0, 0.4);
 }
+
+/* ── Google OAuth Button ── */
+.btn-google {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    width: 100%;
+    padding: 13px 0;
+    background: #1e1e35;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 6px;
+    color: #e8e8f0;
+    font-size: 1rem;
+    font-weight: 600;
+    text-decoration: none;
+    cursor: pointer;
+    letter-spacing: 0.3px;
+    transition: all 0.2s ease;
+    margin-bottom: 4px;
+}
+.btn-google:hover {
+    background: #252545;
+    border-color: rgba(255, 255, 255, 0.22);
+    color: #ffffff;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+}
+.btn-google:active {
+    transform: translateY(0);
+}
+
+/* ── Auth Divider ── */
+.auth-divider {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 6px 0;
+    color: #4a4a6a;
+    font-size: 0.8rem;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+}
+.auth-divider::before,
+.auth-divider::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: #252545;
+}

--- a/game/templates/game/login.html
+++ b/game/templates/game/login.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load socialaccount %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -30,6 +31,22 @@
     </div>
 
     <div class="auth-card">
+        <!-- Google OAuth Button -->
+        <a href="{% provider_login_url 'google' %}" class="btn-google" id="google-signin-btn">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="20" height="20" aria-hidden="true">
+                <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/>
+                <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/>
+                <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"/>
+                <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"/>
+                <path fill="none" d="M0 0h48v48H0z"/>
+            </svg>
+            Continue with Google
+        </a>
+
+        <div class="auth-divider">
+            <span>or sign in with email</span>
+        </div>
+
         <form method="POST">
             {% csrf_token %}
             

--- a/game/templates/game/register.html
+++ b/game/templates/game/register.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load socialaccount %}
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -34,6 +35,22 @@
     </div>
 
     <div class="auth-card">
+        <!-- Google OAuth Button -->
+        <a href="{% provider_login_url 'google' %}" class="btn-google" id="google-register-btn">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="20" height="20" aria-hidden="true">
+                <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/>
+                <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/>
+                <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"/>
+                <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"/>
+                <path fill="none" d="M0 0h48v48H0z"/>
+            </svg>
+            Continue with Google
+        </a>
+
+        <div class="auth-divider">
+            <span>or register with email</span>
+        </div>
+
         <form method="POST">
             {% csrf_token %}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ whitenoise>=6.6.0
 flake8>=7.0.0
 selenium==4.15.0
 webdriver-manager==4.0.1
+django-allauth>=0.61.1


### PR DESCRIPTION
## Summary

Implements [Issue #1568] — adds "Sign in with Google" via Google OAuth 2.0 using `django-allauth`, reducing signup friction and improving the onboarding experience.

- Add `django-allauth>=0.61.1` to `requirements.txt`
- Configure allauth in `settings.py`: `INSTALLED_APPS`, `MIDDLEWARE`, `AUTHENTICATION_BACKENDS`, `SITE_ID`, and `SOCIALACCOUNT_PROVIDERS` (reads `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` from environment)
- Register allauth URL routes under `/accounts/` in `core/urls.py`
- Add "Continue with Google" button and divider to `login.html`
- Add "Continue with Google" button and divider to `register.html`
- Add `.btn-google` and `.auth-divider` CSS to `auth.css` (dark theme)
- Add `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` to `.env.example`

Closes #1568

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #1568

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed (`.env.example` updated)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

The "Continue with Google" button appears at the top of both the Login and Register cards, styled to match Checkora's dark theme, with a divider separating it from the existing email/password form.

## Additional Notes for Reviewers

To activate Google Sign-In after merging:

1. Go to https://console.cloud.google.com/ → Create OAuth 2.0 credentials (Web application type)
2. Add the authorized redirect URI:
   - Local: `http://localhost:8000/accounts/google/login/callback/`
   - Production: `https://<your-vercel-domain>/accounts/google/login/callback/`
3. Set the following in your environment (Vercel dashboard or `.env`):
   - `GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com`
   - `GOOGLE_CLIENT_SECRET=your-client-secret`
4. In Django Admin → Sites, update Site #1's domain to match your production domain.

No breaking changes — the existing email/password login and registration flows are fully preserved.