### PR TITLE
fix: resolve replay system race condition

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -3254,21 +3254,25 @@
             // start autoplay
             playReplayBtn.textContent = '⏸';
 
-            autoReplayInterval = setInterval(() => {
-
+            // 1. Define a function that plays a single move and schedules the next one
+            const playNextMove = () => {
+                // Check if we reached the end of the game
                 if (replayIndex >= replayMoves.length) {
-
-                    clearInterval(autoReplayInterval);
                     autoReplayInterval = null;
-
                     playReplayBtn.textContent = '▶';
-
                     return;
                 }
+
+                // Advance the index and play the move
                 replayIndex++;
                 goToReplayMove(replayIndex);
 
-            }, 1000);
+                // Schedule the NEXT move 1000ms (1 second) from now.
+                autoReplayInterval = setTimeout(playNextMove, 1000);
+            };
+
+            // 2. Kick off the chain reaction
+            autoReplayInterval = setTimeout(playNextMove, 1000);
         };
     }
 
@@ -3276,25 +3280,30 @@
         playReplayBtn.onclick = () => {
 
             if (autoReplayInterval) {
-                clearInterval(autoReplayInterval);
+                clearTimeout(autoReplayInterval);
                 autoReplayInterval = null;
                 playReplayBtn.textContent = '▶';
                 return;
             }
             playReplayBtn.textContent = '⏸';
 
-            autoReplayInterval = setInterval(() => {
-
+            // 1. Define the relay race function
+            const playNextMove = () => {
                 if (replayIndex >= replayMoves.length) {
-                    clearInterval(autoReplayInterval);
                     autoReplayInterval = null;
                     playReplayBtn.textContent = '▶';
                     return;
                 }
+
                 replayIndex++;
                 goToReplayMove(replayIndex);
 
-            }, 1000);
+                // Schedule the next move only after this one is triggered
+                autoReplayInterval = setTimeout(playNextMove, 1000);
+            };
+
+            // 2. Kick off the chain reaction
+            autoReplayInterval = setTimeout(playNextMove, 1000);
         };
     }
 
@@ -4127,31 +4136,31 @@
 
     if (leaveConfirmNo) leaveConfirmNo.addEventListener('click', closeLeaveConfirm);
 
-            // Theme Switcher
-            function initThemeSwitcher() {
-                const themeBtns = document.querySelectorAll('.theme-btn');
-                const currentTheme = document.documentElement.getAttribute('data-board-theme') || 'classic';
-                document.documentElement.setAttribute('data-board-theme', currentTheme);
+    // Theme Switcher
+    function initThemeSwitcher() {
+        const themeBtns = document.querySelectorAll('.theme-btn');
+        const currentTheme = document.documentElement.getAttribute('data-board-theme') || 'classic';
+        document.documentElement.setAttribute('data-board-theme', currentTheme);
 
-                themeBtns.forEach(btn => {
-                    if (btn.dataset.theme === currentTheme) {
-                        btn.classList.add('active');
-                        btn.setAttribute('aria-pressed', 'true');
-                    }
-                    btn.onclick = () => {
-                        const theme = btn.dataset.theme;
-                        document.documentElement.setAttribute('data-board-theme', theme);
-                        localStorage.setItem('boardTheme', theme);
-                        localStorage.setItem('chessBoardTheme', theme);
-                        themeBtns.forEach(b => {
-                            b.classList.remove('active');
-                            b.setAttribute('aria-pressed', 'false');
-                        });
-                        btn.classList.add('active');
-                        btn.setAttribute('aria-pressed', 'true');
-                    };
-                });
+        themeBtns.forEach(btn => {
+            if (btn.dataset.theme === currentTheme) {
+                btn.classList.add('active');
+                btn.setAttribute('aria-pressed', 'true');
             }
+            btn.onclick = () => {
+                const theme = btn.dataset.theme;
+                document.documentElement.setAttribute('data-board-theme', theme);
+                localStorage.setItem('boardTheme', theme);
+                localStorage.setItem('chessBoardTheme', theme);
+                themeBtns.forEach(b => {
+                    b.classList.remove('active');
+                    b.setAttribute('aria-pressed', 'false');
+                });
+                btn.classList.add('active');
+                btn.setAttribute('aria-pressed', 'true');
+            };
+        });
+    }
 
     function showAssetWarning() {
         const t = document.getElementById('confirmTimerContainer');

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -646,7 +646,7 @@
     let replayIndex = 0;
     let replayBoard = null;
     let autoReplayInterval = null;
-
+    let isAutoReplaying = false;
     let pgnDownloadTimeout = null;
     let fenCopyTimeout = null;
     /* ==========================================================
@@ -3280,17 +3280,22 @@
         playReplayBtn.onclick = () => {
 
             if (autoReplayInterval) {
+                isAutoReplaying = false;
                 clearTimeout(autoReplayInterval);
                 autoReplayInterval = null;
                 playReplayBtn.textContent = '▶';
                 return;
             }
             playReplayBtn.textContent = '⏸';
+            isAutoReplaying = true;
 
             // 1. Define the relay race function
             const playNextMove = () => {
+                if (!isAutoReplaying) return;
+
                 if (replayIndex >= replayMoves.length) {
                     autoReplayInterval = null;
+                    isAutoReplaying = false;
                     playReplayBtn.textContent = '▶';
                     return;
                 }
@@ -3299,11 +3304,15 @@
                 goToReplayMove(replayIndex);
 
                 // Schedule the next move only after this one is triggered
-                autoReplayInterval = setTimeout(playNextMove, 1000);
+                if (isAutoReplaying) {
+                    autoReplayInterval = setTimeout(playNextMove, 1000);
+                }
             };
 
             // 2. Kick off the chain reaction
-            autoReplayInterval = setTimeout(playNextMove, 1000);
+            if (isAutoReplaying) {
+                autoReplayInterval = setTimeout(playNextMove, 1000);
+            }
         };
     }
 


### PR DESCRIPTION
## Description

This PR resolves a race condition in the game replay/autoplay functionality where the playback would randomly stop before finishing the game. 

The issue was caused by a rigid `setInterval` timer that blindly triggered the next move every 1 second, regardless of whether the previous move's animation or engine evaluation had finished. When the board state fell behind the move list, the loop silently crashed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #1799

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally