### PR TITLE
docs: add architecture diagram to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,14 @@ Checkora/
 
 Checkora uses a clean three-layer architecture:
 
+```mermaid
+flowchart TD
+    Browser["Browser (JS / HTML / CSS)"] --> Django["Django Views (views.py)"]
+    Django --> Wrapper["ChessGame Wrapper (engine.py)"]
+    Wrapper --> Cpp["C++ Binary (main.exe / main)"]
+    Wrapper --> Python["Python Script (main.py)"]
+```
+
 ```
 Browser (JS/HTML/CSS)
        |


### PR DESCRIPTION
## Summary\n- Add a Mermaid architecture diagram to the README so the Browser -> Django -> engine flow is visible at a glance\n- Keep the existing text architecture table in place for readers who prefer the prose version\n\nCloses #1774\n\n## Verification\n- 