### PR TITLE
fix: remove duplicate AI thinking indicator during AI turns

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1720,14 +1720,12 @@
         const seq = ++aiRequestSeq;
         aiThinking = true;
 
-        // fix: animated thinking dots
-        let dots = 1;
+        // AI state is already shown in the turn badge
         const thinkingInterval = setInterval(() => {
-            if (!aiThinking) { clearInterval(thinkingInterval); return; }
-            showStatus('AI is thinking' + '.'.repeat(dots), false);
-            dots = (dots % 3) + 1;
+            if (!aiThinking) {
+                clearInterval(thinkingInterval);
+            }
         }, 400);
-
         try {
             let piecesOnBoard = 0;
             for (let r = 0; r < 8; r++) {

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1720,12 +1720,7 @@
         const seq = ++aiRequestSeq;
         aiThinking = true;
 
-        // AI state is already shown in the turn badge
-        const thinkingInterval = setInterval(() => {
-            if (!aiThinking) {
-                clearInterval(thinkingInterval);
-            }
-        }, 400);
+       
         try {
             let piecesOnBoard = 0;
             for (let r = 0; r < 8; r++) {
@@ -1742,19 +1737,13 @@
             await new Promise(resolve => setTimeout(resolve, delay));
 
             // Abort if a new game started, reconnect happened, or another request took over during delay
-            if (seq !== aiRequestSeq) {
-                clearInterval(thinkingInterval);
-                return;
-            }
+            if (seq !== aiRequestSeq) return;
 
             // fix: abort if game ended during delay
-            if (gameOver) {
-                clearInterval(thinkingInterval);
-                return;
-            }
+            if (gameOver) return;
 
             const data = await post('/api/ai-move/', {});
-            clearInterval(thinkingInterval); // fix: clear after API call completes, not before
+            
 
             // Abort if sequence is no longer current after API call completes
             if (seq !== aiRequestSeq) {
@@ -1840,10 +1829,9 @@
             } else {
                 showStatus(data.message, true);
             }
-        } catch (e) {
-            clearInterval(thinkingInterval);
-            await handleReconnect();
-        } finally {
+            } catch (e) {
+                await handleReconnect();
+            } finally {
             // always reset aiThinking... a stale sequence means a newer request owns it, but it will set its own flag
             aiThinking = false;
         }


### PR DESCRIPTION
## Description

Removes the duplicate "AI is thinking..." message displayed during AI turns.

### Changes Made
- Removed the redundant AI thinking status update from the game status banner.
- Kept the turn badge indicator to communicate AI thinking state.
- Reduced UI clutter by ensuring only one AI status indicator is shown.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #1851 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

## Screenshots (if applicable)

<img width="1247" height="889" alt="Screenshot 2026-06-14 at 12 35 00 AM" src="https://github.com/user-attachments/assets/becbfd2d-bc81-4abb-867f-95dcfe7bb529" />

### Before
Two identical "AI is thinking..." indicators were displayed simultaneously:
- Game status banner above the board
- Turn badge below the board

### After
Only a single "AI is thinking..." indicator is displayed through the turn badge, reducing UI clutter while keeping the AI state clear to the user.

## Additional Notes

This change is limited to the AI thinking state UI. The duplicate status message from the game status banner was removed while retaining the existing turn badge indicator. No gameplay logic was modified.
