### PR TITLE
Add password reset account selection template

### DIFF
--- a/game/templates/game/password_reset_account_selection.html
+++ b/game/templates/game/password_reset_account_selection.html
@@ -1,0 +1,74 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Select Account | Checkora</title>
+    <link rel="stylesheet" href="{% static 'game/css/auth.css' %}">
+    <link rel="icon" type="image/jpeg" href="{% static 'game/favicon.jpeg' %}">
+</head>
+<body>
+    <a href="{% url 'landing' %}" class="back-home" aria-label="Back to home">&larr; Home</a>
+
+    <div class="header">
+        <div class="logo-container">
+            <img src="{% static 'game/checkora_icon_only.png' %}" class="logo-icon-img" alt="Checkora">
+            <span class="logo-text">Checkora</span>
+        </div>
+        <p>Select the account to reset</p>
+    </div>
+
+    <div class="auth-card">
+        {% include 'game/includes/messages.html' %}
+
+        {% if users %}
+            <p style="text-align:center; margin-bottom:1.5rem;">
+                We found multiple accounts for
+                <strong>{{ email }}</strong>. Choose the account that needs a
+                password reset link.
+            </p>
+
+            {% for user in users %}
+                <form
+                    method="POST"
+                    action="{% url 'password_reset' %}"
+                    style="margin-top: 10px;"
+                >
+                    {% csrf_token %}
+                    <input
+                        type="hidden"
+                        name="email"
+                        value="{{ email }}"
+                    >
+                    <input
+                        type="hidden"
+                        name="selected_username"
+                        value="{{ user.username }}"
+                    >
+                    <button
+                        type="submit"
+                        class="btn btn-gold"
+                        style="width: 100%;"
+                    >
+                        {{ user.username }}
+                    </button>
+                </form>
+            {% endfor %}
+        {% else %}
+            <div style="text-align:center;">
+                <p style="margin-bottom:1.5rem;">
+                    No account was found for this email address.
+                </p>
+                <a href="{% url 'password_reset' %}" class="btn btn-gold">
+                    Try Another Email
+                </a>
+            </div>
+        {% endif %}
+
+        <div class="auth-footer">
+            Remember your password? <a href="{% url 'login' %}">Sign In</a>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Added the missing `game/password_reset_account_selection.html` template.
- Render matching accounts for the submitted email.
- Let users select the account/username to continue the password reset flow.
- Added an empty state when no account is found.

## Validation
- `python manage.py check`

Closes #1244