### PR TITLE
fix(ui): standardize hover intensity across landing page cards

### DIFF
--- a/game/static/game/css/landing.css
+++ b/game/static/game/css/landing.css
@@ -886,9 +886,9 @@ body {
 }
 
 .capability-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
-    border-color: rgba(240, 192, 64, 0.35);
+    transform: translateY(-6px);
+    border-color: var(--accent-gold);
+    box-shadow: 0 0 18px rgba(240, 192, 64, 0.18);
 }
 
 .capability-icon {


### PR DESCRIPTION
## Description

This PR standardizes the hover intensity between the "Why Checkora" and "Platform Capabilities" cards on the landing page.

The hover transform, border highlight, and shadow effect of the Platform Capabilities cards have been updated to match the hover behavior used in the Why Checkora section, creating a more consistent and polished user experience.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #1652 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

## Screenshots (if applicable)


https://github.com/user-attachments/assets/840844fc-fb84-4483-a7a2-d8efc2b8feaa



## Additional Notes

This change only affects UI hover styling and does not introduce any functional changes.
