### PR TITLE
feat: add level-based lesson progression system

### DIFF
--- a/game/templates/game/lesson_map.html
+++ b/game/templates/game/lesson_map.html
@@ -1,0 +1,361 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Learning Journey</title>
+
+<style>
+body{
+    margin:0;
+    background:
+    linear-gradient(
+    45deg,
+    #111 25%,
+    #0f0f0f 25%,
+    #0f0f0f 50%,
+    #111 50%,
+    #111 75%,
+    #0f0f0f 75%
+    );
+
+background-size:60px 60px;
+    color:white;
+    font-family:Segoe UI,sans-serif;
+}
+
+.header{
+    text-align:center;
+    padding:30px;
+}
+
+.header h1{
+    color:#f0c040;
+}
+
+.map-container{
+    max-width:900px;
+    margin:auto;
+    padding:20px;
+}
+
+.level-title{
+    text-align:center;
+    margin:80px 0 30px;
+    font-size:34px;
+    color:#f0c040;
+    font-weight:700;
+    text-shadow:0 0 15px rgba(240,192,64,.5);
+}
+
+.lesson-path{
+    display:flex;
+    flex-direction:column;
+    align-items:center;
+}
+
+.lesson-row{
+    width:100%;
+    display:flex;
+    margin: 10px 0;
+}
+
+.lesson-row.left{
+    justify-content:flex-start;
+    padding-left:120px;
+}
+
+.lesson-row.right{
+    justify-content:flex-end;
+    padding-right:120px;
+
+}
+
+.node{
+    width:90px;
+    height:90px;
+    border-radius:50%;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    text-decoration:none;
+    font-size:34px;
+    color:white;
+    font-weight:bold;
+    transition:.3s;
+}
+
+.node:hover{
+    transform:scale(1.08);
+}
+
+.completed{
+    background:#22c55e;
+    box-shadow:0 0 25px #22c55e;
+}
+
+.current{
+    background:#3b82f6;
+    box-shadow:0 0 25px #3b82f6;
+    border:4px solid white;
+    transform:scale(1.12);
+    position:relative;
+}
+
+.current::before{
+    content:"NEXT";
+    position:absolute;
+    top:-12px;
+    background:white;
+    color:black;
+    font-size:10px;
+    font-weight:700;
+    padding:4px 8px;
+    border-radius:12px;
+}
+
+.locked{
+    background:#555;
+    cursor:not-allowed;
+}
+
+.lesson-name{
+    margin-top:12px;
+    text-align:center;
+    width:180px;
+    color:#ddd;
+}
+
+.lesson-card{
+    margin-top:12px;
+    background:#181818;
+    border:1px solid #2d2d2d;
+    border-radius:16px;
+    padding:12px;
+    width:180px;
+    text-align:center;
+    box-shadow:0 4px 12px rgba(0,0,0,.3);
+}
+
+.lesson-card:hover{
+    border-color:#f0c040;
+    transform:translateY(-3px);
+}
+
+.lesson-card h3{
+    margin:0 0 12px;
+    color:white;
+    font-size:18px;
+}
+
+.badge{
+    display:inline-block;
+    padding:6px 12px;
+    border-radius:20px;
+    font-size:12px;
+    font-weight:600;
+}
+
+.done{
+    background:#22c55e;
+    color:white;
+}
+
+.active{
+    background:#3b82f6;
+    color:white;
+}
+
+.locked-badge{
+    background:#555;
+    color:white;
+}
+
+.node span{
+    font-size:42px;
+}
+
+.node.current{
+    border:4px solid white;
+    transform:scale(1.15);
+}
+
+.progress-box{
+    max-width:700px;
+    margin:0 auto 60px;
+    background:linear-gradient(
+        135deg,
+        #181818,
+        #242424
+    );
+    padding:25px;
+    border-radius:24px;
+    border:1px solid #2d2d2d;
+}
+
+.progress-track{
+    height:12px;
+    background:#333;
+    border-radius:20px;
+    overflow:hidden;
+}
+
+.progress-fill{
+    height:100%;
+    background:linear-gradient(
+        90deg,
+        #22c55e,
+        #36e6c5
+    );
+}
+
+.lesson-wrapper{
+    display:flex;
+    flex-direction:column;
+    align-items:center;
+}
+
+.connector{
+    width:120px;
+    height:45px;
+    border:3px solid #36e6c5;
+    border-top:none;
+    border-radius:0 0 60px 60px;
+    margin:-5px auto;
+    opacity:.7;
+}
+
+.back-btn{
+    color:#f0c040;
+    text-decoration:none;
+    font-weight:bold;
+    margin-left:20px;
+}
+
+@media(max-width:768px){
+
+    .lesson-row.left,
+    .lesson-row.right{
+        justify-content:center;
+    }
+
+    .node{
+        width:90px;
+        height:90px;
+    }
+}
+</style>
+
+</head>
+
+<body>
+
+<a href="/" class="back-btn">
+← Back to Lessons
+</a>
+
+<div class="header">
+    <h1>🗺 Chess Learning Journey</h1>
+    <p>Complete lessons to unlock the next one.</p>
+</div>
+
+<div class="progress-box">
+
+    <h3>Your Journey Progress</h3>
+
+    <div class="progress-track">
+        <div
+            class="progress-fill"
+            style="width:{% widthratio completed_lessons|length 12 100 %}%">
+        </div>
+    </div>
+
+    <p>
+        {{ completed_lessons|length }} / 12 Lessons Completed
+    </p>
+
+</div>
+
+<div class="map-container">
+
+{% for level in levels %}
+
+    <div class="level-title">
+        Level {{ level.id }} • {{ level.title }}
+    </div>
+
+    <div class="lesson-path">
+
+        {% for lesson in level.lessons %}
+
+            <div class="lesson-row {% cycle 'left' 'right' %}">
+
+                <div class="lesson-wrapper">
+
+                    {% if lesson in completed_lessons %}
+
+                        <a
+                            href="{% url 'lesson_detail' lesson|slugify %}"
+                            class="node completed">
+                            <span>♔</span>
+                        </a>
+
+                    {% elif lesson in unlocked_lessons %}
+
+                        <a
+                            href="{% url 'lesson_detail' lesson|slugify %}"
+                            class="node current">
+                            <span>♕</span>
+                        </a>
+
+                    {% else %}
+
+                        <div class="node locked">
+                            <span>🔒</span>
+                        </div>
+
+                    {% endif %}
+
+                    <div class="lesson-card">
+
+                        <h3>{{ lesson }}</h3>
+
+                        {% if lesson in completed_lessons %}
+                            <span class="badge done">
+                                Completed
+                            </span>
+
+                        {% elif lesson in unlocked_lessons %}
+                            <span class="badge active">
+                                Start Lesson
+                            </span>
+
+                        {% else %}
+                            <span class="badge locked-badge">
+                                Locked
+                            </span>
+
+                        {% endif %}
+
+                    </div>
+
+                </div>
+
+            </div>
+
+            {% if not forloop.last %}
+                <div class="connector"></div>
+            {% endif %}
+
+        {% endfor %}
+
+    </div>
+
+{% endfor %}
+
+</div>
+
+</body>
+</html>

--- a/game/templates/game/lesson_map.html
+++ b/game/templates/game/lesson_map.html
@@ -253,7 +253,7 @@ background-size:60px 60px;
 <body>
 
 <a href="/" class="back-btn">
-← Back to Lessons
+← Back to Home
 </a>
 
 <div class="header">

--- a/game/templates/game/lesson_map.html
+++ b/game/templates/game/lesson_map.html
@@ -273,7 +273,7 @@ background-size:60px 60px;
     </div>
 
     <p>
-        {{ completed_lessons|length }} / 12 Lessons Completed
+        {{ completed_lessons|length }} / {{ total_lessons }} Lessons Completed
     </p>
 
 </div>

--- a/game/templates/game/lessons.html
+++ b/game/templates/game/lessons.html
@@ -256,6 +256,10 @@
     <p>Master chess from beginner to advanced lessons.</p>
 </div>
 
+<a href="{% url 'lesson_map' %}" class="btn btn-primary">
+    🗺️ View Learning Journey
+</a>
+
 <div class="progress-box">
     <div class="progress-header">
         <h2>Your Learning Progress</h2>

--- a/game/templates/game/lessons.html
+++ b/game/templates/game/lessons.html
@@ -256,10 +256,6 @@
     <p>Master chess from beginner to advanced lessons.</p>
 </div>
 
-<a href="{% url 'lesson_map' %}" class="btn btn-primary">
-    🗺️ View Learning Journey
-</a>
-
 <div class="progress-box">
     <div class="progress-header">
         <h2>Your Learning Progress</h2>

--- a/game/urls.py
+++ b/game/urls.py
@@ -42,7 +42,7 @@ urlpatterns = [
     
     # Features & Progressions
     path('leaderboard/', views.leaderboard_view, name='leaderboard'),
-    path('lessons/', views.lessons_view, name='lessons'),
+    path("lessons/", views.lesson_map_view, name="lessons"),
     path('lessons/<str:lesson_name>/', views.lesson_detail_view, name='lesson_detail'),
     path('lessons/<str:lesson_name>/complete/', views.complete_lesson, name='complete_lesson'),
     path("api/puzzle-stats/", views.puzzle_stats_view, name="puzzle_stats"),

--- a/game/views.py
+++ b/game/views.py
@@ -1608,6 +1608,8 @@ def get_unlocked_lessons(completed_lessons):
 
     for level_index, level in enumerate(LESSON_LEVELS):
         
+        lessons = level["lessons"]
+        
         previous_level_complete = True
 
         if level_index > 0:
@@ -1629,27 +1631,7 @@ def get_unlocked_lessons(completed_lessons):
     return unlocked
 
 def lessons_view(request):
-    lessons = {
-        "Beginner": [
-            "How Pieces Move",
-            "Check and Checkmate",
-            "Castling",
-            "Opening Principles",
-        ],
-        "Intermediate": [
-            "Forks",
-            "Pins",
-            "Skewers",
-            "Discovered Attacks",
-        ],
-        "Advanced": [
-            "Pawn Structures",
-            "King Safety",
-            "Piece Activity",
-            "Basic Endgames",
-        ],
-    }
-
+    
     completed_lessons = []
 
     if request.user.is_authenticated:

--- a/game/views.py
+++ b/game/views.py
@@ -1557,6 +1557,38 @@ _LESSON_NAMES = (
     "Basic Endgames",
 )
 
+LESSON_LEVELS = [
+    {
+        "id": 1,
+        "title": "Chess Fundamentals",
+        "lessons": [
+            "How Pieces Move",
+            "Check and Checkmate",
+            "Castling",
+            "Opening Principles",
+        ],
+    },
+    {
+        "id": 2,
+        "title": "Basic Tactics",
+        "lessons": [
+            "Forks",
+            "Pins",
+            "Skewers",
+            "Discovered Attacks",
+        ],
+    },
+    {
+        "id": 3,
+        "title": "Advanced Concepts",
+        "lessons": [
+            "Pawn Structures",
+            "King Safety",
+            "Piece Activity",
+            "Basic Endgames",
+        ],
+    },
+]
 
 def _lesson_name_from_slug(lesson_slug):
     for name in _LESSON_NAMES:
@@ -1570,6 +1602,35 @@ def _resolve_lesson_name(url_key):
         return url_key
     return _lesson_name_from_slug(url_key)
 
+
+def get_unlocked_lessons(completed_lessons):
+    unlocked = set()
+
+    for level_index, level in enumerate(LESSON_LEVELS):
+        lessons = level["lessons"]
+
+        if level_index == 0:
+            unlocked.add(lessons[0])
+
+        previous_level_complete = True
+
+        if level_index > 0:
+            previous_level = LESSON_LEVELS[level_index - 1]
+            previous_level_complete = all(
+                lesson in completed_lessons
+                for lesson in previous_level["lessons"]
+            )
+
+        if not previous_level_complete:
+            continue
+
+        for i, lesson in enumerate(lessons):
+            if i == 0:
+                unlocked.add(lesson)
+            elif lessons[i - 1] in completed_lessons:
+                unlocked.add(lesson)
+
+    return unlocked
 
 def lessons_view(request):
     lessons = {
@@ -1611,12 +1672,17 @@ def lessons_view(request):
     )
 
     completed_count = len(completed_lessons)
+    unlocked_lessons = get_unlocked_lessons(
+        completed_lessons
+    )
 
     return render(
         request,
         "game/lessons.html",
         {
             "lessons": lessons,
+            "lesson_levels": LESSON_LEVELS,
+            "unlocked_lessons": unlocked_lessons,
             "completed_lessons": completed_lessons,
             "total_lessons": total_lessons,
             "completed_count": completed_count
@@ -2393,6 +2459,36 @@ def complete_lesson(request, lesson_name):
     )
 
 
+def lesson_map_view(request):
+
+    completed_lessons = []
+
+    if request.user.is_authenticated:
+        completed_lessons = list(
+            LessonProgress.objects.filter(
+                user=request.user,
+                completed=True
+            ).values_list(
+                "lesson_name",
+                flat=True
+            )
+        )
+
+    unlocked_lessons = get_unlocked_lessons(
+        completed_lessons
+    )
+
+    return render(
+        request,
+        "game/lesson_map.html",
+        {
+            "levels": LESSON_LEVELS,
+            "completed_lessons": completed_lessons,
+            "unlocked_lessons": unlocked_lessons,
+        }
+    )
+    
+    
 @login_required
 def achievements_view(request):
     achievements = Achievement.objects.all().order_by(
@@ -2476,3 +2572,4 @@ def remove_featured_badge(request, badge_id):
     )
 
     return redirect("achievements")
+

--- a/game/views.py
+++ b/game/views.py
@@ -1607,11 +1607,7 @@ def get_unlocked_lessons(completed_lessons):
     unlocked = set()
 
     for level_index, level in enumerate(LESSON_LEVELS):
-        lessons = level["lessons"]
-
-        if level_index == 0:
-            unlocked.add(lessons[0])
-
+        
         previous_level_complete = True
 
         if level_index > 0:
@@ -1672,7 +1668,6 @@ def lessons_view(request):
         for level in LESSON_LEVELS
     )
     
-    completed_count = len(completed_lessons)
     unlocked_lessons = get_unlocked_lessons(
         completed_lessons
     )

--- a/game/views.py
+++ b/game/views.py
@@ -1666,11 +1666,12 @@ def lessons_view(request):
                 flat=True
             )
         )
+        
     total_lessons = sum(
-        len(lesson_list)
-        for lesson_list in lessons.values()
+        len(level["lessons"])
+        for level in LESSON_LEVELS
     )
-
+    
     completed_count = len(completed_lessons)
     unlocked_lessons = get_unlocked_lessons(
         completed_lessons
@@ -1680,12 +1681,10 @@ def lessons_view(request):
         request,
         "game/lessons.html",
         {
-            "lessons": lessons,
-            "lesson_levels": LESSON_LEVELS,
+            "levels": LESSON_LEVELS,
             "unlocked_lessons": unlocked_lessons,
             "completed_lessons": completed_lessons,
             "total_lessons": total_lessons,
-            "completed_count": completed_count
         }
     )
 
@@ -2487,15 +2486,15 @@ def lesson_map_view(request):
             "unlocked_lessons": unlocked_lessons,
         }
     )
-    
-    
+
+
 @login_required
 def achievements_view(request):
     achievements = Achievement.objects.all().order_by(
         "category",
         "title"
     )
-    
+
     unlocked = set(
         UserAchievement.objects.filter(
             user=request.user
@@ -2508,7 +2507,7 @@ def achievements_view(request):
     featured_badges = FeaturedBadge.objects.filter(
         user=request.user
     ).select_related("achievement")
-    
+
     return render(
         request,
         "game/achievements.html",
@@ -2518,6 +2517,7 @@ def achievements_view(request):
             "featured_badges": featured_badges,
         }
     )
+
 
 @login_required
 def feature_badge(request, achievement_id):
@@ -2559,6 +2559,7 @@ def feature_badge(request, achievement_id):
 
     return redirect("achievements")
 
+
 @login_required
 def remove_featured_badge(request, badge_id):
     FeaturedBadge.objects.filter(
@@ -2572,4 +2573,3 @@ def remove_featured_badge(request, badge_id):
     )
 
     return redirect("achievements")
-


### PR DESCRIPTION
## Summary

This PR introduces a **Level-Based Lesson Progression System** with an interactive learning map for chess lessons.

The existing lesson experience displayed lessons individually without a structured progression path. This update organizes lessons into levels and provides a visual learning journey that helps users track progress and advance through lessons in a more engaging way.

## Features Added

* Added level-wise lesson organization
* Implemented interactive lesson progression map
* Added zig-zag learning path layout
* Added lesson states:

  * Completed
  * Current/Unlocked
  * Locked
* Added lesson progression logic
* Added learning progress tracking
* Added responsive UI for desktop and mobile devices

## UI Improvements

* Chess-themed lesson nodes
* Visual lesson status indicators
* Level headers for better organization
* Progress section showing completed lessons
* Enhanced lesson cards with status badges
* Improved user navigation through lessons

## Testing

* Verified lesson map renders correctly
* Verified lesson navigation works
* Verified completed and locked lesson states
* Verified responsive layout behavior
* Verified lesson progression workflow
* Confirmed no runtime/template errors during local testing

## Related Issue

Closes #1702
