### PR TITLE
refactor: separate mode selection from player setup in welcome screen (#1653)

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -3250,7 +3250,7 @@
                 
                 pveOptions.style.display = 'none';
                 modeSelection.style.display = 'flex';
-                nameInputs.style.display = 'flex';
+                nameInputs.style.display = 'none';
                 
                 if (whiteInput) {
                     whiteInput.style.display = 'block';
@@ -3326,7 +3326,13 @@
                 });
             }
             
-            if (welcomePvPBtn) welcomePvPBtn.onclick = async () => {            
+            if (welcomePvPBtn) welcomePvPBtn.onclick = () => {
+                modeSelection.style.display = 'none';
+                nameInputs.style.display = 'flex';
+            };
+
+            const startPvPBtn = document.getElementById('startPvPBtn');
+            if (startPvPBtn) startPvPBtn.onclick = async () => {
                 if (!validatePlayerNames()) return;
                 const fen = welcomeFenInput?.value?.trim() || null;
                 const started = await startNewGame('pvp', 'white', 'medium', fen);

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -81,7 +81,7 @@
             </div>
             <p style="color: #aaa; margin-bottom: 30px; font-size: 0.95rem;">Enter names and select a game mode.</p>
 
-            <div id="nameInputs" style="display: flex; flex-direction: column; gap: 10px; margin-bottom: 25px;">
+            <div id="nameInputs" style="display: none; flex-direction: column; gap: 10px; margin-bottom: 25px;">
                 <input type="text" id="whiteNameInput" placeholder="White Player Name" maxlength="17" required
                     minlength="1"
                     style="padding: 10px; border-radius: 5px; border: 1px solid #444; background: #1a1a2e; color: #fff; transition: all 0.3s ease;">
@@ -170,9 +170,9 @@
                         </div>
                     </div>
                 </div>
+                <button class="btn btn-gold" id="startPvPBtn" style="padding: 12px; font-size: 1.05rem; margin-top: 10px;">Start Game</button>
             </div>
 
-            <!-- Rest stays the same -->
             <div id="modeSelection" style="display: flex; flex-direction: column; gap: 14px;">
                 
                 <button class="btn btn-gold" id="welcomePvPBtn" style="padding: 12px; font-size: 1.05rem;">Pass & Play


### PR DESCRIPTION
﻿### Description

**Issue:** Closes #1653

The welcome overlay showed player name inputs and mode selection buttons simultaneously. Clicking "Pass & Play (PvP)" immediately started the game without a separate setup step.

### Fix

Separated the flow into two clear steps:
1. **Select Game Mode** — only mode buttons are shown initially
2. **Player Setup** — clicking PvP hides mode selection and reveals name inputs + a dedicated "Start Game" button

Added a `#startPvPBtn` button for starting PvP games instead of starting directly from the mode button. The AI flow was already correct (mode → PvE options → Start).

### Changes

- `board.html`: hid `#nameInputs` by default, added `#startPvPBtn` button
- `board.js`: changed `welcomePvPBtn.onclick` to show inputs, added `startPvPBtn.onclick` for game start, updated `prepareWelcomeForPvP` to hide name inputs by default
