### PR TITLE
fix: resolve responsive layout issues for board theme labels (#1128)

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -1256,11 +1256,42 @@ body {
 
 .theme-switcher {
     display: flex;
-    gap: 10px;
+    flex-wrap: wrap;
     justify-content: center;
-    margin-top: 4px;
+    gap: 14px 4px; /* 14px vertical gap, 4px horizontal gap */
+    margin-top: 10px;
+    width: 100%;
 }
 
+.theme-option {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 6px;
+    /* Mathematically force 3 columns max per row */
+    flex: 0 0 calc(33.333% - 4px);
+    max-width: calc(33.333% - 4px);
+}
+
+.theme-option .theme-btn {
+    flex-shrink: 0;
+    margin: 0;
+    /* Lock the button sizes so they NEVER squish or change shape */
+    width: 28px !important;
+    height: 28px !important;
+}
+
+.theme-label {
+    /* Smoothly scales the font between 7.5px and 11px based on the screen width */
+    font-size: clamp(7.5px, 2.5vw, 11px);
+    color: rgba(255, 255, 255, 0.65);
+    text-align: center;
+    line-height: 1.15;
+    width: 100%;
+    /* Forces the text to stay on a single line (no word breaking) */
+    white-space: nowrap;
+}
 .theme-btn {
     width: 28px;
     height: 28px;

--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -1288,7 +1288,7 @@ body {
 }
 
 .theme-label {
-    font-size: clamp(6.5px, 2.2vw, 8px);    color: rgba(255, 255, 255, 0.75);
+    font-size: clamp(6.5px, 2.2vw, 8px);
     color: rgba(255, 255, 255, 0.75);
     text-align: center;
     line-height: 1;

--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -957,7 +957,11 @@ body {
         width: 24px;
         height: 24px;
     }
-
+  
+    .theme-option {
+        flex: 0 0 calc((100% - 12px) / 3);
+        max-width: calc((100% - 12px) / 3);
+    } 
     .keyboard-hints {
         font-size: 0.72rem !important;
         line-height: 1.35;
@@ -1256,45 +1260,43 @@ body {
 
 .theme-switcher {
     display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 14px 4px; /* 14px vertical gap, 4px horizontal gap */
+    flex-wrap: nowrap;
+    justify-content: space-between;
+    gap: 2px;
     margin-top: 10px;
-    width: 100%;
+    /* The Magic Fix: Pulls the row wider to bypass the card's inner padding */
+    margin-left: -4px;
+    margin-right: -4px;
+    width: calc(100% + 8px);
 }
 
 .theme-option {
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: flex-start;
-    gap: 6px;
-    /* Mathematically force 3 columns max per row */
-    flex: 0 0 calc(33.333% - 4px);
-    max-width: calc(33.333% - 4px);
+    gap: 4px;
+    flex: 1 ;
 }
 
 .theme-option .theme-btn {
     flex-shrink: 0;
     margin: 0;
     /* Lock the button sizes so they NEVER squish or change shape */
-    width: 28px !important;
-    height: 28px !important;
+    width: 18px !important; 
+    height: 18px !important;
+    border-width: 1.5px;
 }
 
 .theme-label {
-    /* Smoothly scales the font between 7.5px and 11px based on the screen width */
-    font-size: clamp(7.5px, 2.5vw, 11px);
-    color: rgba(255, 255, 255, 0.65);
+    font-size: clamp(6.5px, 2.2vw, 8px);    color: rgba(255, 255, 255, 0.75);
+    color: rgba(255, 255, 255, 0.75);
     text-align: center;
-    line-height: 1.15;
-    width: 100%;
-    /* Forces the text to stay on a single line (no word breaking) */
+    line-height: 1;
+    /* Pull the letters slightly closer together to save space */
+    letter-spacing: -0.4px;
     white-space: nowrap;
 }
 .theme-btn {
-    width: 28px;
-    height: 28px;
     border-radius: 50%;
     border: 2px solid #333;
     cursor: pointer;

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -400,19 +400,26 @@
             <div class="card">
                 <div class="card-title">Board Theme</div>
                 <div class="theme-switcher">
-                    <button class="theme-btn active" data-theme="classic" title="Classic" aria-label="Classic theme"
-                        aria-pressed="true" type="button"></button>
-                    <button class="theme-btn" data-theme="dark" title="Dark" aria-label="Dark theme"
-                        aria-pressed="false" type="button"></button>
-                    <button class="theme-btn" data-theme="green" title="Green" aria-label="Green theme"
-                        aria-pressed="false" type="button"></button>
-                    <button class="theme-btn" data-theme="blue" title="Blue" aria-label="Blue theme"
-                        aria-pressed="false" type="button"></button>
-                    <button class="theme-btn" data-theme="pastel" title="Pastel" aria-label="Pastel theme"
-                        aria-pressed="false" type="button"></button>
-                </div>
-                <div style="margin-top: 8px; font-size: 11px; color: rgba(255,255,255,0.5); text-align: center;">
-                    Classic · Dark · Green · Blue · Pastel
+                    <div class="theme-option">
+                        <button class="theme-btn active" data-theme="classic" title="Classic" aria-label="Classic theme" aria-pressed="true" type="button"></button>
+                        <span class="theme-label">Classic</span>
+                    </div>
+                    <div class="theme-option">
+                        <button class="theme-btn" data-theme="dark" title="Dark" aria-label="Dark theme" aria-pressed="false" type="button"></button>
+                        <span class="theme-label">Dark</span>
+                    </div>
+                    <div class="theme-option">
+                        <button class="theme-btn" data-theme="green" title="Green" aria-label="Green theme" aria-pressed="false" type="button"></button>
+                        <span class="theme-label">Green</span>
+                    </div>
+                    <div class="theme-option">
+                        <button class="theme-btn" data-theme="blue" title="Blue" aria-label="Blue theme" aria-pressed="false" type="button"></button>
+                        <span class="theme-label">Blue</span>
+                    </div>
+                    <div class="theme-option">
+                        <button class="theme-btn" data-theme="pastel" title="Pastel" aria-label="Pastel theme" aria-pressed="false" type="button"></button>
+                        <span class="theme-label">Pastel</span>
+                    </div>
                 </div>
             </div>
             <div class="card">


### PR DESCRIPTION
## Description
This PR addresses the responsive layout bug in the "Board Theme" control panel where color names would misalign, break awkwardly, or overflow their containers on smaller screens.
To fix this, I restructured the HTML to logically group each color button with its corresponding label and updated the CSS to use a mathematically precise flex layout with fluid typography.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #1128 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings


## Screenshots
BEFORE
<img width="167" height="126" alt="image" src="https://github.com/user-attachments/assets/94f40b99-8136-4f82-bae6-13b3996d3104" />

AFTER
<img width="169" height="177" alt="image" src="https://github.com/user-attachments/assets/48baf756-0f73-4e45-b567-078902a4da10" />


## Additional Notes
I'm a GSSOC Contributor.
