### PR TITLE
fix: prevent profile dropdown from closing before option can be selected (#1651)

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -188,7 +188,6 @@ body {
 }
 
 .dropdown-content{
-    display: none;
     position: absolute;
     right: 0;
     top: 100%;
@@ -200,10 +199,17 @@ body {
     overflow: hidden;
     box-shadow: 0 10px 30px rgba(0,0,0,0.4);
     z-index: 9999;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.15s ease, visibility 0.15s ease;
+    pointer-events: none;
 }
 
-.profile-dropdown:hover .dropdown-content{
-    display: block;
+.profile-dropdown:hover .dropdown-content,
+.profile-dropdown:focus-within .dropdown-content{
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
 }
 
 .dropdown-content a,

--- a/game/static/game/css/landing.css
+++ b/game/static/game/css/landing.css
@@ -174,7 +174,6 @@ body {
 }
 
 .dropdown-content{
-    display: none;
     position: absolute;
     right: 0;
     top: 55px;
@@ -185,10 +184,17 @@ body {
     border: 1px solid rgba(255,255,255,0.08);
     box-shadow: 0 10px 30px rgba(0,0,0,0.4);
     z-index: 9999;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.15s ease, visibility 0.15s ease;
+    pointer-events: none;
 }
 
-.profile-dropdown:hover .dropdown-content{
-    display: block;
+.profile-dropdown:hover .dropdown-content,
+.profile-dropdown:focus-within .dropdown-content{
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
 }
 
 .dropdown-content a,


### PR DESCRIPTION
﻿### Description

**Issue:** Closes #1651

The profile dropdown menu used `display: none/block` to show/hide on hover. When the cursor moved from the trigger button to the dropdown items, it passed through a gap that triggered the hide, making menu items unclickable.

### Fix

Replaced `display: none/block` with `opacity`, `visibility`, and `pointer-events` transitions:
- Dropdown fades in/out smoothly with a 150ms transition
- The transition delay prevents instantaneous closure when cursor briefly leaves the trigger area
- Added `focus-within` support for keyboard accessibility

### Changes

- `landing.css`: refactored `.dropdown-content` visibility to use opacity/visibility with transition
- `board.css`: same refactoring for the game board navbar dropdown
