### PR TITLE
test: add CSRF enforcement verification tests for analyze_game_view

### DIFF
--- a/game/test_analysis.py
+++ b/game/test_analysis.py
@@ -1,5 +1,5 @@
 import json
-from django.test import TestCase, override_settings
+from django.test import TestCase, Client, override_settings
 from django.urls import reverse
 from game.views import MAX_ANALYSIS_MOVES, MAX_MOVE_LENGTH
 from game.analysis import (
@@ -185,3 +185,51 @@ class AnalysisTest(TestCase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertIn('total_moves', data)
+
+
+@override_settings(SECURE_SSL_REDIRECT=False)
+class AnalyzeGameCsrfTest(TestCase):
+    """Verify that CSRF protection is enforced on analyze_game_view."""
+
+    def setUp(self):
+        from django.contrib.auth.models import User
+        self.user = User.objects.create_user(
+            username='csrfuser', password='password123'
+        )
+
+    def test_post_without_csrf_token_is_rejected(self):
+        """POST without a CSRF token must return 403."""
+        csrf_client = Client(enforce_csrf_checks=True)
+        csrf_client.force_login(self.user)
+
+        response = csrf_client.post(
+            reverse('analyze_game'),
+            data=json.dumps({
+                'moves': ['e4', 'e5'],
+                'result': 'Win',
+                'reason': 'Checkmate',
+            }),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_post_with_valid_csrf_token_succeeds(self):
+        """POST with a valid X-CSRFToken header must return 200."""
+        csrf_client = Client(enforce_csrf_checks=True)
+        csrf_client.force_login(self.user)
+
+        # Fetch a CSRF cookie by hitting a GET endpoint
+        csrf_client.get(reverse('index'))
+        token = csrf_client.cookies.get('csrftoken').value
+
+        response = csrf_client.post(
+            reverse('analyze_game'),
+            data=json.dumps({
+                'moves': ['e4', 'e5'],
+                'result': 'Win',
+                'reason': 'Checkmate',
+            }),
+            content_type='application/json',
+            HTTP_X_CSRFTOKEN=token,
+        )
+        self.assertEqual(response.status_code, 200)

--- a/game/test_analysis.py
+++ b/game/test_analysis.py
@@ -220,7 +220,7 @@ class AnalyzeGameCsrfTest(TestCase):
 
         # Fetch a CSRF cookie by hitting a GET endpoint
         csrf_client.get(reverse('index'))
-        token = csrf_client.cookies.get('csrftoken').value
+        token = csrf_client.cookies['csrftoken'].value
 
         response = csrf_client.post(
             reverse('analyze_game'),


### PR DESCRIPTION

## Description

This PR adds unit and integration tests to verify that CSRF protection is properly enforced on the `analyze_game_view` endpoint.

The added test suite `AnalyzeGameCsrfTest` (in `game/test_analysis.py`) verifies the following behaviors:
1. **test_post_without_csrf_token_is_rejected**: Ensures a POST request without a CSRF token is correctly rejected with a `403 Forbidden` status.
2. **test_post_with_valid_csrf_token_succeeds**: Verifies that a POST request containing a valid `X-CSRFToken` header successfully accesses the endpoint and returns a `200 OK` status.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality / tests)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #1784 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

N/A

## Additional Notes

- Python test suite (including Django & Selenium E2E tests) successfully ran 195/195 tests with 100% success.
- JS frontend unit tests successfully ran 17/17 tests with 100% success.
