### PR TITLE
fix: DOM-based XSS via innerHTML in board.js and toast.js

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -987,11 +987,24 @@
                     const moveNum = Math.floor(whiteIdx / 2) + 1;
                     const row = document.createElement('div');
                     row.className = 'move-row';
-                    row.innerHTML = `
-                        <span class="move-num">${moveNum}.</span>
-                        <span class="move-white">${history[whiteIdx]?.notation ?? ''}</span>
-                        ${history[blackIdx] ? `<span class="move-black">${history[blackIdx].notation}</span>` : ''}
-                    `;
+
+                    const numSpan = document.createElement('span');
+                    numSpan.className = 'move-num';
+                    numSpan.textContent = `${moveNum}.`;
+                    row.appendChild(numSpan);
+
+                    const whiteSpan = document.createElement('span');
+                    whiteSpan.className = 'move-white';
+                    whiteSpan.textContent = history[whiteIdx]?.notation ?? '';
+                    row.appendChild(whiteSpan);
+
+                    if (history[blackIdx]) {
+                        const blackSpan = document.createElement('span');
+                        blackSpan.className = 'move-black';
+                        blackSpan.textContent = history[blackIdx].notation;
+                        row.appendChild(blackSpan);
+                    }
+
                     movesEl.appendChild(row);
                 }
             }

--- a/game/static/game/js/toast.js
+++ b/game/static/game/js/toast.js
@@ -37,8 +37,10 @@
 
         toast.innerHTML = `
             <span class="toast-icon">${icons[type] || icons.info}</span>
-            <span class="toast-message">${message}</span>
+            <span class="toast-message"></span>
         `;
+
+        toast.querySelector('.toast-message').textContent = message;
 
         container.appendChild(toast);
 


### PR DESCRIPTION
Two security fixes:

## board.js (Closes #1827)
Replaced innerHTML template literal interpolation of `history[].notation` with proper DOM construction using `textContent`. This prevents XSS injection through crafted PGN data containing malicious HTML/scripts.

## toast.js (Closes #1828)
Moved the user-controlled `message` variable from innerHTML to `textContent` to prevent XSS injection through toast messages.