### PR TITLE
Feat/arrow key navigation replay

### DIFF
--- a/board.test.js
+++ b/board.test.js
@@ -48,6 +48,8 @@ document.body.innerHTML = `
   <div id="blackCapturedName"></div>
   <div id="turnBadgeText"></div>
 `;
+global.SOUND_BASE_URL = '/static/game/sounds/';
+
 // Mock Worker for Jest
 global.Worker = class MockWorker {
   constructor(url) {

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -3867,7 +3867,28 @@
                 const tag = document.activeElement && document.activeElement.tagName;
                 if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
 
-                
+                if (replayMode) {
+                    if (e.key === 'ArrowLeft') {
+                        e.preventDefault();
+                        prevReplayBtn?.click();
+                        return;
+                    }
+                    if (e.key === 'ArrowRight') {
+                        e.preventDefault();
+                        nextReplayBtn?.click();
+                        return;
+                    }
+                    if (e.key === 'ArrowUp') {
+                        e.preventDefault();
+                        firstReplayBtn?.click();
+                        return;
+                    }
+                    if (e.key === 'ArrowDown') {
+                        e.preventDefault();
+                        lastReplayBtn?.click();
+                        return;
+                    }
+                }
 
                 const key = e.key.toLowerCase();
                 const hasBlockingOverlay =


### PR DESCRIPTION
# Description

Closes #1634
This PR implements keyboard arrow key navigation for Replay & Analysis Mode as requested in #1634. Standard chess applications support keyboard navigation for a better desktop replay experience.

### Key Changes
1. **Replay Controls Keyboard Shortcuts**:
   - **`ArrowLeft`**: Navigates to the **previous** move (`prevReplayBtn.click()`).
   - **`ArrowRight`**: Navigates to the **next** move (`nextReplayBtn.click()`).
   - **`ArrowUp`**: Jumps to the **first** move (`firstReplayBtn.click()`).
   - **`ArrowDown`**: Jumps to the **last** move (`lastReplayBtn.click()`).
2. **Event & Focus Guards**:
   - The arrow key actions are only active when `replayMode` is `true`.
   - Prevented default browser behaviors (such as vertical page scrolling) on arrow keys when replay mode is active.
   - Preserved early return behaviors if input elements (e.g. FEN textboxes, textareas) are active, ensuring typing remains unimpeded.
3. **Test Suite Fixes**:
   - Resolved a testing environment `ReferenceError` regarding `SOUND_BASE_URL` by defining it on the mock `global` scope in Jest tests.

