### PR TITLE
fix: prevent OTP leak to stdout via DISPLAY_OTP env var (#1631)

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -1,4 +1,5 @@
 """Game views for the Checkora chess platform."""
+import os
 import logging
 import json
 import time
@@ -641,7 +642,7 @@ def register_view(request):
                 not settings.EMAIL_HOST_PASSWORD
             )
 
-            if settings.DEBUG and missing_email_credentials:
+            if os.getenv("DISPLAY_OTP", "").lower() == "true" and missing_email_credentials:
                 print(f"[Checkora] Development registration OTP for {user.email}: {otp}")
                 return redirect('verify_otp')
 


### PR DESCRIPTION
﻿### Description

**Issue:** Closes #1631

The registration endpoint printed the OTP to stdout when `settings.DEBUG=True` and email was not configured. A production misconfiguration setting `DEBUG=True` would leak every registration OTP to server logs.

### Fix

Replaced the `settings.DEBUG` gate with `os.getenv("DISPLAY_OTP", "").lower() == "true"`, a dedicated environment variable. Developers can set `DISPLAY_OTP=true` locally to see OTPs during development, but no production misconfiguration will accidentally expose them.

### Changes

- `game/views.py`: added `import os`, replaced `settings.DEBUG` gate with `DISPLAY_OTP` env var
