### PR TITLE
feat: expand chess learning curriculum (#1769)

### DIFF
--- a/game/static/game/js/lesson_practice.js
+++ b/game/static/game/js/lesson_practice.js
@@ -284,7 +284,15 @@ document.addEventListener(
             B: "♗",
             R: "♖",
             Q: "♕",
-            K: "♔"
+            K: "♔",
+
+            p: "♟",
+            n: "♞",
+            b: "♝",
+            r: "♜",
+            q: "♛",
+            k: "♚",
+            
         };
 
         board.innerHTML = "";

--- a/game/static/game/js/lesson_practice.js
+++ b/game/static/game/js/lesson_practice.js
@@ -286,12 +286,6 @@ document.addEventListener(
             Q: "♕",
             K: "♔",
 
-            p: "♟",
-            n: "♞",
-            b: "♝",
-            r: "♜",
-            q: "♛",
-            k: "♚",
             
         };
 

--- a/game/static/game/js/lesson_practice.js
+++ b/game/static/game/js/lesson_practice.js
@@ -68,6 +68,10 @@ function getPawnMoves(square) {
             file + (rank + 1)
         );
     }
+    
+    if (rank === 2) {
+        moves.push(file + (rank + 2));
+    }
 
     return moves;
 }

--- a/game/views.py
+++ b/game/views.py
@@ -2407,7 +2407,7 @@ def lesson_detail_view(request, lesson_name):
                     "title": "En Passant Opportunity",
                     "position": {
                         "e5": "P",
-                        "d5": "p"
+                        "d5": "P"
                     },
                     "highlight": ["d6"]
                 }
@@ -2420,7 +2420,7 @@ def lesson_detail_view(request, lesson_name):
             ],
             "practice_position": {
                 "e5": "P",
-                "d5": "p"
+                "d5": "P"
             }
         },
 
@@ -2769,7 +2769,7 @@ def lesson_detail_view(request, lesson_name):
                     "title": "Deflect the Rook",
                     "position": {
                         "d8": "R",
-                        "d7": "q"
+                        "d7": "Q"
                     },
                     "highlight": ["d8"]
                 }
@@ -2783,7 +2783,7 @@ def lesson_detail_view(request, lesson_name):
             "practice_position": {
                 "d1": "Q",
                 "d8": "R",
-                "d7": "q"
+                "d7": "Q"
             }
         },
 
@@ -2812,7 +2812,7 @@ def lesson_detail_view(request, lesson_name):
                     "title": "Decoy the King",
                     "position": {
                         "g7": "Q",
-                        "h8": "k"
+                        "h8": "K"
                     },
                     "highlight": ["g7"]
                 }
@@ -2825,7 +2825,7 @@ def lesson_detail_view(request, lesson_name):
             ],
             "practice_position": {
                 "g7": "Q",
-                "h8": "k"
+                "h8": "K"
             }
         },
         

--- a/game/views.py
+++ b/game/views.py
@@ -1922,7 +1922,7 @@ LESSON_LEVELS = [
             "Check and Checkmate",
             "Castling",
             "Opening Principles",
-           "Chess Notation",
+            "Chess Notation",
             "Piece Values",
             "En Passant",
             "Pawn Promotion",
@@ -2407,7 +2407,7 @@ def lesson_detail_view(request, lesson_name):
                     "title": "En Passant Opportunity",
                     "position": {
                         "e5": "P",
-                        "d5": "P"
+                        "d5": "p"
                     },
                     "highlight": ["d6"]
                 }
@@ -2420,7 +2420,7 @@ def lesson_detail_view(request, lesson_name):
             ],
             "practice_position": {
                 "e5": "P",
-                "d5": "P"
+                "d5": "p"
             }
         },
 
@@ -2725,7 +2725,7 @@ def lesson_detail_view(request, lesson_name):
                 {
                     "title": "Remove the Defender",
                     "position": {
-                        "d8": "Q",
+                        "d8": "q",
                         "d7": "R"
                     },
                     "highlight": ["d7"]
@@ -2740,7 +2740,7 @@ def lesson_detail_view(request, lesson_name):
             "practice_position": {
                 "d1": "Q",
                 "d7": "R",
-                "d8": "Q"
+                "d8": "q"
             }
         },
 
@@ -2769,7 +2769,7 @@ def lesson_detail_view(request, lesson_name):
                     "title": "Deflect the Rook",
                     "position": {
                         "d8": "R",
-                        "d7": "Q"
+                        "d7": "q"
                     },
                     "highlight": ["d8"]
                 }
@@ -2783,7 +2783,7 @@ def lesson_detail_view(request, lesson_name):
             "practice_position": {
                 "d1": "Q",
                 "d8": "R",
-                "d7": "Q"
+                "d7": "q"
             }
         },
 
@@ -2812,7 +2812,7 @@ def lesson_detail_view(request, lesson_name):
                     "title": "Decoy the King",
                     "position": {
                         "g7": "Q",
-                        "h8": "K"
+                        "h8": "k"
                     },
                     "highlight": ["g7"]
                 }
@@ -2825,7 +2825,7 @@ def lesson_detail_view(request, lesson_name):
             ],
             "practice_position": {
                 "g7": "Q",
-                "h8": "K"
+                "h8": "k"
             }
         },
         

--- a/game/views.py
+++ b/game/views.py
@@ -1893,10 +1893,20 @@ _LESSON_NAMES = (
     "Check and Checkmate",
     "Castling",
     "Opening Principles",
+    "Chess Notation",
+    "Piece Values",
+    "En Passant",
+    "Pawn Promotion",
+    
     "Forks",
     "Pins",
     "Skewers",
     "Discovered Attacks",
+    "Double Attacks",
+    "Removing the Defender",
+    "Deflection",
+    "Decoy",
+
     "Pawn Structures",
     "King Safety",
     "Piece Activity",
@@ -1912,6 +1922,10 @@ LESSON_LEVELS = [
             "Check and Checkmate",
             "Castling",
             "Opening Principles",
+           "Chess Notation",
+            "Piece Values",
+            "En Passant",
+            "Pawn Promotion",
         ],
     },
     {
@@ -1922,6 +1936,10 @@ LESSON_LEVELS = [
             "Pins",
             "Skewers",
             "Discovered Attacks",
+            "Double Attacks",
+            "Removing the Defender",
+            "Deflection",
+            "Decoy",
         ],
     },
     {
@@ -2282,6 +2300,170 @@ def lesson_detail_view(request, lesson_name):
             },
         },
 
+        "Chess Notation": {
+            "title": "Chess Notation",
+            "description": "Learn how chess moves are recorded.",
+            "practice_question": "What does Nf3 mean?",
+            "practice_answer": "Knight moves to f3.",
+            "quiz_question": "Which letter represents the King?",
+            "quiz_options": [
+                "Q",
+                "K",
+                "N",
+                "R"
+            ],
+            "quiz_answer": "K",
+            "content": [
+                "Chess notation records every move in a game.",
+                "Files are labeled a through h.",
+                "Ranks are labeled 1 through 8.",
+                "Pieces use letter abbreviations.",
+                "Notation helps analyze games."
+            ],
+            "board_examples": [
+                {
+                    "title": "Square e4",
+                    "position": {
+                        "e4": "P"
+                    },
+                    "highlight": ["e4"]
+                }
+            ],
+            "lesson_steps": [
+                {
+                    "instruction": "Move the pawn from e2 to e4.",
+                    "expected_move": "e2-e4"
+                }
+            ],
+            "practice_position": {
+                "e2": "P"
+            }
+        },
+
+        "Piece Values": {
+            "title": "Piece Values",
+            "description": "Understand the relative value of pieces.",
+            "practice_question": "Which piece is usually worth 9 points?",
+            "practice_answer": "Queen",
+            "quiz_question": "How many points is a rook worth?",
+            "quiz_options": [
+                "3",
+                "5",
+                "9",
+                "1"
+            ],
+            "quiz_answer": "5",
+            "content": [
+                "Pawn = 1 point.",
+                "Knight = 3 points.",
+                "Bishop = 3 points.",
+                "Rook = 5 points.",
+                "Queen = 9 points.",
+                "King is invaluable."
+            ],
+            "board_examples": [
+                {
+                    "title": "Major Pieces",
+                    "position": {
+                        "d1": "Q",
+                        "a1": "R"
+                    },
+                    "highlight": ["d1", "a1"]
+                }
+            ],
+            "lesson_steps": [
+                {
+                    "instruction": "Move the queen from d1 to d4.",
+                    "expected_move": "d1-d4"
+                }
+            ],
+            "practice_position": {
+                "d1": "Q"
+            }
+        },
+
+        "En Passant": {
+            "title": "En Passant",
+            "description": "Learn the special pawn capture rule.",
+            "practice_question": "When can en passant be played?",
+            "practice_answer": "Immediately after a pawn advances two squares.",
+            "quiz_question": "How long is an en passant opportunity available?",
+            "quiz_options": [
+                "One move",
+                "Two moves",
+                "Forever",
+                "Until capture"
+            ],
+            "quiz_answer": "One move",
+            "content": [
+                "En passant is a special pawn capture.",
+                "It occurs after an enemy pawn advances two squares.",
+                "The capture must be immediate.",
+                "The captured pawn is removed.",
+                "The opportunity disappears after one move."
+            ],
+            "board_examples": [
+                {
+                    "title": "En Passant Opportunity",
+                    "position": {
+                        "e5": "P",
+                        "d5": "P"
+                    },
+                    "highlight": ["d6"]
+                }
+            ],
+            "lesson_steps": [
+                {
+                    "instruction": "Capture the pawn en passant.",
+                    "expected_move": "d5-d6"
+                }
+            ],
+            "practice_position": {
+                "e5": "P",
+                "d5": "P"
+            }
+        },
+
+        "Pawn Promotion": {
+            "title": "Pawn Promotion",
+            "description": "Promote a pawn when it reaches the final rank.",
+            "practice_question": "What piece is most commonly chosen during promotion?",
+            "practice_answer": "Queen",
+            "quiz_question": "When can a pawn be promoted?",
+            "quiz_options": [
+                "At the 5th rank",
+                "At the 6th rank",
+                "At the 8th rank",
+                "After capturing"
+            ],
+            "quiz_answer": "At the 8th rank",
+            "content": [
+                "A pawn promotes upon reaching the last rank.",
+                "Promotion usually becomes a queen.",
+                "You may choose rook, bishop, knight, or queen.",
+                "Promotion can decide games.",
+                "Always look for promotion opportunities."
+            ],
+            "board_examples": [
+                {
+                    "title": "Promotion Square",
+                    "position": {
+                        "g7": "P"
+                    },
+                    "highlight": ["g8"]
+                }
+            ],
+            "lesson_steps": [
+                {
+                    "instruction": "Move the pawn from g7 to g8.",
+                    "expected_move": "g7-g8"
+                }
+            ],
+            "practice_position": {
+                "g7": "P"
+            }
+        },
+        
         "Forks": {
             "title": "Forks",
             "description": "Attack multiple pieces with one move.",
@@ -2475,6 +2657,178 @@ def lesson_detail_view(request, lesson_name):
             }
         },
 
+        "Double Attacks": {
+            "title": "Double Attacks",
+            "description": "Attack two targets at the same time.",
+            "practice_question": "What is the goal of a double attack?",
+            "practice_answer": "To attack multiple targets simultaneously.",
+            "quiz_question": "A fork is a type of?",
+            "quiz_options": [
+                "Pin",
+                "Double Attack",
+                "Skewer",
+                "Promotion"
+            ],
+            "quiz_answer": "Double Attack",
+            "content": [
+                "A double attack threatens two targets at once.",
+                "Forks are common examples of double attacks.",
+                "Double attacks often win material.",
+                "Look for overloaded defenders.",
+                "Knights excel at double attacks."
+            ],
+            "board_examples": [
+                {
+                    "title": "Knight Double Attack",
+                    "position": {
+                        "e5": "N",
+                        "d7": "Q",
+                        "f7": "R"
+                    },
+                    "highlight": ["d7", "f7"]
+                }
+            ],
+            "lesson_steps": [
+                {
+                    "instruction": "Move the knight from e5 to c6 and attack two pieces.",
+                    "expected_move": "e5-c6"
+                }
+            ],
+            "practice_position": {
+                "e5": "N",
+                "d8": "Q",
+                "e8": "K"
+            }
+        },
+
+        "Removing the Defender": {
+            "title": "Removing the Defender",
+            "description": "Eliminate a key defending piece.",
+            "practice_question": "Why remove a defender?",
+            "practice_answer": "To make another piece vulnerable.",
+            "quiz_question": "What happens after removing a defender?",
+            "quiz_options": [
+                "The defended piece becomes vulnerable",
+                "The king castles",
+                "A pawn promotes",
+                "The game ends"
+            ],
+            "quiz_answer": "The defended piece becomes vulnerable",
+            "content": [
+                "Many pieces rely on defenders.",
+                "Removing a defender creates tactical opportunities.",
+                "Captures often begin combinations.",
+                "Always identify key defenders.",
+                "Winning defenders wins material."
+            ],
+            "board_examples": [
+                {
+                    "title": "Remove the Defender",
+                    "position": {
+                        "d8": "Q",
+                        "d7": "R"
+                    },
+                    "highlight": ["d7"]
+                }
+            ],
+            "lesson_steps": [
+                {
+                    "instruction": "Capture the defending rook on d7.",
+                    "expected_move": "d1-d7"
+                }
+            ],
+            "practice_position": {
+                "d1": "Q",
+                "d7": "R",
+                "d8": "Q"
+            }
+        },
+
+        "Deflection": {
+            "title": "Deflection",
+            "description": "Force a piece away from an important square.",
+            "practice_question": "What is the purpose of deflection?",
+            "practice_answer": "To move a defender away from its duty.",
+            "quiz_question": "Deflection works by?",
+            "quiz_options": [
+                "Promoting a pawn",
+                "Moving a piece away from defense",
+                "Castling",
+                "Checking the king"
+            ],
+            "quiz_answer": "Moving a piece away from defense",
+            "content": [
+                "Deflection distracts a defending piece.",
+                "The defender abandons an important square.",
+                "This often wins material.",
+                "Deflection appears in many combinations.",
+                "Look for overloaded pieces."
+            ],
+            "board_examples": [
+                {
+                    "title": "Deflect the Rook",
+                    "position": {
+                        "d8": "R",
+                        "d7": "Q"
+                    },
+                    "highlight": ["d8"]
+                }
+            ],
+            "lesson_steps": [
+                {
+                    "instruction": "Move the queen to d8 and deflect the rook.",
+                    "expected_move": "d1-d8"
+                }
+            ],
+            "practice_position": {
+                "d1": "Q",
+                "d8": "R",
+                "d7": "Q"
+            }
+        },
+
+        "Decoy": {
+            "title": "Decoy",
+            "description": "Lure a piece onto a vulnerable square.",
+            "practice_question": "What is a decoy tactic?",
+            "practice_answer": "Luring a piece to an unfavorable square.",
+            "quiz_question": "What does a decoy do?",
+            "quiz_options": [
+                "Protects a pawn",
+                "Lures a piece",
+                "Promotes a pawn",
+                "Creates a draw"
+            ],
+            "quiz_answer": "Lures a piece",
+            "content": [
+                "A decoy lures a piece away.",
+                "The target is forced onto a bad square.",
+                "Decoys often lead to checkmate.",
+                "Sacrifices are common in decoy tactics.",
+                "Always look for forced responses."
+            ],
+            "board_examples": [
+                {
+                    "title": "Decoy the King",
+                    "position": {
+                        "g7": "Q",
+                        "h8": "K"
+                    },
+                    "highlight": ["g7"]
+                }
+            ],
+            "lesson_steps": [
+                {
+                    "instruction": "Sacrifice the queen on g8 to lure the king.",
+                    "expected_move": "g7-g8"
+                }
+            ],
+            "practice_position": {
+                "g7": "Q",
+                "h8": "K"
+            }
+        },
+        
         "Pawn Structures": {
             "title": "Pawn Structures",
             "description": "Understand how pawns shape the game.",
@@ -2724,7 +3078,12 @@ def lesson_detail_view(request, lesson_name):
         "Forks",
         "Pins",
         "Skewers",
-        "Discovered Attacks"
+        "Discovered Attacks",
+        "Double Attacks",
+        "Removing the Defender",
+        "Deflection",
+        "Decoy",
+        
     ]:
         difficulty = "Intermediate"
 


### PR DESCRIPTION
## Summary

Expanded the chess learning curriculum by adding new beginner and tactical lessons.

### Added Lessons

#### Chess Fundamentals
- Chess Notation
- Piece Values
- En Passant
- Pawn Promotion

#### Basic Tactics
- Double Attacks
- Removing the Defender
- Deflection
- Decoy

### Improvements
- Added lesson content
- Added board examples
- Added practice positions
- Added interactive lesson steps
- Added quizzes and practice exercises

Closes #1769