### PR TITLE
fix: add IP format validation to TRUSTED_PROXIES setting (#1887)

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -228,6 +228,20 @@ CRON_SECRET = os.environ.get('CRON_SECRET')
 # Trusted proxies for client IP extraction from X-Forwarded-For header
 TRUSTED_PROXIES = os.environ.get('TRUSTED_PROXIES', '127.0.0.1,::1').split(',')
 TRUSTED_PROXIES = [ip.strip() for ip in TRUSTED_PROXIES if ip.strip()]
+_invalid_trusted_proxies = []
+for _entry in TRUSTED_PROXIES:
+    try:
+        ipaddress.ip_address(_entry)
+    except ValueError:
+        try:
+            ipaddress.ip_network(_entry, strict=False)
+        except ValueError:
+            _invalid_trusted_proxies.append(_entry)
+if _invalid_trusted_proxies:
+    raise ImproperlyConfigured(
+        "TRUSTED_PROXIES contains invalid IP/CIDR values: "
+        + ", ".join(_invalid_trusted_proxies)
+    )
 
 # Trusted proxies for password reset rate limiting client IP extraction
 _trusted_proxy_ips_raw = [


### PR DESCRIPTION
## Description
`TRUSTED_PROXY_IPS` has proper CIDR/IP validation using `ipaddress.ip_network()` and raises `ImproperlyConfigured` for invalid entries. However, `TRUSTED_PROXIES` (a separate setting used for client IP extraction) had no such validation — it just splits the string and accepts any value including invalid IPs, empty strings, or garbage values.

## Fix
Added validation for each entry in `TRUSTED_PROXIES` using `ipaddress.ip_address()` and `ipaddress.ip_network()`, raising `ImproperlyConfigured` for invalid values (matching the pattern used by `TRUSTED_PROXY_IPS`).

Closes #1887