### PR TITLE
fix: add missing PGN Seven Tag Roster headers

### DIFF
--- a/game/engine.py
+++ b/game/engine.py
@@ -126,9 +126,11 @@ class ChessGame:
         today = date.today().strftime('%Y.%m.%d')
         headers = [
             '[Event "Checkora Match"]',
+            '[Site "checkora.io"]',
+            f'[Date "{today}"]',
+            '[Round "?"]',
             f'[White "{white_name}"]',
             f'[Black "{black_name}"]',
-            f'[Date "{today}"]',
             f'[Result "{result}"]',
         ]
         moves = " ".join(pgn_moves)


### PR DESCRIPTION
## Description

Adds the missing PGN Seven Tag Roster headers required by the PGN specification in `generate_pgn()`.

### Changes Made

* Added `[Site "checkora.io"]`
* Added `[Round "?"]`
* Ensured exported PGN files contain all required Seven Tag Roster headers

This improves compatibility with PGN-compliant tools such as Lichess, Chess.com, SCID, and ChessBase.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

## Related Issue

Fixes #1678

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [ ] I have commented my code where necessary
* [ ] I have updated the documentation if needed
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix/feature works
* [ ] New and existing tests pass locally

## Screenshots 

<img width="1422" height="710" alt="1" src="https://github.com/user-attachments/assets/94b9e5cb-86b8-459a-94ac-74c9ae70f783" />


## Additional Notes

This PR only modifies `game/engine.py` and does not introduce any functional changes outside of PGN export compliance.
