### PR TITLE
chore: Add .editorconfig for consistent coding styles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.js]
+indent_size = 2
+
+[*.json]
+indent_size = 2
+
+[*.html]
+indent_size = 2
+
+[*.css]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
## Summary
Adds .editorconfig to maintain consistent formatting across different editors and IDEs.

## Config
- 4-space indent for Python (PEP 8)
- 2-space indent for JS/JSON/HTML/CSS
- LF line endings
- UTF-8 charset
- Trim trailing whitespace
- Insert final newline

## Benefits
- Consistent formatting for all contributors
- Reduces diff noise from editor inconsistencies