### PR TITLE
fix: add IP/CIDR validation for TRUSTED_PROXIES (#1887)

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -228,6 +228,20 @@ CRON_SECRET = os.environ.get('CRON_SECRET')
 # Trusted proxies for client IP extraction from X-Forwarded-For header
 TRUSTED_PROXIES = os.environ.get('TRUSTED_PROXIES', '127.0.0.1,::1').split(',')
 TRUSTED_PROXIES = [ip.strip() for ip in TRUSTED_PROXIES if ip.strip()]
+_invalid_trusted_proxies = []
+for _entry in TRUSTED_PROXIES:
+    try:
+        ipaddress.ip_address(_entry)
+    except ValueError:
+        try:
+            ipaddress.ip_network(_entry, strict=False)
+        except ValueError:
+            _invalid_trusted_proxies.append(_entry)
+if _invalid_trusted_proxies:
+    raise ImproperlyConfigured(
+        "TRUSTED_PROXIES contains invalid IP/CIDR values: "
+        + ", ".join(_invalid_trusted_proxies)
+    )
 
 # Trusted proxies for password reset rate limiting client IP extraction
 _trusted_proxy_ips_raw = [


### PR DESCRIPTION
Fixes #1887

TRUSTED_PROXY_IPS already validates each entry via ip_network() and raises ImproperlyConfigured for invalid values. Apply the same validation to TRUSTED_PROXIES so garbage values, empty strings, and malformed IPs are caught at startup instead of silently accepted.