### PR TITLE
fix: make Start Lesson badge clickable and interactive

### DIFF
--- a/game/templates/game/lesson_map.html
+++ b/game/templates/game/lesson_map.html
@@ -1,357 +1,345 @@
 {% load static %}
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-<title>Learning Journey</title>
+    <title>Learning Journey</title>
 
-<style>
-body{
-    margin:0;
-    background:
-    linear-gradient(
-    45deg,
-    #111 25%,
-    #0f0f0f 25%,
-    #0f0f0f 50%,
-    #111 50%,
-    #111 75%,
-    #0f0f0f 75%
-    );
+    <style>
+      body {
+        margin: 0;
+        background: linear-gradient(
+          45deg,
+          #111 25%,
+          #0f0f0f 25%,
+          #0f0f0f 50%,
+          #111 50%,
+          #111 75%,
+          #0f0f0f 75%
+        );
 
-background-size:60px 60px;
-    color:white;
-    font-family:Segoe UI,sans-serif;
-}
+        background-size: 60px 60px;
+        color: white;
+        font-family:
+          Segoe UI,
+          sans-serif;
+      }
 
-.header{
-    text-align:center;
-    padding:30px;
-}
+      .header {
+        text-align: center;
+        padding: 30px;
+      }
 
-.header h1{
-    color:#f0c040;
-}
+      .header h1 {
+        color: #f0c040;
+      }
 
-.map-container{
-    max-width:900px;
-    margin:auto;
-    padding:20px;
-    position: relative;
-}
+      .map-container {
+        max-width: 900px;
+        margin: auto;
+        padding: 20px;
+        position: relative;
+      }
 
-.level-title{
-    text-align:center;
-    margin:80px 0 30px;
-    font-size:34px;
-    color:#f0c040;
-    font-weight:700;
-    text-shadow:0 0 15px rgba(240,192,64,.5);
-}
+      .level-title {
+        text-align: center;
+        margin: 80px 0 30px;
+        font-size: 34px;
+        color: #f0c040;
+        font-weight: 700;
+        text-shadow: 0 0 15px rgba(240, 192, 64, 0.5);
+      }
 
-.lesson-path{
-    display:flex;
-    flex-direction:column;
-    align-items:center;
-}
+      .lesson-path {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
 
-.lesson-row{
-    width:100%;
-    display:flex;
-    margin: 10px 0;
-}
+      .lesson-row {
+        width: 100%;
+        display: flex;
+        margin: 10px 0;
+      }
 
-.lesson-row.left{
-    justify-content:flex-start;
-    padding-left:120px;
-}
+      .lesson-row.left {
+        justify-content: flex-start;
+        padding-left: 120px;
+      }
 
-.lesson-row.right{
-    justify-content:flex-end;
-    padding-right:120px;
+      .lesson-row.right {
+        justify-content: flex-end;
+        padding-right: 120px;
+      }
 
-}
+      .node {
+        width: 60px;
+        height: 60px;
+        background: #2a2a35;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 24px;
+        border: 2px solid #444;
+        transition:
+          transform 0.3s,
+          box-shadow 0.3s;
+        text-decoration: none;
+        color: white;
+        position: relative;
+        z-index: 1;
+      }
 
-.node{
-    width: 60px;
-    height: 60px;
-    background: #2a2a35;
-    border-radius:50%;
-    display:flex;
-    align-items:center;
-    justify-content:center;
-    font-size:24px;
-    border: 2px solid #444;
-    transition: transform 0.3s, box-shadow 0.3s;
-    text-decoration:none;
-    color:white;
-    position: relative;
-    z-index: 1;
-}
+      .node:hover {
+        transform: scale(1.08);
+      }
 
-.node:hover{
-    transform:scale(1.08);
-}
+      .completed {
+        background: #22c55e;
+        box-shadow: 0 0 25px #22c55e;
+      }
 
-.completed{
-    background:#22c55e;
-    box-shadow:0 0 25px #22c55e;
-}
+      .current {
+        background: #3b82f6;
+        box-shadow: 0 0 25px #3b82f6;
+        border: 4px solid white;
+        transform: scale(1.12);
+        position: relative;
+      }
 
-.current{
-    background:#3b82f6;
-    box-shadow:0 0 25px #3b82f6;
-    border:4px solid white;
-    transform:scale(1.12);
-    position:relative;
-}
+      .current::before {
+        content: "NEXT";
+        position: absolute;
+        top: -12px;
+        background: white;
+        color: black;
+        font-size: 10px;
+        font-weight: 700;
+        padding: 4px 8px;
+        border-radius: 12px;
+      }
 
-.current::before{
-    content:"NEXT";
-    position:absolute;
-    top:-12px;
-    background:white;
-    color:black;
-    font-size:10px;
-    font-weight:700;
-    padding:4px 8px;
-    border-radius:12px;
-}
+      .locked {
+        background: #555;
+        cursor: not-allowed;
+      }
 
-.locked{
-    background:#555;
-    cursor:not-allowed;
-}
+      .lesson-name {
+        margin-top: 12px;
+        text-align: center;
+        width: 180px;
+        color: #ddd;
+      }
 
-.lesson-name{
-    margin-top:12px;
-    text-align:center;
-    width:180px;
-    color:#ddd;
-}
+      .lesson-card {
+        margin-top: 12px;
+        background: #181818;
+        border: 1px solid #2d2d2d;
+        border-radius: 16px;
+        padding: 12px;
+        width: 180px;
+        text-align: center;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+      }
 
-.lesson-card{
-    margin-top:12px;
-    background:#181818;
-    border:1px solid #2d2d2d;
-    border-radius:16px;
-    padding:12px;
-    width:180px;
-    text-align:center;
-    box-shadow:0 4px 12px rgba(0,0,0,.3);
-}
+      .lesson-card:hover {
+        border-color: #f0c040;
+        transform: translateY(-3px);
+      }
 
-.lesson-card:hover{
-    border-color:#f0c040;
-    transform:translateY(-3px);
-}
+      .lesson-card h3 {
+        margin: 0 0 12px;
+        color: white;
+        font-size: 18px;
+      }
 
-.lesson-card h3{
-    margin:0 0 12px;
-    color:white;
-    font-size:18px;
-}
+      .badge {
+        display: inline-block;
+        padding: 6px 12px;
+        border-radius: 20px;
+        font-size: 12px;
+        font-weight: 600;
+        cursor: pointer;
+        user-select: none;
+        text-decoration: none;
+      }
 
-.badge{
-    display:inline-block;
-    padding:6px 12px;
-    border-radius:20px;
-    font-size:12px;
-    font-weight:600;
-}
+      .done {
+        background: #22c55e;
+        color: white;
+      }
 
-.done{
-    background:#22c55e;
-    color:white;
-}
+      .active {
+        background: #3b82f6;
+        color: white;
+      }
 
-.active{
-    background:#3b82f6;
-    color:white;
-}
+      .locked-badge {
+        background: #555;
+        color: white;
+      }
 
-.locked-badge{
-    background:#555;
-    color:white;
-}
+      .node span {
+        font-size: 42px;
+      }
 
-.node span{
-    font-size:42px;
-}
+      .node.current {
+        border: 4px solid white;
+        transform: scale(1.15);
+      }
 
-.node.current{
-    border:4px solid white;
-    transform:scale(1.15);
-}
+      .progress-box {
+        max-width: 700px;
+        margin: 0 auto 60px;
+        background: linear-gradient(135deg, #181818, #242424);
+        padding: 25px;
+        border-radius: 24px;
+        border: 1px solid #2d2d2d;
+      }
 
-.progress-box{
-    max-width:700px;
-    margin:0 auto 60px;
-    background:linear-gradient(
-        135deg,
-        #181818,
-        #242424
-    );
-    padding:25px;
-    border-radius:24px;
-    border:1px solid #2d2d2d;
-}
+      .progress-track {
+        height: 12px;
+        background: #333;
+        border-radius: 20px;
+        overflow: hidden;
+      }
 
-.progress-track{
-    height:12px;
-    background:#333;
-    border-radius:20px;
-    overflow:hidden;
-}
+      .progress-fill {
+        height: 100%;
+        background: linear-gradient(90deg, #22c55e, #36e6c5);
+      }
 
-.progress-fill{
-    height:100%;
-    background:linear-gradient(
-        90deg,
-        #22c55e,
-        #36e6c5
-    );
-}
+      .lesson-wrapper {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        position: relative;
+        z-index: 2;
+      }
 
-.lesson-wrapper{
-    display:flex;
-    flex-direction:column;
-    align-items:center;
-    position: relative; 
-    z-index: 2;
-}
+      .back-btn {
+        color: #f0c040;
+        text-decoration: none;
+        font-weight: bold;
+        margin-left: 20px;
+      }
 
-.back-btn{
-    color:#f0c040;
-    text-decoration:none;
-    font-weight:bold;
-    margin-left:20px;
-}
+      @media (max-width: 768px) {
+        .lesson-row.left,
+        .lesson-row.right {
+          justify-content: center;
+        }
 
-@media(max-width:768px){
+        .node {
+          width: 90px;
+          height: 90px;
+        }
+      }
+    </style>
+  </head>
 
-    .lesson-row.left,
-    .lesson-row.right{
-        justify-content:center;
-    }
+  <body>
+    <a href="{% url 'landing' %}" class="back-btn"> ← Back to Home </a>
 
-    .node{
-        width:90px;
-        height:90px;
-    }
-}
-</style>
+    <div class="header">
+      <h1>🗺 Chess Learning Journey</h1>
+      <p>Complete lessons to unlock the next one.</p>
+    </div>
 
-</head>
+    <div class="progress-box">
+      <h3>Your Journey Progress</h3>
 
-<body>
-
-<a href="{% url 'landing' %}" class="back-btn">
-← Back to Home
-</a>
-
-<div class="header">
-    <h1>🗺 Chess Learning Journey</h1>
-    <p>Complete lessons to unlock the next one.</p>
-</div>
-
-<div class="progress-box">
-
-    <h3>Your Journey Progress</h3>
-
-    <div class="progress-track">
+      <div class="progress-track">
         <div
-            class="progress-fill"
-            style="width:{% widthratio completed_lessons|length 12 100 %}%">
-        </div>
-    </div>
+          class="progress-fill"
+          style="width:{% widthratio completed_lessons|length 12 100 %}%"
+        ></div>
+      </div>
 
-    <p>
+      <p>
         {{ completed_lessons|length }} / {{ total_lessons }} Lessons Completed
-    </p>
-
-</div>
-
-<div class="map-container">
-    <svg id="roadmap-connectors" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none; z-index: 0;"></svg>
-
-    {% for level in levels %}
-
-    <div class="level-title">
-        Level {{ level.id }} • {{ level.title }}
+      </p>
     </div>
 
-    <div class="lesson-path">
+    <div class="map-container">
+      <svg
+        id="roadmap-connectors"
+        style="
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          pointer-events: none;
+          z-index: 0;
+        "
+      ></svg>
 
+      {% for level in levels %}
+
+      <div class="level-title">Level {{ level.id }} • {{ level.title }}</div>
+
+      <div class="lesson-path">
         {% for lesson in level.lessons %}
 
-            <div class="lesson-row {% cycle 'left' 'right' %}">
+        <div class="lesson-row {% cycle 'left' 'right' %}">
+          <div class="lesson-wrapper">
+            {% if lesson in completed_lessons %}
 
-                <div class="lesson-wrapper">
+            <a
+              href="{% url 'lesson_detail' lesson|slugify %}"
+              class="node completed roadmap-node"
+            >
+              <span>♔</span>
+            </a>
 
-                    {% if lesson in completed_lessons %}
+            {% elif lesson in unlocked_lessons %}
 
-                        <a
-                            href="{% url 'lesson_detail' lesson|slugify %}"
-                            class="node completed roadmap-node">
-                            <span>♔</span>
-                        </a>
+            <a
+              href="{% url 'lesson_detail' lesson|slugify %}"
+              class="node current roadmap-node"
+            >
+              <span>♕</span>
+            </a>
 
-                    {% elif lesson in unlocked_lessons %}
+            {% else %}
 
-                        <a
-                            href="{% url 'lesson_detail' lesson|slugify %}"
-                            class="node current roadmap-node">
-                            <span>♕</span>
-                        </a>
-
-                    {% else %}
-
-                        <div class="node locked roadmap-node">
-                            <span>🔒</span>
-                        </div>
-
-                    {% endif %}
-
-                    <div class="lesson-card">
-
-                        <h3>{{ lesson }}</h3>
-
-                        {% if lesson in completed_lessons %}
-                            <span class="badge done">
-                                Completed
-                            </span>
-
-                        {% elif lesson in unlocked_lessons %}
-                            <span class="badge active">
-                                Start Lesson
-                            </span>
-
-                        {% else %}
-                            <span class="badge locked-badge">
-                                Locked
-                            </span>
-
-                        {% endif %}
-
-                    </div>
-
-                </div>
-
+            <div class="node locked roadmap-node">
+              <span>🔒</span>
             </div>
 
-           
+            {% endif %}
+
+            <div class="lesson-card">
+              <h3>{{ lesson }}</h3>
+
+              {% if lesson in completed_lessons %}
+              <span class="badge done"> Completed </span>
+
+              {% elif lesson in unlocked_lessons %}
+              <a
+                href="{% url 'lesson_detail' lesson|slugify %}"
+                class="badge active"
+              >
+                Start Lesson
+              </a>
+
+              {% else %}
+              <span class="badge locked-badge"> Locked </span>
+
+              {% endif %}
+            </div>
+          </div>
+        </div>
 
         {% endfor %}
+      </div>
 
+      {% endfor %}
     </div>
-
-{% endfor %}
-
-</div>
-<script src="{% static 'game/js/roadmap_connectors.js' %}"></script>
-    
-    </body>
-    </html>
+    <script src="{% static 'game/js/roadmap_connectors.js' %}"></script>
+  </body>
+</html>

--- a/game/templates/game/lesson_map.html
+++ b/game/templates/game/lesson_map.html
@@ -1,345 +1,360 @@
 {% load static %}
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <title>Learning Journey</title>
+<title>Learning Journey</title>
 
-    <style>
-      body {
-        margin: 0;
-        background: linear-gradient(
-          45deg,
-          #111 25%,
-          #0f0f0f 25%,
-          #0f0f0f 50%,
-          #111 50%,
-          #111 75%,
-          #0f0f0f 75%
-        );
+<style>
+body{
+    margin:0;
+    background:
+    linear-gradient(
+    45deg,
+    #111 25%,
+    #0f0f0f 25%,
+    #0f0f0f 50%,
+    #111 50%,
+    #111 75%,
+    #0f0f0f 75%
+    );
 
-        background-size: 60px 60px;
-        color: white;
-        font-family:
-          Segoe UI,
-          sans-serif;
-      }
+background-size:60px 60px;
+    color:white;
+    font-family:Segoe UI,sans-serif;
+}
 
-      .header {
-        text-align: center;
-        padding: 30px;
-      }
+.header{
+    text-align:center;
+    padding:30px;
+}
 
-      .header h1 {
-        color: #f0c040;
-      }
+.header h1{
+    color:#f0c040;
+}
 
-      .map-container {
-        max-width: 900px;
-        margin: auto;
-        padding: 20px;
-        position: relative;
-      }
+.map-container{
+    max-width:900px;
+    margin:auto;
+    padding:20px;
+    position: relative;
+}
 
-      .level-title {
-        text-align: center;
-        margin: 80px 0 30px;
-        font-size: 34px;
-        color: #f0c040;
-        font-weight: 700;
-        text-shadow: 0 0 15px rgba(240, 192, 64, 0.5);
-      }
+.level-title{
+    text-align:center;
+    margin:80px 0 30px;
+    font-size:34px;
+    color:#f0c040;
+    font-weight:700;
+    text-shadow:0 0 15px rgba(240,192,64,.5);
+}
 
-      .lesson-path {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-      }
+.lesson-path{
+    display:flex;
+    flex-direction:column;
+    align-items:center;
+}
 
-      .lesson-row {
-        width: 100%;
-        display: flex;
-        margin: 10px 0;
-      }
+.lesson-row{
+    width:100%;
+    display:flex;
+    margin: 10px 0;
+}
 
-      .lesson-row.left {
-        justify-content: flex-start;
-        padding-left: 120px;
-      }
+.lesson-row.left{
+    justify-content:flex-start;
+    padding-left:120px;
+}
 
-      .lesson-row.right {
-        justify-content: flex-end;
-        padding-right: 120px;
-      }
+.lesson-row.right{
+    justify-content:flex-end;
+    padding-right:120px;
 
-      .node {
-        width: 60px;
-        height: 60px;
-        background: #2a2a35;
-        border-radius: 50%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        font-size: 24px;
-        border: 2px solid #444;
-        transition:
-          transform 0.3s,
-          box-shadow 0.3s;
-        text-decoration: none;
-        color: white;
-        position: relative;
-        z-index: 1;
-      }
+}
 
-      .node:hover {
-        transform: scale(1.08);
-      }
+.node{
+    width: 60px;
+    height: 60px;
+    background: #2a2a35;
+    border-radius:50%;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    font-size:24px;
+    border: 2px solid #444;
+    transition: transform 0.3s, box-shadow 0.3s;
+    text-decoration:none;
+    color:white;
+    position: relative;
+    z-index: 1;
+}
 
-      .completed {
-        background: #22c55e;
-        box-shadow: 0 0 25px #22c55e;
-      }
+.node:hover{
+    transform:scale(1.08);
+}
 
-      .current {
-        background: #3b82f6;
-        box-shadow: 0 0 25px #3b82f6;
-        border: 4px solid white;
-        transform: scale(1.12);
-        position: relative;
-      }
+.completed{
+    background:#22c55e;
+    box-shadow:0 0 25px #22c55e;
+}
 
-      .current::before {
-        content: "NEXT";
-        position: absolute;
-        top: -12px;
-        background: white;
-        color: black;
-        font-size: 10px;
-        font-weight: 700;
-        padding: 4px 8px;
-        border-radius: 12px;
-      }
+.current{
+    background:#3b82f6;
+    box-shadow:0 0 25px #3b82f6;
+    border:4px solid white;
+    transform:scale(1.12);
+    position:relative;
+}
 
-      .locked {
-        background: #555;
-        cursor: not-allowed;
-      }
+.current::before{
+    content:"NEXT";
+    position:absolute;
+    top:-12px;
+    background:white;
+    color:black;
+    font-size:10px;
+    font-weight:700;
+    padding:4px 8px;
+    border-radius:12px;
+}
 
-      .lesson-name {
-        margin-top: 12px;
-        text-align: center;
-        width: 180px;
-        color: #ddd;
-      }
+.locked{
+    background:#555;
+    cursor:not-allowed;
+}
 
-      .lesson-card {
-        margin-top: 12px;
-        background: #181818;
-        border: 1px solid #2d2d2d;
-        border-radius: 16px;
-        padding: 12px;
-        width: 180px;
-        text-align: center;
-        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-      }
+.lesson-name{
+    margin-top:12px;
+    text-align:center;
+    width:180px;
+    color:#ddd;
+}
 
-      .lesson-card:hover {
-        border-color: #f0c040;
-        transform: translateY(-3px);
-      }
+.lesson-card{
+    margin-top:12px;
+    background:#181818;
+    border:1px solid #2d2d2d;
+    border-radius:16px;
+    padding:12px;
+    width:180px;
+    text-align:center;
+    box-shadow:0 4px 12px rgba(0,0,0,.3);
+}
 
-      .lesson-card h3 {
-        margin: 0 0 12px;
-        color: white;
-        font-size: 18px;
-      }
+.lesson-card:hover{
+    border-color:#f0c040;
+    transform:translateY(-3px);
+}
 
-      .badge {
-        display: inline-block;
-        padding: 6px 12px;
-        border-radius: 20px;
-        font-size: 12px;
-        font-weight: 600;
-        cursor: pointer;
-        user-select: none;
-        text-decoration: none;
-      }
+.lesson-card h3{
+    margin:0 0 12px;
+    color:white;
+    font-size:18px;
+}
 
-      .done {
-        background: #22c55e;
-        color: white;
-      }
+.badge{
+    display:inline-block;
+    padding:6px 12px;
+    border-radius:20px;
+    font-size:12px;
+    font-weight:600;
+    cursor: pointer;
+user-select: none;
+text-decoration: none;
+}
 
-      .active {
-        background: #3b82f6;
-        color: white;
-      }
+.done{
+    background:#22c55e;
+    color:white;
+}
 
-      .locked-badge {
-        background: #555;
-        color: white;
-      }
+.active{
+    background:#3b82f6;
+    color:white;
+}
 
-      .node span {
-        font-size: 42px;
-      }
+.locked-badge{
+    background:#555;
+    color:white;
+}
 
-      .node.current {
-        border: 4px solid white;
-        transform: scale(1.15);
-      }
+.node span{
+    font-size:42px;
+}
 
-      .progress-box {
-        max-width: 700px;
-        margin: 0 auto 60px;
-        background: linear-gradient(135deg, #181818, #242424);
-        padding: 25px;
-        border-radius: 24px;
-        border: 1px solid #2d2d2d;
-      }
+.node.current{
+    border:4px solid white;
+    transform:scale(1.15);
+}
 
-      .progress-track {
-        height: 12px;
-        background: #333;
-        border-radius: 20px;
-        overflow: hidden;
-      }
+.progress-box{
+    max-width:700px;
+    margin:0 auto 60px;
+    background:linear-gradient(
+        135deg,
+        #181818,
+        #242424
+    );
+    padding:25px;
+    border-radius:24px;
+    border:1px solid #2d2d2d;
+}
 
-      .progress-fill {
-        height: 100%;
-        background: linear-gradient(90deg, #22c55e, #36e6c5);
-      }
+.progress-track{
+    height:12px;
+    background:#333;
+    border-radius:20px;
+    overflow:hidden;
+}
 
-      .lesson-wrapper {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        position: relative;
-        z-index: 2;
-      }
+.progress-fill{
+    height:100%;
+    background:linear-gradient(
+        90deg,
+        #22c55e,
+        #36e6c5
+    );
+}
 
-      .back-btn {
-        color: #f0c040;
-        text-decoration: none;
-        font-weight: bold;
-        margin-left: 20px;
-      }
+.lesson-wrapper{
+    display:flex;
+    flex-direction:column;
+    align-items:center;
+    position: relative; 
+    z-index: 2;
+}
 
-      @media (max-width: 768px) {
-        .lesson-row.left,
-        .lesson-row.right {
-          justify-content: center;
-        }
+.back-btn{
+    color:#f0c040;
+    text-decoration:none;
+    font-weight:bold;
+    margin-left:20px;
+}
 
-        .node {
-          width: 90px;
-          height: 90px;
-        }
-      }
-    </style>
-  </head>
+@media(max-width:768px){
 
-  <body>
-    <a href="{% url 'landing' %}" class="back-btn"> ← Back to Home </a>
+    .lesson-row.left,
+    .lesson-row.right{
+        justify-content:center;
+    }
 
-    <div class="header">
-      <h1>🗺 Chess Learning Journey</h1>
-      <p>Complete lessons to unlock the next one.</p>
-    </div>
+    .node{
+        width:90px;
+        height:90px;
+    }
+}
+</style>
 
-    <div class="progress-box">
-      <h3>Your Journey Progress</h3>
+</head>
 
-      <div class="progress-track">
+<body>
+
+<a href="{% url 'landing' %}" class="back-btn">
+← Back to Home
+</a>
+
+<div class="header">
+    <h1>🗺 Chess Learning Journey</h1>
+    <p>Complete lessons to unlock the next one.</p>
+</div>
+
+<div class="progress-box">
+
+    <h3>Your Journey Progress</h3>
+
+    <div class="progress-track">
         <div
-          class="progress-fill"
-          style="width:{% widthratio completed_lessons|length 12 100 %}%"
-        ></div>
-      </div>
-
-      <p>
-        {{ completed_lessons|length }} / {{ total_lessons }} Lessons Completed
-      </p>
+            class="progress-fill"
+            style="width:{% widthratio completed_lessons|length 12 100 %}%">
+        </div>
     </div>
 
-    <div class="map-container">
-      <svg
-        id="roadmap-connectors"
-        style="
-          position: absolute;
-          top: 0;
-          left: 0;
-          width: 100%;
-          height: 100%;
-          pointer-events: none;
-          z-index: 0;
-        "
-      ></svg>
+    <p>
+        {{ completed_lessons|length }} / {{ total_lessons }} Lessons Completed
+    </p>
 
-      {% for level in levels %}
+</div>
 
-      <div class="level-title">Level {{ level.id }} • {{ level.title }}</div>
+<div class="map-container">
+    <svg id="roadmap-connectors" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none; z-index: 0;"></svg>
 
-      <div class="lesson-path">
+    {% for level in levels %}
+
+    <div class="level-title">
+        Level {{ level.id }} • {{ level.title }}
+    </div>
+
+    <div class="lesson-path">
+
         {% for lesson in level.lessons %}
 
-        <div class="lesson-row {% cycle 'left' 'right' %}">
-          <div class="lesson-wrapper">
-            {% if lesson in completed_lessons %}
+            <div class="lesson-row {% cycle 'left' 'right' %}">
 
-            <a
-              href="{% url 'lesson_detail' lesson|slugify %}"
-              class="node completed roadmap-node"
-            >
-              <span>♔</span>
-            </a>
+                <div class="lesson-wrapper">
 
-            {% elif lesson in unlocked_lessons %}
+                    {% if lesson in completed_lessons %}
 
-            <a
-              href="{% url 'lesson_detail' lesson|slugify %}"
-              class="node current roadmap-node"
-            >
-              <span>♕</span>
-            </a>
+                        <a
+                            href="{% url 'lesson_detail' lesson|slugify %}"
+                            class="node completed roadmap-node">
+                            <span>♔</span>
+                        </a>
 
-            {% else %}
+                    {% elif lesson in unlocked_lessons %}
 
-            <div class="node locked roadmap-node">
-              <span>🔒</span>
+                        <a
+                            href="{% url 'lesson_detail' lesson|slugify %}"
+                            class="node current roadmap-node">
+                            <span>♕</span>
+                        </a>
+
+                    {% else %}
+
+                        <div class="node locked roadmap-node">
+                            <span>🔒</span>
+                        </div>
+
+                    {% endif %}
+
+                    <div class="lesson-card">
+
+                        <h3>{{ lesson }}</h3>
+
+                        {% if lesson in completed_lessons %}
+                            <span class="badge done">
+                                Completed
+                            </span>
+
+                        {% elif lesson in unlocked_lessons %}
+                            <a href="{% url 'lesson_detail' lesson|slugify %}" class="badge active">
+    Start Lesson
+</a>
+
+                        {% else %}
+                            <span class="badge locked-badge">
+                                Locked
+                            </span>
+
+                        {% endif %}
+
+                    </div>
+
+                </div>
+
             </div>
 
-            {% endif %}
-
-            <div class="lesson-card">
-              <h3>{{ lesson }}</h3>
-
-              {% if lesson in completed_lessons %}
-              <span class="badge done"> Completed </span>
-
-              {% elif lesson in unlocked_lessons %}
-              <a
-                href="{% url 'lesson_detail' lesson|slugify %}"
-                class="badge active"
-              >
-                Start Lesson
-              </a>
-
-              {% else %}
-              <span class="badge locked-badge"> Locked </span>
-
-              {% endif %}
-            </div>
-          </div>
-        </div>
+           
 
         {% endfor %}
-      </div>
 
-      {% endfor %}
     </div>
-    <script src="{% static 'game/js/roadmap_connectors.js' %}"></script>
-  </body>
-</html>
+
+{% endfor %}
+
+</div>
+<script src="{% static 'game/js/roadmap_connectors.js' %}"></script>
+    
+    </body>
+    </html>


### PR DESCRIPTION
## Description

This PR fixes the "Start Lesson" badge behavior on the lesson roadmap.

### Changes
- Made the Start Lesson badge clickable by linking it to the lesson detail page.
- Added `cursor: pointer` for proper hover feedback.
- Added `user-select: none` to prevent accidental text selection.
- Added `text-decoration: none` to preserve badge styling.

### Result
Users can now launch lessons by clicking either the crown icon or the Start Lesson badge.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Documentation update

## Related

Fixes #1895

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
<img width="362" height="322" alt="image" src="https://github.com/user-attachments/assets/6ea11b1b-b626-419e-86f6-f63d719cca00" />
<img width="1170" height="93" alt="image" src="https://github.com/user-attachments/assets/e66f561b-f012-4d34-9966-42f5945193ac" />
