### PR TITLE
fix: raise ImproperlyConfigured when DEFAULT_FROM_EMAIL is empty (#1886)

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -207,6 +207,12 @@ EMAIL_HOST_USER = os.getenv('EMAIL_HOST_USER', '')
 EMAIL_HOST_PASSWORD = os.getenv('EMAIL_HOST_PASSWORD', '')
 DEFAULT_FROM_EMAIL = os.getenv('DEFAULT_FROM_EMAIL') or EMAIL_HOST_USER
 
+if not DEFAULT_FROM_EMAIL:
+    raise ImproperlyConfigured(
+        "Neither DEFAULT_FROM_EMAIL nor EMAIL_HOST_USER is set. "
+        "At least one must be configured to send outgoing emails."
+    )
+
 
 # Redirect after login
 LOGIN_URL = 'login'


### PR DESCRIPTION
Fixes #1886

When neither DEFAULT_FROM_EMAIL nor EMAIL_HOST_USER is configured, DEFAULT_FROM_EMAIL silently resolves to an empty string, causing all outgoing emails (OTP, password reset, welcome) to fail with no warning.

Raise ImproperlyConfigured at startup so the misconfiguration is caught immediately instead of failing silently at runtime.