### PR TITLE
feat: add arrow key navigation in replay mode

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -2407,6 +2407,32 @@
                     goToReplayMove(replayIndex);
                 };
             }
+
+            // Arrow key navigation in replay mode
+            document.addEventListener('keydown', (e) => {
+                if (!replayMode) return;
+                const tag = e.target.tagName;
+                if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+                switch (e.key) {
+                    case 'ArrowLeft':
+                        e.preventDefault();
+                        if (prevReplayBtn) prevReplayBtn.click();
+                        break;
+                    case 'ArrowRight':
+                        e.preventDefault();
+                        if (nextReplayBtn) nextReplayBtn.click();
+                        break;
+                    case 'ArrowUp':
+                        e.preventDefault();
+                        if (firstReplayBtn) firstReplayBtn.click();
+                        break;
+                    case 'ArrowDown':
+                        e.preventDefault();
+                        if (lastReplayBtn) lastReplayBtn.click();
+                        break;
+                }
+            });
+
             if (replayGameBtn) {
 
                 replayGameBtn.onclick = () => {


### PR DESCRIPTION
## Summary

Adds keyboard navigation support when reviewing game replays. When replay mode is active and the user is not focused on an input field, arrow keys control replay navigation.

## Changes

- **board.js**: Added global \keydown\ event listener that handles ArrowLeft, ArrowRight, ArrowUp, and ArrowDown to control replay navigation

## Key Bindings

| Key | Action |
|---|---|
| ArrowLeft | Previous move |
| ArrowRight | Next move |
| ArrowUp | First move |
| ArrowDown | Last move |

Closes #1634