### PR TITLE
fix: resolve light mode contrast on feature cards and Learn More button (#1875)

### DIFF
--- a/game/static/game/css/landing.css
+++ b/game/static/game/css/landing.css
@@ -622,7 +622,7 @@ body {
     text-decoration: none;
     background-color: transparent;
     color: var(--text-primary);
-    border: 1px solid rgba(255, 255, 255, 0.15);
+    border: 1px solid var(--border-color);
     backdrop-filter: blur(4px);
     -webkit-backdrop-filter: blur(4px);
     transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
@@ -799,8 +799,8 @@ body {
 
 /* Subtle accent focus on the primary technical engine feature */
 .about-bento-card.highlight-accent {
-    background: linear-gradient(145deg, var(--card-bg), #1a1a32);
-    border-color: rgba(255, 255, 255, 0.08);
+    background: linear-gradient(145deg, var(--card-bg), var(--bg-primary));
+    border-color: var(--border-color);
 }
 
 .about-bento-card.highlight-accent:hover {


### PR DESCRIPTION
Fixes #1875

Replace hardcoded #1a1a32 and rgba(255,255,255,0.15) with CSS custom properties so that:
- .about-bento-card.highlight-accent adapts its gradient end color to the current theme
- .btn-secondary-ghost border is visible in both themes (was invisible white-on-white in light mode)

In light mode, #1a1a32 on a white card caused dark text to become unreadable, and a white-border-on-white-background made the Learn More button appear borderless.