### PR TITLE
fix: enforce server move position validation

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -75,6 +75,7 @@
 
             let expectedMoveEval = null;
             let evaluationCache = {};
+            let currentFen = null;
             let currentDifficulty = 'medium';
             let currentWhiteName = 'White';
             let currentBlackName = 'Black';
@@ -985,6 +986,7 @@
 
                 board = parseBoard(data.board);
                 turn = data.current_turn;
+                currentFen = data.fen || null;
                 whiteTime = data.white_time;
                 blackTime = data.black_time;
                 paused = data.paused;
@@ -1507,6 +1509,7 @@
                         from_row: fr, from_col: fc,
                         to_row: tr, to_col: tc,
                     };
+                    if (currentFen) body.fen = currentFen;
                     if (promotionPiece) body.promotion_piece = promotionPiece;
 
                     const data = await post('/api/move/', body);
@@ -1516,6 +1519,7 @@
                             if (!skipAnimation) await animateMove(fr, fc, tr, tc);
                             board = parseBoard(data.board);
                             turn = data.current_turn;
+                            currentFen = data.fen || null;
 
                             // Daily Puzzle Validation
                             if (dailyPuzzleMode && currentPuzzle && !puzzleAnalyzing) {

--- a/game/tests.py
+++ b/game/tests.py
@@ -472,6 +472,52 @@ class MoveValidationTest(TestCase):
         self.assertEqual(data['captured'], 'p')
 
 
+class ServerSideMoveValidationTest(TestCase):
+    """Test server-side move validation resists stale or tampered clients."""
+
+    def setUp(self):
+        self.client.get('/play/')
+
+    def _session_game_data(self):
+        return self.client.session['game']
+
+    def test_rejects_stale_client_fen_before_mutating_session(self):
+        before = self._session_game_data()
+        response = self.client.post(
+            '/api/move/',
+            data=json.dumps({
+                'from_row': 6, 'from_col': 4,
+                'to_row': 4, 'to_col': 4,
+                'fen': '8/8/8/8/8/8/8/8 w -',
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertFalse(response.json()['valid'])
+        self.assertEqual(self._session_game_data(), before)
+
+    @mock.patch.object(ChessGame, '_call_engine')
+    def test_rejects_illegal_move_without_changing_session(self, mock_engine):
+        mock_engine.return_value = "MOVES"
+        before = self._session_game_data()
+        game = ChessGame.from_dict(before)
+
+        response = self.client.post(
+            '/api/move/',
+            data=json.dumps({
+                'from_row': 6, 'from_col': 4,
+                'to_row': 3, 'to_col': 4,
+                'fen': game.generate_fen_key(),
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.json()['valid'])
+        self.assertEqual(self._session_game_data(), before)
+
+
 class MoveCoordinatesValidationTest(TestCase):
     """Test coordinate validation for chess move API endpoint."""
 

--- a/game/views.py
+++ b/game/views.py
@@ -86,6 +86,16 @@ def record_game_result(request, mode, winner, reason, player_color='white', move
     )
 
 
+def _client_position_matches_session(data, game):
+    """Return whether an optional client FEN still matches server state."""
+    client_fen = data.get('fen')
+    if client_fen is None:
+        return True
+    if not isinstance(client_fen, str) or not client_fen.strip():
+        return False
+    return client_fen.strip() == game.generate_fen_key()
+
+
 @require_POST
 def make_move(request):
     """Validate and execute a chess move via the C++ engine."""
@@ -122,6 +132,15 @@ def make_move(request):
 
     game_data = request.session.get('game')
     game = ChessGame.from_dict(game_data) if game_data else ChessGame()
+
+    if not _client_position_matches_session(data, game):
+        return JsonResponse({
+            'valid': False,
+            'message': 'Board state is stale. Reload the game before moving.',
+            'board': game.board,
+            'current_turn': game.current_turn,
+            'fen': game.generate_fen_key(),
+        }, status=409)
 
     success, message, captured, game_status = game.make_move(
         from_row, from_col, to_row, to_col, promotion_piece,


### PR DESCRIPTION
## Summary
- include the server-issued FEN with move submissions so the backend can detect stale or tampered board state
- reject mismatched client positions before mutating the session game
- keep existing server-side legal-move validation in place and add regression tests for stale FEN and illegal move attempts

Closes #1626

## Validation
- uv run --python 3.12 --with-requirements requirements.txt python manage.py test game.tests.ServerSideMoveValidationTest game.tests.MoveValidationTest --verbosity=2
- npm test -- --runInBand
- node --check game/static/game/js/board.js
- npx eslint game/static/game/js/board.js --no-config-lookup --rule "no-unused-vars: off" --rule "no-undef: off"
- git diff --check origin/main..HEAD

Note: I requested assignment on the issue with /assign before opening this PR. The contribution guide requires PRs from a fork branch and passing checks; it does not state a hard assignment gate.