### PR TITLE
Add interactive lesson practice system

### DIFF
--- a/game/static/game/js/lesson_practice.js
+++ b/game/static/game/js/lesson_practice.js
@@ -1,6 +1,7 @@
 let lessonSteps = [];
 let currentStep = 0;
 let initialPosition = {};
+let currentLegalMoves = [];
 
 function getKnightMoves(square) {
 
@@ -362,6 +363,10 @@ document.addEventListener(
 
                     const piece =
                         square.innerText;
+                    
+                    if (!piece) {
+                        return;
+                    }
 
                     let moves = [];
 
@@ -413,6 +418,8 @@ document.addEventListener(
                             );
                     }
 
+                    currentLegalMoves = moves;
+
                     moves.forEach(
                         move => {
 
@@ -441,6 +448,14 @@ document.addEventListener(
 
                 const move =
                     from + "-" + to;
+                if (
+                    !currentLegalMoves.includes(
+                        to
+                    )
+                ) {
+
+                    return;
+                }
                 
                 const sourceSquare =
                     selectedSquare;
@@ -500,7 +515,7 @@ function checkMove(move) {
     ) {
         return false;
     }
-    
+
     const expectedMove =
         lessonSteps[
             currentStep

--- a/game/static/game/js/lesson_practice.js
+++ b/game/static/game/js/lesson_practice.js
@@ -1,114 +1,559 @@
-document.addEventListener("DOMContentLoaded", () => {
+let lessonSteps = [];
+let currentStep = 0;
+let initialPosition = {};
 
-    const lessonDataElement =
-        document.getElementById("lesson-steps");
+function getKnightMoves(square) {
 
-    if (!lessonDataElement) {
-        return;
-    }
+    const file =
+        square.charCodeAt(0);
 
-    const lessonSteps =
-        JSON.parse(lessonDataElement.textContent);
+    const rank =
+        parseInt(square[1]);
 
-    let currentStep = 0;
+    const offsets = [
+        [-2,-1],
+        [-2,1],
+        [-1,-2],
+        [-1,2],
+        [1,-2],
+        [1,2],
+        [2,-1],
+        [2,1]
+    ];
 
-    function loadStep() {
+    const moves = [];
 
-        if (
-            currentStep >= lessonSteps.length
-        ) {
-            return;
+    offsets.forEach(
+        ([df,dr]) => {
+
+            const newFile =
+                file + df;
+
+            const newRank =
+                rank + dr;
+
+            if (
+                newFile >= 97 &&
+                newFile <= 104 &&
+                newRank >= 1 &&
+                newRank <= 8
+            ) {
+
+                moves.push(
+                    String.fromCharCode(
+                        newFile
+                    ) + newRank
+                );
+            }
         }
+    );
 
-        const step =
-            lessonSteps[currentStep];
+    return moves;
+}
 
-        const instruction =
-            document.getElementById(
-                "lesson-instruction"
-            );
+function getPawnMoves(square) {
 
-        if (instruction) {
+    const file =
+        square[0];
 
-            instruction.innerHTML =
-                step.instruction;
-        }
+    const rank =
+        parseInt(square[1]);
 
-        console.log(
-            "Current Lesson Step:",
-            step
+    const moves = [];
+
+    if (rank < 8) {
+
+        moves.push(
+            file + (rank + 1)
         );
     }
 
-    function completeLesson() {
+    return moves;
+}
 
-        const result =
+function getKingMoves(square) {
+
+    const file =
+        square.charCodeAt(0);
+
+    const rank =
+        parseInt(square[1]);
+
+    const moves = [];
+
+    for (
+        let df = -1;
+        df <= 1;
+        df++
+    ) {
+
+        for (
+            let dr = -1;
+            dr <= 1;
+            dr++
+        ) {
+
+            if (
+                df === 0 &&
+                dr === 0
+            ) {
+                continue;
+            }
+
+            const newFile =
+                file + df;
+
+            const newRank =
+                rank + dr;
+
+            if (
+                newFile >= 97 &&
+                newFile <= 104 &&
+                newRank >= 1 &&
+                newRank <= 8
+            ) {
+
+                moves.push(
+                    String.fromCharCode(
+                        newFile
+                    ) + newRank
+                );
+            }
+        }
+    }
+
+    return moves;
+}
+
+function getRookMoves(square) {
+
+    const file =
+        square[0];
+
+    const rank =
+        parseInt(square[1]);
+
+    const moves = [];
+
+    for (
+        let r = 1;
+        r <= 8;
+        r++
+    ) {
+
+        if (r !== rank) {
+
+            moves.push(
+                file + r
+            );
+        }
+    }
+
+    const files =
+        ["a","b","c","d","e","f","g","h"];
+
+    files.forEach(
+        f => {
+
+            if (f !== file) {
+
+                moves.push(
+                    f + rank
+                );
+            }
+        }
+    );
+
+    return moves;
+}
+
+function getBishopMoves(square) {
+
+    const moves = [];
+
+    const file =
+        square.charCodeAt(0);
+
+    const rank =
+        parseInt(square[1]);
+
+    [
+        [1,1],
+        [1,-1],
+        [-1,1],
+        [-1,-1]
+    ].forEach(
+        ([df,dr]) => {
+
+            let f =
+                file + df;
+
+            let r =
+                rank + dr;
+
+            while (
+                f >= 97 &&
+                f <= 104 &&
+                r >= 1 &&
+                r <= 8
+            ) {
+
+                moves.push(
+                    String.fromCharCode(
+                        f
+                    ) + r
+                );
+
+                f += df;
+                r += dr;
+            }
+        }
+    );
+
+    return moves;
+}
+
+function getQueenMoves(square) {
+
+    return [
+        ...getRookMoves(
+            square
+        ),
+        ...getBishopMoves(
+            square
+        )
+    ];
+}
+
+document.addEventListener(
+    "DOMContentLoaded",
+    () => {
+
+        const positionData =
             document.getElementById(
-                "lesson-result"
+                "practice-position-data"
             );
 
-        if (result) {
+        if (!positionData) {
+            return;
+        }
 
-            result.innerHTML =
-                "🏆 Lesson Completed!";
+        const position =
+            JSON.parse(
+                positionData.textContent
+            );
+        
+        initialPosition =
+            JSON.parse(
+                JSON.stringify(position)
+            )
+        
+        const lessonStepsData =
+            document.getElementById(
+                "lesson-steps-data"
+            );
+
+        lessonSteps =
+            JSON.parse(
+                lessonStepsData.textContent
+            );
+
+        currentStep = 0;
+
+        document.getElementById(
+            "lesson-instruction"
+        ).textContent =
+            lessonSteps[0].instruction;
+
+        const board =
+            document.getElementById(
+                "practice-board"
+            );
+
+        const files =
+            ["a", "b", "c", "d", "e", "f", "g", "h"];
+
+        const pieces = {
+            P: "♙",
+            N: "♘",
+            B: "♗",
+            R: "♖",
+            Q: "♕",
+            K: "♔"
+        };
+
+        board.innerHTML = "";
+
+        for (
+            let row = 8;
+            row >= 1;
+            row--
+        ) {
+
+            for (
+                let col = 0;
+                col < 8;
+                col++
+            ) {
+
+                const square =
+                    document.createElement(
+                        "div"
+                    );
+
+                square.classList.add(
+                    "lesson-square"
+                );
+
+                square.classList.add(
+                    (
+                        row + col
+                    ) % 2 === 0
+                        ? "light"
+                        : "dark"
+                );
+
+                const squareName =
+                    files[col] + row;
+
+                square.dataset.square =
+                    squareName;
+
+                if (
+                    position[squareName]
+                ) {
+
+                    square.innerHTML =
+                        pieces[
+                        position[
+                        squareName
+                        ]
+                        ];
+                }
+
+                board.appendChild(
+                    square
+                );
+            }
+        }
+
+        let selectedSquare = null;
+
+        board.addEventListener(
+            "click",
+            (event) => {
+
+                const square =
+                    event.target.closest(
+                        ".lesson-square"
+                    );
+
+                if (!square) {
+                    return;
+                }
+
+                if (!selectedSquare) {
+
+                    selectedSquare = square;
+
+                    square.classList.add(
+                        "selected-square"
+                    );
+
+                    const piece =
+                        square.innerText;
+
+                    let moves = [];
+
+                    if (piece === "♘") {
+
+                        moves =
+                            getKnightMoves(
+                                square.dataset.square
+                            );
+                    }
+
+                    if (piece === "♙") {
+
+                        moves =
+                            getPawnMoves(
+                                square.dataset.square
+                            );
+                    }
+
+                    if (piece === "♔") {
+
+                        moves =
+                            getKingMoves(
+                                square.dataset.square
+                            );
+                    }
+
+                    if (piece === "♖") {
+
+                        moves =
+                            getRookMoves(
+                                square.dataset.square
+                            );
+                    }
+
+                    if (piece === "♗") {
+
+                        moves =
+                            getBishopMoves(
+                                square.dataset.square
+                            );
+                    }
+
+                    if (piece === "♕") {
+
+                        moves =
+                            getQueenMoves(
+                                square.dataset.square
+                            );
+                    }
+
+                    moves.forEach(
+                        move => {
+
+                            const target =
+                                board.querySelector(
+                                    `[data-square="${move}"]`
+                                );
+
+                            if (target) {
+
+                                target.classList.add(
+                                    "valid-move"
+                                );
+                            }
+                        }
+                    );
+
+                    return;
+                }
+
+                const from =
+                    selectedSquare.dataset.square;
+
+                const to =
+                    square.dataset.square;
+
+                const move =
+                    from + "-" + to;
+                
+                const sourceSquare =
+                    selectedSquare;
+                
+                selectedSquare.classList.remove(
+                    "selected-square"
+                );
+
+                document
+                    .querySelectorAll(
+                        ".valid-move"
+                    )
+                    .forEach(
+                        square => {
+                            square.classList.remove(
+                                "valid-move"
+                            );
+                        }
+                    );
+                document.
+                    getElementById(
+                        "retry-btn"
+                    )
+                    .addEventListener(
+                        "click",
+                        () => {
+                            location.reload();
+                        }
+                    );
+                
+                selectedSquare = null;
+
+                const isCorrect = checkMove(move);
+                if (isCorrect) {
+
+                const piece =
+                    sourceSquare.innerHTML;
+
+                square.innerHTML =
+                    piece;
+
+                sourceSquare.innerHTML =
+                    "";
+                }
+            }
+        );
+    }
+);
+
+function checkMove(move) {
+
+    const expectedMove =
+        lessonSteps[
+            currentStep
+        ].expected_move;
+
+    const result =
+        document.getElementById(
+            "lesson-result"
+        );
+
+    if (
+        move === expectedMove
+    ) {
+
+        result.textContent =
+            "✅ Correct Move!";
+
+        result.style.color =
+            "#4caf50";
+
+        currentStep++;
+
+        if (
+            currentStep <
+            lessonSteps.length
+        ) {
+
+            document.getElementById(
+                "lesson-instruction"
+            ).textContent =
+                lessonSteps[
+                    currentStep
+                ].instruction;
+
+        } else {
+
+            document.getElementById(
+                "lesson-instruction"
+            ).textContent =
+                "🎉 Lesson Complete!";
+
+            result.textContent =
+                "🏆 Great Job!";
 
             result.style.color =
                 "#4caf50";
         }
+
+        return true;
+
+    } else {
+
+        result.textContent =
+            "❌ Try Again";
+
+        result.style.color =
+            "#ff5252";
+        document.getElementById(
+            "retry-btn"
+        ).style.display =
+            "inline-block";
+
+        return false;
     }
-
-    function nextStep() {
-
-        currentStep++;
-
-        if (currentStep < lessonSteps.length) {
-
-            loadStep();
-
-        } else {
-
-            completeLesson();
-        }
-    }
-
-    window.checkLessonMove = function (moveNotation) {
-
-        if (currentStep >= lessonSteps.length) {
-            return;
-        }
-
-        const step = lessonSteps[currentStep];
-        const result =
-            document.getElementById(
-                "lesson-result"
-            );
-        
-        if (moveNotation === step.expected_move) {
-            if (result) {
-
-                result.innerHTML =
-                    "✅ Correct Move!";
-
-                result.style.color =
-                    "#4caf50";
-            }
-
-            setTimeout(() => {
-
-                nextStep();
-
-            }, 1000);
-
-        } else {
-            if (result) {
-                result.innerHTML =
-                    "❌ Try again";
-
-                result.style.color =
-                    "#f44336";
-            }
-        }
-    };
-    
-    loadStep();
-});
+}

--- a/game/static/game/js/lesson_practice.js
+++ b/game/static/game/js/lesson_practice.js
@@ -460,16 +460,18 @@ document.addEventListener(
                             );
                         }
                     );
-                document.
-                    getElementById(
+                const retryBtn =
+                    document.getElementById(
                         "retry-btn"
-                    )
-                    .addEventListener(
+                    );
+                if (retryBtn) {
+                    retryBtn.addEventListener(
                         "click",
                         () => {
                             location.reload();
                         }
                     );
+                }
                 
                 selectedSquare = null;
 
@@ -492,6 +494,13 @@ document.addEventListener(
 
 function checkMove(move) {
 
+    if (
+        currentStep >=
+        lessonSteps.length
+    ) {
+        return false;
+    }
+    
     const expectedMove =
         lessonSteps[
             currentStep

--- a/game/templates/game/landing.html
+++ b/game/templates/game/landing.html
@@ -174,7 +174,7 @@
 
         <div class="hero-actions">
           <a href="{% url 'index' %}" class="btn-primary-gold">Start Game</a>
-          <a href="{% url 'lessons' %}" class="btn-primary-gold">📚 Lessons</a>
+          <a href="{% url 'lessons' %}" class="btn-primary-gold" aria-label="Chess Lessons">📚 Lessons</a>
           <a href="#about" class="btn-secondary-ghost">Learn More</a>
         </div>
       </div>

--- a/game/templates/game/landing.html
+++ b/game/templates/game/landing.html
@@ -174,6 +174,7 @@
 
         <div class="hero-actions">
           <a href="{% url 'index' %}" class="btn-primary-gold">Start Game</a>
+          <a href="{% url 'lessons' %}" class="btn-primary-gold">📚 Lessons</a>
           <a href="#about" class="btn-secondary-ghost">Learn More</a>
         </div>
       </div>

--- a/game/templates/game/lesson_detail.html
+++ b/game/templates/game/lesson_detail.html
@@ -216,6 +216,30 @@
             background:#81c784 !important;
         }
 
+        #lesson-instruction{
+            text-align:center;
+            font-size:18px;
+            margin-bottom:15px;
+            color:#f0c040;
+        }
+
+        #lesson-result{
+            text-align:center;
+            font-size:18px;
+            font-weight:bold;
+            margin-top:15px;
+        }
+
+        .valid-move{
+            background:#81c784 !important;
+        }
+
+        .selected-square{
+            outline:4px solid yellow;
+        }
+
+
+
     </style>
 </head>
 <body>
@@ -268,6 +292,34 @@
 
     {% endif %}
 
+    {% if lesson.lesson_steps %}
+
+    <div class="lesson-practice">
+
+        <h2>🎯 Practice Position</h2>
+
+        <p id="lesson-instruction"></p>
+
+        <div class="lesson-board-wrapper">
+            <div id="practice-board" class="lesson-board"></div>
+        </div>
+
+        <p id="lesson-result"></p>
+
+        <button
+            id="retry-btn"
+            class="complete-btn"
+            style="display:none; margin-top:10px;"
+        >
+            🔄 Retry
+        </button>
+
+    </div>
+
+    {{ lesson.lesson_steps|json_script:"lesson-steps-data" }}
+    {{ lesson.practice_position|json_script:"practice-position-data" }}
+
+    {% endif %}
 
     {% if lesson.practice_question %}
     <div class="coming-soon">
@@ -394,5 +446,6 @@ function checkAnswer(selected, correct) {
 
 </script>
 <script src="{% static 'game/js/lesson_demo.js' %}"></script>
+<script src="{% static 'game/js/lesson_practice.js' %}"></script>
 </body>
 </html>

--- a/game/templates/game/lesson_detail.html
+++ b/game/templates/game/lesson_detail.html
@@ -307,6 +307,7 @@
         <p id="lesson-result"></p>
 
         <button
+            type="button"
             id="retry-btn"
             class="complete-btn"
             style="display:none; margin-top:10px;"
@@ -394,11 +395,6 @@
     </div>
 
     {% endif %}
-
-    <div class="coming-soon">
-        🚀 Future update: Interactive board demonstrations,
-        practice positions, quizzes, and lesson progress tracking.
-    </div>
     <div class="lesson-navigation">
 
         {% if previous_lesson %}

--- a/game/views.py
+++ b/game/views.py
@@ -1521,10 +1521,6 @@ def lesson_detail_view(request, lesson_name):
             ],
             "lesson_steps": [
                 {
-                    "instruction": "Move the queen from h5 to e8 and give check.",
-                    "expected_move": "h5-e8"
-                },
-                {
                     "instruction": "Move the queen from h5 to f7 and deliver checkmate.",
                     "expected_move": "h5-f7"
                 }
@@ -1534,7 +1530,6 @@ def lesson_detail_view(request, lesson_name):
                 "h5": "Q",
                 "e8": "K",
                 "c4": "B",
-                "e8": "K",
                 "f7": "P"
             },
         },
@@ -1576,11 +1571,6 @@ def lesson_detail_view(request, lesson_name):
                 {
                     "instruction": "Castle kingside by moving the king from e1 to g1.",
                     "expected_move": "e1-g1"
-                },
-                {
-
-                    "instruction": "Castle queenside by moving the king from e1 to c1.",
-                    "expected_move": "e1-c1"
                 }
             ],
 

--- a/game/views.py
+++ b/game/views.py
@@ -482,7 +482,7 @@ def ai_move(request):
             record_game_result(request, game.mode, winner, 'checkmate', game.player_color, moves=game.move_history)
         elif game_status in ('stalemate', 'draw'):
             record_game_result(request, game.mode, 'draw', game.draw_reason or 'stalemate', game.player_color, moves=game.move_history)
-    
+
     return JsonResponse({
         'valid': success,
         'message': message,
@@ -1447,8 +1447,38 @@ def lesson_detail_view(request, lesson_name):
                         "h8"
                     ]
                 }
-            ]
+            ],
+            "lesson_steps": [
+                {
+                    "instruction": "Move the knight from g1 to f3.",
+                    "expected_move": "g1-f3"
+                },
+                {
+                    "instruction": "Move the bishop from f1 to c4.",
+                    "expected_move": "f1-c4"
+                },
+                {
+                    "instruction": "Move the rook from a1 to a4.",
+                    "expected_move": "a1-a4"
+                },
+                {
+                    "instruction": "Move the queen from d1 to h5.",
+                    "expected_move": "d1-h5"
+                },
+                {
+                    "instruction": "Move the king from e1 to e2.",
+                    "expected_move": "e1-e2"
+                }
+            ],
+            "practice_position": {
+                "g1": "N",
+                "f1": "B",
+                "a1": "R",
+                "d1": "Q",
+                "e1": "K"
+            },
         },
+
 
         "Check and Checkmate": {
             "title": "Check and Checkmate",
@@ -1488,7 +1518,25 @@ def lesson_detail_view(request, lesson_name):
                     },
                     "highlight": ["g7"]
                 }
-            ]
+            ],
+            "lesson_steps": [
+                {
+                    "instruction": "Move the queen from h5 to e8 and give check.",
+                    "expected_move": "h5-e8"
+                },
+                {
+                    "instruction": "Move the queen from h5 to f7 and deliver checkmate.",
+                    "expected_move": "h5-f7"
+                }
+            ],
+
+            "practice_position": {
+                "h5": "Q",
+                "e8": "K",
+                "c4": "B",
+                "e8": "K",
+                "f7": "P"
+            },
         },
 
         "Castling": {
@@ -1523,7 +1571,24 @@ def lesson_detail_view(request, lesson_name):
                         "g1"
                     ]
                 }
-            ]
+            ],
+            "lesson_steps": [
+                {
+                    "instruction": "Castle kingside by moving the king from e1 to g1.",
+                    "expected_move": "e1-g1"
+                },
+                {
+
+                    "instruction": "Castle queenside by moving the king from e1 to c1.",
+                    "expected_move": "e1-c1"
+                }
+            ],
+
+            "practice_position": {
+                "e1": "K",
+                "h1": "R",
+                "a1": "R"
+            }
         },
 
         "Opening Principles": {
@@ -1569,7 +1634,30 @@ def lesson_detail_view(request, lesson_name):
                         "f3"
                     ]
                 }
-            ]
+            ],
+            "lesson_steps": [
+                {
+                    "instruction": "Control the center by playing e4.",
+                    "expected_move": "e2-e4"
+                },
+                {
+                    "instruction": "Develop the knight from g1 to f3.",
+                    "expected_move": "g1-f3"
+                },
+                {
+                    "instruction": "Develop the bishop from f1 to c4.",
+                    "expected_move": "f1-c4"
+                }
+            ],
+
+            "practice_position": {
+                "e1": "K",
+                "d1": "Q",
+                "f1": "B",
+                "g1": "N",
+                "e2": "P",
+                "d2": "P"
+            },
         },
 
         "Forks": {
@@ -1610,7 +1698,18 @@ def lesson_detail_view(request, lesson_name):
                         "g8"
                     ]
                 }
-            ]
+            ],
+            "lesson_steps": [
+                {
+                    "instruction": "Move the knight from e5 to c6 and fork the king and queen.",
+                    "expected_move": "e5-c6"
+                }
+            ],
+            "practice_position": {
+                "e5": "N",
+                "d8": "Q",
+                "e8": "K"
+            }
         },
 
         "Pins": {
@@ -1646,7 +1745,18 @@ def lesson_detail_view(request, lesson_name):
                         "e8"
                     ]
                 }
-            ]
+            ],
+            "lesson_steps": [
+                {
+                    "instruction": "Move the bishop from b5 to pin the knight to the king.",
+                    "expected_move": "f1-b5"
+                }
+            ],
+            "practice_position": {
+                "f1": "B",
+                "c6": "N",
+                "e8": "K"
+            }
         },
 
         "Skewers": {
@@ -1682,7 +1792,18 @@ def lesson_detail_view(request, lesson_name):
                         "e7"
                     ]
                 }
-            ]
+            ],
+            "lesson_steps": [
+                {
+                    "instruction": "Move the queen from a4 to create a skewer.",
+                    "expected_move": "a4-e8"
+                }
+            ],
+            "practice_position": {
+                "a4": "Q",
+                "e8": "K",
+                "d7": "R"
+            }
         },
 
         "Discovered Attacks": {
@@ -1718,7 +1839,18 @@ def lesson_detail_view(request, lesson_name):
                         "a8"
                     ]
                 }
-            ]
+            ],
+            "lesson_steps": [
+                {
+                    "instruction": "Move the knight from e2 to c3 to reveal the rook attack.",
+                    "expected_move": "e2-c3"
+                }
+            ],
+            "practice_position": {
+                "a1": "R",
+                "e2": "N",
+                "a8": "Q"
+            }
         },
 
         "Pawn Structures": {
@@ -1764,7 +1896,18 @@ def lesson_detail_view(request, lesson_name):
                         "d4"
                     ]
                 }
-            ]
+            ],
+            "lesson_steps": [
+                {
+                    "instruction": "Advance the passed pawn from d5 to d6.",
+                    "expected_move": "d5-d6"
+                }
+            ],
+
+            "practice_position": {
+                "d5": "P",
+                "e1": "K"
+            },
         },
 
         "King Safety": {
@@ -1802,7 +1945,17 @@ def lesson_detail_view(request, lesson_name):
                         "h2"
                     ]
                 }
-            ]
+            ],
+            "lesson_steps": [
+                {
+                    "instruction": "Castle kingside.",
+                    "expected_move": "e1-g1"
+                }
+            ],
+            "practice_position": {
+                "e1": "K",
+                "h1": "R"
+            }
         },
 
         "Piece Activity": {
@@ -1842,7 +1995,18 @@ def lesson_detail_view(request, lesson_name):
                         "f6"
                     ]
                 }
-            ]
+            ],
+            "lesson_steps": [
+                {
+                    "instruction": "Activate the rook by moving from a1 to a7.",
+                    "expected_move": "a1-a7"
+                }
+            ],
+
+            "practice_position": {
+                "a1": "R",
+                "e1": "K"
+            },
         },
 
         "Basic Endgames": {
@@ -1890,15 +2054,26 @@ def lesson_detail_view(request, lesson_name):
                         "e6"
                     ]
                 }
-            ]
+            ],
+            "lesson_steps": [
+                {
+                    "instruction": "Promote the pawn by moving from e7 to e8.",
+                    "expected_move": "e7-e8"
+                }
+            ],
+            "practice_position": {
+                "e7": "P",
+                "e1": "K",
+                "e8": ""
+            }
         }
     }
 
     lesson = lesson_data.get(lesson_name)
-    
+
     if lesson is None:
         raise Http404("Lesson not found")
-    
+
     lesson_order = list(lesson_data.keys())
 
     current_index = lesson_order.index(lesson_name)
@@ -1956,6 +2131,7 @@ def lesson_detail_view(request, lesson_name):
         }
     )
 
+
 @login_required
 @require_POST
 def complete_lesson(request, lesson_name):
@@ -1973,3 +2149,4 @@ def complete_lesson(request, lesson_name):
         "lesson_detail",
         lesson_name=lesson_name
     )
+ 


### PR DESCRIPTION
## Description

This PR enhances the Chess Lessons Hub by introducing interactive lesson practice exercises that allow users to learn chess concepts through guided board interactions.

### Features Added

- Interactive practice boards for lessons
- Step-by-step lesson instructions
- Move validation system
- Legal move highlighting for selected pieces
- Correct move feedback
- Retry button for restarting practice exercises
- Piece movement on successful lesson moves
- Homepage Lessons button for quick access

### Practice Lessons Added

- How Pieces Move
- Check and Checkmate
- Castling
- Opening Principles
- Pawn Structures
- Piece Activity

### User Experience Improvements

- Interactive learning workflow
- Visual move guidance
- Immediate feedback on moves
- Lesson retry functionality
- Easier access to lessons from landing page

### Testing

- Verified lesson pages render correctly
- Verified move validation logic
- Verified piece highlighting
- Verified retry functionality
- Verified lesson navigation
- Verified homepage Lessons button

Fixes #1609