### PR TITLE
fix: enforce SECRET_KEY and CRON_SECRET in production

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/6.0/ref/settings/
 import os
 from pathlib import Path
 from dotenv import load_dotenv
+from django.core.exceptions import ImproperlyConfigured
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -24,11 +25,16 @@ load_dotenv(BASE_DIR / '.env')
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/6.0/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get('SECRET_KEY', 'django-insecure-dev-key-for-local-testing')
-
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get('DEBUG', 'True').lower() == 'true'
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = os.environ.get('SECRET_KEY')
+if not SECRET_KEY:
+    if DEBUG:
+        SECRET_KEY = 'django-insecure-dev-key-for-local-testing'
+    else:
+        raise ImproperlyConfigured('SECRET_KEY environment variable is required in production')
 
 ALLOWED_HOSTS = ['.vercel.app', '*']
 
@@ -165,3 +171,5 @@ SECURE_HSTS_PRELOAD = True
 
 # Secret token for authenticating Vercel cron job requests to /api/cron/cleanup-stale-games/
 CRON_SECRET = os.environ.get('CRON_SECRET')
+if not CRON_SECRET and not DEBUG:
+    raise ImproperlyConfigured('CRON_SECRET environment variable is required in production')

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -987,11 +987,24 @@
                     const moveNum = Math.floor(whiteIdx / 2) + 1;
                     const row = document.createElement('div');
                     row.className = 'move-row';
-                    row.innerHTML = `
-                        <span class="move-num">${moveNum}.</span>
-                        <span class="move-white">${history[whiteIdx]?.notation ?? ''}</span>
-                        ${history[blackIdx] ? `<span class="move-black">${history[blackIdx].notation}</span>` : ''}
-                    `;
+
+                    const numSpan = document.createElement('span');
+                    numSpan.className = 'move-num';
+                    numSpan.textContent = `${moveNum}.`;
+                    row.appendChild(numSpan);
+
+                    const whiteSpan = document.createElement('span');
+                    whiteSpan.className = 'move-white';
+                    whiteSpan.textContent = history[whiteIdx]?.notation ?? '';
+                    row.appendChild(whiteSpan);
+
+                    if (history[blackIdx]) {
+                        const blackSpan = document.createElement('span');
+                        blackSpan.className = 'move-black';
+                        blackSpan.textContent = history[blackIdx].notation;
+                        row.appendChild(blackSpan);
+                    }
+
                     movesEl.appendChild(row);
                 }
             }

--- a/game/static/game/js/toast.js
+++ b/game/static/game/js/toast.js
@@ -37,8 +37,10 @@
 
         toast.innerHTML = `
             <span class="toast-icon">${icons[type] || icons.info}</span>
-            <span class="toast-message">${message}</span>
+            <span class="toast-message"></span>
         `;
+
+        toast.querySelector('.toast-message').textContent = message;
 
         container.appendChild(toast);
 


### PR DESCRIPTION
Two security fixes:

## SECRET_KEY (Closes #1829)
Removed the hardcoded fallback `django-insecure-dev-key-for-local-testing`. The key is now only defaulted in DEBUG mode; production deployments must set SECRET_KEY via environment variable or get an ImproperlyConfigured error.

## CRON_SECRET (Closes #1830)
Added validation that CRON_SECRET is set in production. If missing, raises ImproperlyConfigured to prevent unauthenticated cron job access.

Also moved DEBUG before SECRET_KEY to fix a reference-before-assignment issue.