### PR TITLE
refactor: dynamicize chess opening book detection

### DIFF
--- a/game/analysis.py
+++ b/game/analysis.py
@@ -1,52 +1,31 @@
+import json
+import os
+
+_openings_cache = None
+
+def _load_openings() -> list[dict]:
+    global _openings_cache
+    if _openings_cache is None:
+        path = os.path.join(os.path.dirname(__file__), 'opening_book_index.json')
+        with open(path) as f:
+            data = json.load(f)
+        _openings_cache = sorted(data, key=lambda x: len(x["moves"]), reverse=True)
+    return _openings_cache
+
 def detect_opening(moves: list[str]) -> str | None:
     """
     Detect the opening played based on the move sequence.
     Replicates and enhances the existing frontend logic.
     Returns None if no specific opening is matched.
     """
-    if not moves or len(moves) == 0:
+    if not moves:
         return None
 
-    m1 = moves[0] if len(moves) > 0 else None
-    m2 = moves[1] if len(moves) > 1 else None
-    m3 = moves[2] if len(moves) > 2 else None
-    m4 = moves[3] if len(moves) > 3 else None
-    m5 = moves[4] if len(moves) > 4 else None
-
-    # Sanitize inputs to remove checks, mates, etc., if needed,
-    # though usually opening moves don't involve checks/captures initially,
-    # it's safe to use exact matches for standard openings.
-    
-    if m1 == 'e4':
-        if m2 == 'c5': return 'Sicilian Defense'
-        if m2 == 'e5':
-            if m3 == 'Nf3':
-                if m4 == 'Nc6':
-                    if m5 == 'Bb5': return 'Ruy Lopez'
-                    if m5 == 'Bc4': return 'Italian Game'
-                    if m5 == 'd4': return 'Scotch Game'
-                if m4 == 'Nf6': return 'Petrov Defense'
-            return "King's Pawn Game"
-        if m2 == 'e6': return 'French Defense'
-        if m2 == 'c6': return 'Caro-Kann Defense'
-        if m2 == 'd6': return 'Pirc Defense'
-        return "King's Pawn Game"
-        
-    if m1 == 'd4':
-        if m2 == 'd5':
-            if m3 == 'c4': return "Queen's Gambit"
-            return "Queen's Pawn Game"
-        if m2 == 'Nf6':
-            if m3 == 'c4':
-                if m4 == 'e6': return 'Nimzo-Indian Defense'
-                if m4 == 'g6': return "King's Indian Defense"
-            return 'Indian Defense'
-        return "Queen's Pawn Game"
-        
-    if m1 == 'Nf3': return 'Réti Opening'
-    if m1 == 'c4': return 'English Opening'
-    if m1 == 'f4': return "Bird's Opening"
-    
+    openings = _load_openings()
+    for opening in openings:
+        op_moves = opening["moves"]
+        if len(moves) >= len(op_moves) and moves[:len(op_moves)] == op_moves:
+            return opening["name"]
     return None
 
 def count_captures(moves: list[str]) -> int:

--- a/game/opening_book_index.json
+++ b/game/opening_book_index.json
@@ -1,0 +1,21 @@
+[
+  {"name": "Italian Game", "moves": ["e4", "e5", "Nf3", "Nc6", "Bc4"], "eco": "C50"},
+  {"name": "Ruy Lopez", "moves": ["e4", "e5", "Nf3", "Nc6", "Bb5"], "eco": "C60"},
+  {"name": "Scotch Game", "moves": ["e4", "e5", "Nf3", "Nc6", "d4"], "eco": "C45"},
+  {"name": "Petrov Defense", "moves": ["e4", "e5", "Nf3", "Nf6"], "eco": "C42"},
+  {"name": "Sicilian Defense", "moves": ["e4", "c5"], "eco": "B20"},
+  {"name": "French Defense", "moves": ["e4", "e6"], "eco": "C00"},
+  {"name": "Caro-Kann Defense", "moves": ["e4", "c6"], "eco": "B10"},
+  {"name": "Pirc Defense", "moves": ["e4", "d6"], "eco": "B07"},
+  {"name": "King's Pawn Game", "moves": ["e4", "e5"], "eco": "C20"},
+  {"name": "King's Pawn Game", "moves": ["e4"], "eco": "C20"},
+  {"name": "Queen's Gambit", "moves": ["d4", "d5", "c4"], "eco": "D06"},
+  {"name": "Nimzo-Indian Defense", "moves": ["d4", "Nf6", "c4", "e6"], "eco": "E20"},
+  {"name": "King's Indian Defense", "moves": ["d4", "Nf6", "c4", "g6"], "eco": "E60"},
+  {"name": "Indian Defense", "moves": ["d4", "Nf6"], "eco": "A50"},
+  {"name": "Queen's Pawn Game", "moves": ["d4", "d5"], "eco": "D00"},
+  {"name": "Queen's Pawn Game", "moves": ["d4"], "eco": "D00"},
+  {"name": "Réti Opening", "moves": ["Nf3"], "eco": "A04"},
+  {"name": "English Opening", "moves": ["c4"], "eco": "A10"},
+  {"name": "Bird's Opening", "moves": ["f4"], "eco": "A02"}
+]


### PR DESCRIPTION
## Description\nReplaced the 50-line hardcoded if-else chain in analysis.py with a JSON-based opening definitions file and prefix-matching logic.\n\n## Changes\n- Created game/opening_book_index.json with 19 opening definitions\n- Refactored detect_opening() to use lazy-loaded JSON + prefix matching\n- Same function signature and return values - no breaking changes\n- All existing test scenarios pass\n\n## Related Issue\nCloses #1636