### PR TITLE
fix: use slug URLs for chess lessons on Vercel

### DIFF
--- a/game/static/game/js/lesson_practice.js
+++ b/game/static/game/js/lesson_practice.js
@@ -354,7 +354,7 @@ document.addEventListener(
                 }
 
                 if (!selectedSquare) {
-                    const piece = square.innerText.trim();
+                    const piece = square.innerHTML.trim();
                     if (!piece) {
                         return;
                     }

--- a/game/static/game/js/lesson_practice.js
+++ b/game/static/game/js/lesson_practice.js
@@ -354,19 +354,16 @@ document.addEventListener(
                 }
 
                 if (!selectedSquare) {
+                    const piece = square.innerText.trim();
+                    if (!piece) {
+                        return;
+                    }
 
                     selectedSquare = square;
 
                     square.classList.add(
                         "selected-square"
                     );
-
-                    const piece =
-                        square.innerText;
-                    
-                    if (!piece) {
-                        return;
-                    }
 
                     let moves = [];
 
@@ -475,19 +472,7 @@ document.addEventListener(
                             );
                         }
                     );
-                const retryBtn =
-                    document.getElementById(
-                        "retry-btn"
-                    );
-                if (retryBtn) {
-                    retryBtn.addEventListener(
-                        "click",
-                        () => {
-                            location.reload();
-                        }
-                    );
-                }
-                
+
                 selectedSquare = null;
 
                 const isCorrect = checkMove(move);
@@ -504,6 +489,13 @@ document.addEventListener(
                 }
             }
         );
+
+        const retryBtn = document.getElementById("retry-btn");
+        if (retryBtn) {
+            retryBtn.addEventListener("click", () => {
+                location.reload();
+            });
+        }
     }
 );
 

--- a/game/templates/game/lesson_detail.html
+++ b/game/templates/game/lesson_detail.html
@@ -353,7 +353,7 @@
 
     <form
         method="post"
-        action="{% url 'complete_lesson' lesson.title %}"
+        action="{% url 'complete_lesson' lesson.title|slugify %}"
     >
         {% csrf_token %}
 
@@ -398,13 +398,13 @@
     <div class="lesson-navigation">
 
         {% if previous_lesson %}
-            <a href="{% url 'lesson_detail' previous_lesson %}">
+            <a href="{% url 'lesson_detail' previous_lesson|slugify %}">
                 ← {{ previous_lesson }}
             </a>
         {% endif %}
 
         {% if next_lesson %}
-            <a href="{% url 'lesson_detail' next_lesson %}">
+            <a href="{% url 'lesson_detail' next_lesson|slugify %}">
                 {{ next_lesson }} →
             </a>
         {% endif %}

--- a/game/templates/game/lessons.html
+++ b/game/templates/game/lessons.html
@@ -82,7 +82,7 @@
 
         {% for lesson in lesson_list %}
 
-        <a href="{% url 'lesson_detail' lesson %}">
+        <a href="{% url 'lesson_detail' lesson|slugify %}">
             <div class="lesson-card">
                 {% if lesson in completed_lessons %}
                     ✓ {{ lesson }}

--- a/game/tests.py
+++ b/game/tests.py
@@ -2169,3 +2169,9 @@ class AdditionalViewsSecurityAndLessonsTest(TestCase):
         self.assertIn('lesson_steps', response.context)
         self.assertIn('practice_position', response.context)
         self.assertNotEqual(response.context['lesson_steps'], [])
+
+    def test_lesson_detail_invalid_slug_returns_404(self):
+        response = self.client.get(
+            reverse('lesson_detail', args=['not-a-real-lesson'])
+        )
+        self.assertEqual(response.status_code, 404)

--- a/game/tests.py
+++ b/game/tests.py
@@ -2152,16 +2152,19 @@ class AdditionalViewsSecurityAndLessonsTest(TestCase):
         self.assertEqual(session.get('registration_otp_hash'), initial_hash)
 
     def test_lesson_detail_view_exposes_context(self):
-        # Test beginner lesson "How Pieces Move"
-        response = self.client.get(reverse('lesson_detail', args=['How Pieces Move']))
+        response = self.client.get(reverse('lesson_detail', args=['how-pieces-move']))
         self.assertEqual(response.status_code, 200)
         self.assertIn('lesson_steps', response.context)
         self.assertIn('practice_position', response.context)
         self.assertNotEqual(response.context['lesson_steps'], [])
         self.assertIsNotNone(response.context['practice_position'])
 
-        # Test intermediate lesson "Forks" which has steps mapping
-        response = self.client.get(reverse('lesson_detail', args=['Forks']))
+        response = self.client.get(
+            reverse('lesson_detail', args=['check-and-checkmate'])
+        )
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.get(reverse('lesson_detail', args=['forks']))
         self.assertEqual(response.status_code, 200)
         self.assertIn('lesson_steps', response.context)
         self.assertIn('practice_position', response.context)

--- a/game/views.py
+++ b/game/views.py
@@ -22,6 +22,7 @@ from django.utils.encoding import (
     force_bytes,
     force_str
 )
+from django.utils.text import slugify
 
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.auth.forms import AuthenticationForm, PasswordResetForm
@@ -1475,6 +1476,36 @@ def analyze_game_view(request):
         logger.error('Failed to analyze game: %s', e)
         return JsonResponse({'error': 'Failed to analyze game'}, status=400)
 
+
+_LESSON_NAMES = (
+    "How Pieces Move",
+    "Check and Checkmate",
+    "Castling",
+    "Opening Principles",
+    "Forks",
+    "Pins",
+    "Skewers",
+    "Discovered Attacks",
+    "Pawn Structures",
+    "King Safety",
+    "Piece Activity",
+    "Basic Endgames",
+)
+
+
+def _lesson_name_from_slug(lesson_slug):
+    for name in _LESSON_NAMES:
+        if slugify(name) == lesson_slug:
+            return name
+    return None
+
+
+def _resolve_lesson_name(url_key):
+    if url_key in _LESSON_NAMES:
+        return url_key
+    return _lesson_name_from_slug(url_key)
+
+
 def lessons_view(request):
     lessons = {
         "Beginner": [
@@ -1529,6 +1560,10 @@ def lessons_view(request):
 
 
 def lesson_detail_view(request, lesson_name):
+    resolved_name = _resolve_lesson_name(lesson_name)
+    if resolved_name is not None:
+        lesson_name = resolved_name
+
     lesson_data = {
         "How Pieces Move": {
             "title": "How Pieces Move",
@@ -2271,6 +2306,12 @@ def lesson_detail_view(request, lesson_name):
 @login_required
 @require_POST
 def complete_lesson(request, lesson_name):
+    resolved_name = _resolve_lesson_name(lesson_name)
+    if resolved_name is not None:
+        lesson_name = resolved_name
+
+    if lesson_name not in _LESSON_NAMES:
+        raise Http404("Lesson not found")
 
     LessonProgress.objects.update_or_create(
         user=request.user,
@@ -2283,6 +2324,5 @@ def complete_lesson(request, lesson_name):
 
     return redirect(
         "lesson_detail",
-        lesson_name=lesson_name
+        lesson_name=slugify(lesson_name)
     )
- 


### PR DESCRIPTION
Multi-word lesson paths with encoded spaces returned 404 in production. Resolve lessons by slug and expose slug links across the hub and board nav.

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #(issue number)

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

## Screenshots (if applicable)

Add screenshots to demonstrate visual changes.

## Additional Notes

Any additional information reviewers should know.
