### PR TITLE
templates: Add guest sign-in banner on lessons page

### DIFF
--- a/game/templates/game/lesson_map.html
+++ b/game/templates/game/lesson_map.html
@@ -346,7 +346,7 @@ background-size:60px 60px;
             <a href="{% url 'login' %}" class="alert-link">Sign in</a> or <a href="{% url 'register' %}" class="alert-link">create a free account</a> to save your lesson progress.
         </span>
     </div>
-    <button class="alert-close" onclick="dismissAlert()" aria-label="Close message">&times;</button>
+    <button class="alert-close" type="button" onclick="dismissAlert()" aria-label="Close message">&times;</button>
 </div>
 {% endif %}
 

--- a/game/templates/game/lesson_map.html
+++ b/game/templates/game/lesson_map.html
@@ -270,11 +270,85 @@ background-size:60px 60px;
         height:90px;
     }
 }
+
+.alert-banner {
+    background: linear-gradient(135deg, #2c1f00, #1b1300);
+    border: 1px solid #f0c040;
+    border-radius: 12px;
+    padding: 16px 20px;
+    margin: 20px 20px 0 20px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    box-shadow: 0 4px 20px rgba(240, 192, 64, 0.15);
+    animation: fadeIn 0.5s ease;
+}
+
+.alert-content {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.alert-banner a.alert-link {
+    color: #f0c040;
+    text-decoration: underline;
+    font-weight: 600;
+    transition: color 0.2s ease;
+}
+
+.alert-banner a.alert-link:hover {
+    color: #ffdf70;
+}
+
+.alert-text {
+    font-size: 1rem;
+    color: #e0e0e0;
+    line-height: 1.5;
+}
+
+.alert-icon {
+    font-size: 1.25rem;
+}
+
+.alert-close {
+    background: transparent;
+    border: none;
+    color: #bdbdbd;
+    font-size: 1.5rem;
+    cursor: pointer;
+    padding: 0 4px;
+    line-height: 1;
+    transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.alert-close:hover {
+    color: #ffffff;
+    transform: scale(1.1);
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(-10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
 </style>
 
 </head>
 
 <body>
+
+{% if not user.is_authenticated %}
+<div class="alert-banner" id="guest-alert">
+    <div class="alert-content">
+        <span class="alert-icon">💡</span>
+        <span class="alert-text">
+            <a href="{% url 'login' %}" class="alert-link">Sign in</a> or <a href="{% url 'register' %}" class="alert-link">create a free account</a> to save your lesson progress.
+        </span>
+    </div>
+    <button class="alert-close" onclick="dismissAlert()" aria-label="Close message">&times;</button>
+</div>
+{% endif %}
 
 <a href="{% url 'landing' %}" class="back-btn">
 ← Back to Home
@@ -380,6 +454,28 @@ background-size:60px 60px;
 
 </div>
 <script src="{% static 'game/js/roadmap_connectors.js' %}"></script>
-    
-    </body>
-    </html>
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        if (localStorage.getItem('lessons_guest_alert_dismissed') === 'true') {
+            var alert = document.getElementById('guest-alert');
+            if (alert) {
+                alert.style.display = 'none';
+            }
+        }
+    });
+
+    function dismissAlert() {
+        var alert = document.getElementById('guest-alert');
+        if (alert) {
+            alert.style.transition = 'opacity 0.3s ease, transform 0.3s ease';
+            alert.style.opacity = '0';
+            alert.style.transform = 'translateY(-10px)';
+            localStorage.setItem('lessons_guest_alert_dismissed', 'true');
+            setTimeout(function() {
+                alert.style.display = 'none';
+            }, 300);
+        }
+    }
+</script>
+</body>
+</html>

--- a/game/templates/game/lessons.html
+++ b/game/templates/game/lessons.html
@@ -320,7 +320,7 @@
             <a href="{% url 'login' %}" class="alert-link">Sign in</a> or <a href="{% url 'register' %}" class="alert-link">create a free account</a> to save your lesson progress.
         </span>
     </div>
-    <button class="alert-close" onclick="dismissAlert()" aria-label="Close message">&times;</button>
+    <button class="alert-close" type="button" onclick="dismissAlert()" aria-label="Close message">&times;</button>
 </div>
 {% endif %}
 

--- a/game/templates/game/lessons.html
+++ b/game/templates/game/lessons.html
@@ -246,10 +246,83 @@
             }
         }
 
+        .alert-banner {
+            background: linear-gradient(135deg, #2c1f00, #1b1300);
+            border: 1px solid #f0c040;
+            border-radius: 12px;
+            padding: 16px 20px;
+            margin-bottom: 30px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            box-shadow: 0 4px 20px rgba(240, 192, 64, 0.15);
+            animation: fadeIn 0.5s ease;
+        }
+
+        .alert-content {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+        }
+
+        .alert-banner a.alert-link {
+            color: #f0c040;
+            text-decoration: underline;
+            font-weight: 600;
+            transition: color 0.2s ease;
+        }
+
+        .alert-banner a.alert-link:hover {
+            color: #ffdf70;
+        }
+
+        .alert-text {
+            font-size: 1rem;
+            color: #e0e0e0;
+            line-height: 1.5;
+        }
+
+        .alert-icon {
+            font-size: 1.25rem;
+        }
+
+        .alert-close {
+            background: transparent;
+            border: none;
+            color: #bdbdbd;
+            font-size: 1.5rem;
+            cursor: pointer;
+            padding: 0 4px;
+            line-height: 1;
+            transition: color 0.2s ease, transform 0.2s ease;
+        }
+
+        .alert-close:hover {
+            color: #ffffff;
+            transform: scale(1.1);
+        }
+
+        @keyframes fadeIn {
+            from { opacity: 0; transform: translateY(-10px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
     </style>
 </head>
 
 <body>
+
+{% if not user.is_authenticated %}
+<div class="alert-banner" id="guest-alert">
+    <div class="alert-content">
+        <span class="alert-icon">💡</span>
+        <span class="alert-text">
+            <a href="{% url 'login' %}" class="alert-link">Sign in</a> or <a href="{% url 'register' %}" class="alert-link">create a free account</a> to save your lesson progress.
+        </span>
+    </div>
+    <button class="alert-close" onclick="dismissAlert()" aria-label="Close message">&times;</button>
+</div>
+{% endif %}
 
 <div class="hero">
     <h1>♟ Chess Learning Hub</h1>
@@ -355,5 +428,28 @@
 
 {% endfor %}
 
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        if (localStorage.getItem('lessons_guest_alert_dismissed') === 'true') {
+            var alert = document.getElementById('guest-alert');
+            if (alert) {
+                alert.style.display = 'none';
+            }
+        }
+    });
+
+    function dismissAlert() {
+        var alert = document.getElementById('guest-alert');
+        if (alert) {
+            alert.style.transition = 'opacity 0.3s ease, transform 0.3s ease';
+            alert.style.opacity = '0';
+            alert.style.transform = 'translateY(-10px)';
+            localStorage.setItem('lessons_guest_alert_dismissed', 'true');
+            setTimeout(function() {
+                alert.style.display = 'none';
+            }, 300);
+        }
+    }
+</script>
 </body>
 </html>

--- a/game/tests.py
+++ b/game/tests.py
@@ -2282,6 +2282,26 @@ class AdditionalViewsSecurityAndLessonsTest(TestCase):
         )
         self.assertEqual(response.status_code, 404)
 
+    def test_lessons_map_guest_user_shows_alert(self):
+        """Guest users should see the sign-in alert banner on the lessons map page."""
+        response = self.client.get(reverse('lessons'))
+        self.assertEqual(response.status_code, 200)
+        # Check that the alert is rendered
+        self.assertContains(response, 'id="guest-alert"')
+        self.assertContains(response, 'Sign in')
+        self.assertContains(response, 'create a free account')
+        self.assertContains(response, 'to save your lesson progress.')
+
+    def test_lessons_map_authenticated_user_hides_alert(self):
+        """Authenticated users should not see the sign-in alert banner on the lessons map page."""
+        User.objects.create_user(username='lesson_player', password='password123')
+        self.client.login(username='lesson_player', password='password123')
+        response = self.client.get(reverse('lessons'))
+        self.assertEqual(response.status_code, 200)
+        # Check that the alert is NOT rendered
+        self.assertNotContains(response, 'id="guest-alert"')
+        self.assertNotContains(response, 'to save your lesson progress.')
+
 
 @override_settings(CACHES={
     'default': {


### PR DESCRIPTION
## Description

When a guest (not logged in) user visits the Chess Lessons page, they can complete lessons, but their progress is silently lost on page refresh or navigation. This PR adds a responsive, dismissible, beautifully styled warning/alert banner at the top of the Chess Learning Journey page prompting unauthenticated users to sign in or create an account to save their lesson progress.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issue

Fixes #1842

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

*(N/A - Unit tests added and verified)*

## Additional Notes

The banner's dismiss state is persisted in `localStorage` so that once a guest dismisses it, it stays hidden across page reloads/navigating between lessons during their session, preventing annoying prompt repetitions.
