### PR TITLE
Improve back button styling on lesson map page

### DIFF
--- a/game/templates/game/lesson_map.html
+++ b/game/templates/game/lesson_map.html
@@ -223,11 +223,39 @@ background-size:60px 60px;
     z-index: 2;
 }
 
-.back-btn{
-    color:#f0c040;
-    text-decoration:none;
-    font-weight:bold;
-    margin-left:20px;
+.back-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    margin: 20px 0 0 20px;
+    padding: 0.6rem 1.2rem;
+
+    background: rgba(22, 22, 42, 0.6);
+    color: #ffffff;
+
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-decoration: none;
+
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 30px;
+
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+
+    transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.back-btn:hover {
+    color: #f0c040;
+    border-color: rgba(240, 192, 64, 0.3);
+
+    transform: translateX(-3px);
+
+    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.4);
 }
 
 @media(max-width:768px){


### PR DESCRIPTION
## Description

Updated the Back to Home button styling in `lesson_map.html` to improve its appearance and make it consistent with the application's existing design language. Replaced the plain text link styling with a ghost/outline button design inspired by the back button pattern used elsewhere in the project.

The updated button includes:
- Rounded pill-shaped appearance
- Subtle background and border styling
- Improved spacing and padding
- Smooth hover transition effects
- Gold accent color on hover for better visual feedback
- Better visual hierarchy while remaining clearly interactive

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #1820 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Screenshots
<img width="1366" height="728" alt="B2H fix" src="https://github.com/user-attachments/assets/a8454f77-fa6f-4aea-88c4-7634c9168f69" />


## Additional Notes

The styling was tested locally by running the Django development server and verifying the button appearance and functionality on the lesson map page.