### PR TITLE
feat: add board coordinates visibility toggle (#1635)

### DIFF
--- a/board.test.js
+++ b/board.test.js
@@ -47,6 +47,7 @@ document.body.innerHTML = `
   <div id="whiteCapturedName"></div>
   <div id="blackCapturedName"></div>
   <div id="turnBadgeText"></div>
+  <input type="checkbox" id="showCoordinatesCheckbox">
 `;
 // Mock Worker for Jest
 global.Worker = class MockWorker {
@@ -95,6 +96,16 @@ global.Chess = class MockChess {
     const moveStr = typeof moveObj === 'string' ? moveObj : `${moveObj.from}${moveObj.to}`;
     this._fen = `${this._fen}_then_${moveStr}`;
     return {};
+  }
+};
+
+global.SOUND_BASE_URL = '/static/game/sounds/';
+global.Audio = class MockAudio {
+  constructor(src) {
+    this.src = src;
+  }
+  play() {
+    return Promise.resolve();
   }
 };
 
@@ -194,5 +205,28 @@ describe("validateMoveWithStockfish", () => {
     global.mockScores['played_fen'] = { type: 'cp', value: 200 };
     const result = await validateMoveWithStockfish("startpos", "played_fen", "e2e4");
     expect(result).toBe(false);
+  });
+});
+
+describe("Coordinates visibility toggle", () => {
+  test("toggles .hide-coordinates class on #board when checkbox changes state", () => {
+    const checkbox = document.getElementById("showCoordinatesCheckbox");
+    const board = document.getElementById("board");
+    
+    // Default should be checked (true) and class should not be present
+    expect(checkbox.checked).toBe(true);
+    expect(board.classList.contains("hide-coordinates")).toBe(false);
+    
+    // Simulate unchecking
+    checkbox.checked = false;
+    checkbox.dispatchEvent(new Event("change"));
+    expect(board.classList.contains("hide-coordinates")).toBe(true);
+    expect(localStorage.getItem("showCoordinates")).toBe("false");
+    
+    // Simulate checking again
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event("change"));
+    expect(board.classList.contains("hide-coordinates")).toBe(false);
+    expect(localStorage.getItem("showCoordinates")).toBe("true");
   });
 });

--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -2595,6 +2595,11 @@ body.blindfold-mode .capture-ring {
     border-color: #f0c040;
 }
 
+.custom-checkbox:focus-visible {
+    outline: 2px solid #f0c040;
+    outline-offset: 2px;
+}
+
 .custom-checkbox:checked {
     background-color: #f0c040;
     border-color: #f0c040;

--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -2562,3 +2562,77 @@ body.blindfold-mode .capture-ring {
         0 0 12px rgba(76, 175, 80, 0.6);
     border-radius: 4px;
 }
+
+/* ============================================================
+   Coordinates Visibility Preference
+   ============================================================ */
+.preference-container {
+    margin-top: 14px;
+    padding-top: 12px;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+}
+
+.custom-checkbox {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 16px;
+    height: 16px;
+    border: 1px solid #444;
+    border-radius: 4px;
+    outline: none;
+    background-color: #1a1a2e;
+    cursor: pointer;
+    display: grid;
+    place-content: center;
+    transition: all 0.2s ease;
+}
+
+.custom-checkbox:hover {
+    border-color: #f0c040;
+}
+
+.custom-checkbox:checked {
+    background-color: #f0c040;
+    border-color: #f0c040;
+}
+
+.custom-checkbox::before {
+    content: "";
+    width: 10px;
+    height: 10px;
+    transform: scale(0);
+    transition: 120ms transform ease-in-out;
+    box-shadow: inset 1em 1em #1a1a2e;
+    transform-origin: bottom left;
+    clip-path: polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%);
+}
+
+.custom-checkbox:checked::before {
+    transform: scale(1);
+}
+
+.preference-label {
+    color: #ccc;
+    font-size: 0.85rem;
+    cursor: pointer;
+    user-select: none;
+    transition: color 0.2s ease;
+}
+
+.preference-label:hover {
+    color: #f0c040;
+}
+
+/* Hide chessboard coordinate labels when .hide-coordinates is active on the main #board */
+.board-row:has(#board.hide-coordinates) .ranks,
+.board-aligned:has(#board.hide-coordinates) .files {
+    visibility: hidden;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease, visibility 0.2s ease;
+}
+

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -3767,10 +3767,37 @@
                 });
             }
 
+            // Coordinates Visibility Preference
+            function initCoordinatesToggle() {
+                const showCoordsBtn = document.getElementById('showCoordinatesCheckbox');
+                if (!showCoordsBtn) return;
+
+                const savedShowCoords = localStorage.getItem('showCoordinates') !== 'false';
+                showCoordsBtn.checked = savedShowCoords;
+
+                if (!savedShowCoords && boardEl) {
+                    boardEl.classList.add('hide-coordinates');
+                }
+
+                showCoordsBtn.addEventListener('change', () => {
+                    if (showCoordsBtn.checked) {
+                        if (boardEl) boardEl.classList.remove('hide-coordinates');
+                        localStorage.setItem('showCoordinates', 'true');
+                    } else {
+                        if (boardEl) boardEl.classList.add('hide-coordinates');
+                        localStorage.setItem('showCoordinates', 'false');
+                    }
+                });
+            }
+
             if (document.readyState === 'loading') {
-                document.addEventListener('DOMContentLoaded', initThemeSwitcher);
+                document.addEventListener('DOMContentLoaded', () => {
+                    initThemeSwitcher();
+                    initCoordinatesToggle();
+                });
             } else {
                 initThemeSwitcher();
+                initCoordinatesToggle();
             }
 
     document.addEventListener('visibilitychange', async() => {

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -414,6 +414,10 @@
                 <div style="margin-top: 8px; font-size: 11px; color: rgba(255,255,255,0.5); text-align: center;">
                     Classic · Dark · Green · Blue · Pastel
                 </div>
+                <div class="preference-container">
+                    <input type="checkbox" id="showCoordinatesCheckbox" class="custom-checkbox" checked>
+                    <label for="showCoordinatesCheckbox" class="preference-label">Show Coordinates</label>
+                </div>
             </div>
             <div class="card">
                 <div class="card-title">Game Controls</div>


### PR DESCRIPTION
Closes #1635. 
### Description
This PR resolves #1635 by adding a "Show Coordinates" visibility toggle to the chessboard. Advanced players often prefer clean chessboards without alphanumeric coordinate labels (A-H, 1-8) along the edges, while beginners find them essential. This change adds a preference setting to toggle showing/hiding coordinates, providing a customized experience for both audiences.

### Changes Made

1. **HTML Layout (`game/templates/game/board.html`)**:
   - Added a "Show Coordinates" checkbox preference item with clean semantics and accessibility inside the "Board Theme" card in the settings sidebar/panel.

2. **CSS Rules (`game/static/game/css/board.css`)**:
   - Implemented sleek, premium custom styling for the checkbox matching Checkora's theme palette (`#f0c040` / gold).
   - Added CSS rules using the `:has` selector to hide vertical ranks (`.ranks`) and horizontal files (`.files`) when `#board` has the `.hide-coordinates` class.
   - Used `visibility: hidden` and `opacity: 0` to ensure that coordinates are smoothly hidden without causing any visual layout shifts or chessboard alignment changes.

3. **JavaScript Logic (`game/static/game/js/board.js`)**:
   - Created the `initCoordinatesToggle` function.
   - Loads preference on initial render from `localStorage` (`showCoordinates`). If set to `'false'`, coordinates are hidden.
   - Listen to changes on the checkbox to toggle the class `.hide-coordinates` on `#board` and save the new state in `localStorage`.

4. **Testing (`board.test.js`)**:
   - Mocked global dependencies (`SOUND_BASE_URL` and `Audio`) to fix environment errors in Node/Jest test runs.
   - Added a robust unit test suite verifying coordinates toggle checkbox interactions, DOM changes (`.hide-coordinates` class addition/removal), and `localStorage` persistence.

