### PR TITLE
fixed contrast bug on light mode on the learn more cards

### DIFF
--- a/game/static/game/css/landing.css
+++ b/game/static/game/css/landing.css
@@ -1410,6 +1410,22 @@ body {
 [data-theme="light"] .faq-answer-content {
     color: #374151;
 }
+
+/* --- light-mode overrides for dark-only components --- */
+
+[data-theme="light"] .about-bento-card.highlight-accent {
+    background: linear-gradient(145deg, var(--card-bg), rgba(0, 0, 0, 0.03));
+    border-color: var(--card-border);
+}
+
+[data-theme="light"] .btn-secondary-ghost {
+    border-color: rgba(0, 0, 0, 0.15);
+}
+
+[data-theme="light"] .btn-secondary-ghost:hover {
+    background-color: rgba(0, 0, 0, 0.04);
+}
+
 .modal-scroll-content {
     scrollbar-width: thin;
     scrollbar-color: var(--accent-gold) #131522;


### PR DESCRIPTION
## Description

Fixed an issue with poor contrast on feature cards in learn more cards in light mode.

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #1875

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [X] New and existing tests pass locally

## Screenshots (if applicable)

<img width="1448" height="691" alt="image" src="https://github.com/user-attachments/assets/9a70d59d-b774-41a8-8853-92360b6830fa" />


