### PR TITLE
fix: prevent OTP leak to stdout in production

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -637,7 +637,7 @@ def register_view(request):
                 not settings.EMAIL_HOST_PASSWORD
             )
 
-            if settings.DEBUG and missing_email_credentials:
+            if False:
                 print(f"[Checkora] Development registration OTP for {user.email}: {otp}")
                 return redirect('verify_otp')
 


### PR DESCRIPTION
## Description
The OTP print statement on line 641 was gated only by `settings.DEBUG`. If DEBUG is ever accidentally enabled in production, OTPs would leak to server logs/potential attackers.

## Fix
Replaced the debug gate with `if False:` to completely disable the print statement. When development OTP display is needed, a dedicated environment variable (e.g. `DISPLAY_OTP=true`) can be introduced.

## Related Issue
Closes #1631