### PR TITLE
fix: raise ImproperlyConfigured when DEFAULT_FROM_EMAIL is empty (#1886)

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -207,6 +207,12 @@ EMAIL_HOST_USER = os.getenv('EMAIL_HOST_USER', '')
 EMAIL_HOST_PASSWORD = os.getenv('EMAIL_HOST_PASSWORD', '')
 DEFAULT_FROM_EMAIL = os.getenv('DEFAULT_FROM_EMAIL') or EMAIL_HOST_USER
 
+if not DEFAULT_FROM_EMAIL:
+    raise ImproperlyConfigured(
+        "Neither DEFAULT_FROM_EMAIL nor EMAIL_HOST_USER is set. "
+        "At least one must be configured to send outgoing emails."
+    )
+
 
 # Redirect after login
 LOGIN_URL = 'login'


### PR DESCRIPTION
## Description
When neither `DEFAULT_FROM_EMAIL` nor `EMAIL_HOST_USER` is set in the .env file, `DEFAULT_FROM_EMAIL` silently resolves to an empty string. This causes all outgoing emails (OTP, password reset, welcome email) to fail silently.

## Fix
Added an `ImproperlyConfigured` check after the `DEFAULT_FROM_EMAIL` assignment, matching the validation pattern used by other settings. Developers are now immediately alerted if the email configuration is invalid.

Closes #1886