### PR TITLE
fix: enforce server-side validation for puzzle stats

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -1135,16 +1135,20 @@ def leaderboard_view(request):
 @login_required
 @require_POST
 def update_puzzle_stats(request):
-    data = json.loads(request.body)
+    try:
+        data = json.loads(request.body)
+    except json.JSONDecodeError:
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
 
     stats, _ = PuzzleStats.objects.get_or_create(
         user=request.user
     )
 
-    stats.puzzles_solved = data.get("puzzles_solved", 0)
-    stats.current_streak = data.get("current_streak", 0)
-    stats.best_streak = data.get("best_streak", 0)
-    stats.daily_completions = data.get("daily_completions", 0)
+    stats.puzzles_solved += 1
+    stats.current_streak += 1
+    if stats.current_streak > stats.best_streak:
+        stats.best_streak = stats.current_streak
+    stats.daily_completions += 1
 
     stats.save()
 


### PR DESCRIPTION
## Description
The `update_puzzle_stats` endpoint accepted arbitrary client-supplied integers for all puzzle stats fields with zero server-side verification. Attackers could set any value.

## Fix
- Replaced direct assignment with server-side increment-only logic
- Added try/except around json.loads() to prevent 500 errors
- Best streak is now tracked server-side (auto-updates from current streak)

## Related Issue
Closes #1632