### PR TITLE
fix: prevent lost XP updates with atomic select_for_update (#1884)

### DIFF
--- a/game/progression.py
+++ b/game/progression.py
@@ -1,3 +1,5 @@
+from django.db import transaction
+
 from .models import UserProgress
 
 LEVEL_THRESHOLDS = {
@@ -33,15 +35,16 @@ def award_xp(user, amount: int) -> UserProgress:
             f"amount must be positive, got {amount}"
         )
         
-    progress, _ = UserProgress.objects.get_or_create(
-        user=user
-    )
+    with transaction.atomic():
+        progress, _ = UserProgress.objects.select_for_update().get_or_create(
+            user=user
+        )
 
-    progress.xp += amount
-    progress.level = calculate_level(
-        progress.xp
-    )
-    
-    progress.save()
+        progress.xp += amount
+        progress.level = calculate_level(
+            progress.xp
+        )
+        
+        progress.save()
 
     return progress


### PR DESCRIPTION
## Description
The XP progression system in `award_xp()` performed a non-atomic read-modify-write cycle on the `UserProgress` model. When multiple XP-granting events happened simultaneously (lesson completion, achievement unlock, puzzle completion), concurrent requests could overwrite each other, causing lost XP updates.

## Fix
- Wrapped the read-modify-write in `transaction.atomic()`
- Used `select_for_update()` to acquire a row-level lock on the `UserProgress` row
- This prevents concurrent writes from overwriting each other

Closes #1884