### PR TITLE
fix: standardize hover effects across all landing page sections (#1652)

### DIFF
--- a/game/static/game/css/landing.css
+++ b/game/static/game/css/landing.css
@@ -853,9 +853,9 @@ body {
 }
 
 .capability-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
-    border-color: rgba(240, 192, 64, 0.35);
+    transform: translateY(-6px);
+    border-color: var(--accent-gold);
+    box-shadow: 0 0 18px rgba(240, 192, 64, 0.18);
 }
 
 .capability-icon {


### PR DESCRIPTION
﻿### Description

**Issue:** Closes #1652

The "Why Checkora" and "Platform Capabilities" sections used different hover intensities (gold glow vs dark shadow, 6px vs 5px lift).

### Fix

Standardized `.capability-card:hover` to match `.card:hover`:
- Same `translateY(-6px)` lift
- Same gold border (`var(--accent-gold)`)
- Same gold glow (`0 0 18px rgba(240, 192, 64, 0.18)`)

### Changes

- `landing.css`: aligned `.capability-card:hover` with `.card:hover` hover properties
