### PR TITLE
templates: Fix start lesson button navigation.

### DIFF
--- a/game/templates/game/lesson_map.html
+++ b/game/templates/game/lesson_map.html
@@ -325,10 +325,10 @@ background-size:60px 60px;
                             </span>
 
                         {% elif lesson in unlocked_lessons %}
-                            <span class="badge active">
-                                Start Lesson
-                            </span>
-
+                            <a href="{% url 'lesson_detail' lesson|slugify %}"
+                            class="badge active">
+                            Start Lesson
+                            </a>
                         {% else %}
                             <span class="badge locked-badge">
                                 Locked


### PR DESCRIPTION
## Description

This PR fixes the issue where the **Start Lesson** button on the Lessons page was not navigating users to the corresponding lesson content.

Previously, only the lesson icon was clickable, while the Start Lesson button appeared interactive but did not perform any action. This change makes the button navigate to the same lesson page as the lesson icon.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

## Related Issue

Fixes #1856

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [ ] I have commented my code where necessary
* [ ] I have updated the documentation if needed
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix/feature works
* [x] New and existing tests pass locally

## Additional Notes

Tested locally and verified that:

* Clicking the lesson icon opens the lesson page.
* Clicking the Start Lesson button now correctly opens the lesson page.
* No UI/layout issues were introduced.
