### PR TITLE
docs: Update README API endpoints reference.

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,9 @@ Checkora features a decoupled API layer. Below is the endpoint catalog accompani
 | `POST` | `/api/resign/` | Resign the current game | `/api/resign/` |
 | `POST` | `/api/draw/` | Offer or accept a draw in PvP mode | `/api/draw/` |
 | `GET` | `/api/check-username/` | Check if a username is available | `/api/check-username/?username=player1` |
+| `POST` | `/api/analyze-game/` | Analyze a completed game and return statistics | `/api/analyze-game/` |
+| `GET` | `/api/puzzle-stats/` | Retrieve puzzle streak and statistics | `/api/puzzle-stats/` |
+| `POST` | `/api/cron/cleanup-stale-games/` | Secure cron-triggered cleanup for abandoned games | `/api/cron/cleanup-stale-games/` |
 
 ---
 
@@ -457,6 +460,65 @@ Resets current session variables and starts a fresh match.
   "move_history": [],
   "captured_pieces": {"white": [], "black": []},
   "mode": "ai"
+}
+```
+
+#### 6. Analyze Game (`POST /api/analyze-game/`)
+Analyzes a completed game based on its move history and returns statistics.
+
+**Request Body:**
+
+```json
+{
+  "moves": ["e4", "e5", "Nf3", "Nc6"],
+  "result": "White wins",
+  "reason": "checkmate"
+}
+```
+
+**Response (Success - `200 OK`):**
+
+```json
+{
+  "opening": "Italian Game",
+  "result": "White wins",
+  "total_moves": 2,
+  "captures": 0,
+  "checks": 0,
+  "checkmates": 0,
+  "promotions": 0,
+  "end_reason": "checkmate"
+}
+```
+
+#### 7. Get Puzzle Stats (`GET /api/puzzle-stats/`)
+Returns puzzle streak information for the puzzle interface.
+
+**Response (Success - `200 OK`):**
+
+```json
+{
+  "streak": 0,
+  "longest_streak": 0
+}
+```
+
+#### 8. Cleanup Cron (`POST /api/cron/cleanup-stale-games/`)
+Secure cron-triggered cleanup endpoint for abandoned games.
+
+**Request Headers:**
+
+```http
+Authorization: Bearer <cron_secret>
+```
+
+**Response (Success - `200 OK`):**
+
+```json
+{
+  "status": "success",
+  "deleted_games": 2,
+  "resigned_games": 1
 }
 ```
 


### PR DESCRIPTION
## Description

This PR updates `README.md` to include all missing REST API endpoints that are implemented in the codebase but were not documented in the API Reference section. 

Added the following endpoints to the API catalog table and added Request/Response JSON Examples for each:
- `POST /api/analyze-game/` - Analyzes game history and returns summary statistics.
- `GET /api/puzzle-stats/` - Retrieves current and longest puzzle streaks.
- `POST /api/cron/cleanup-stale-games/` - Secure cron-triggered cleanup for abandoned games.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Related Issue

Fixes #1754 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

N/A (Documentation changes only)

## Additional Notes

These documentation changes help contributors understand and integrate with the complete set of game endpoints.