### PR TITLE
fix: Add PvP Game Summary to stats page

### DIFF
--- a/game/templates/game/stats.html
+++ b/game/templates/game/stats.html
@@ -216,6 +216,14 @@
             </div>
         </div>
 
+        <h2>PvP Game Summary</h2>
+        <div class="summary">
+            <div class="card"><div class="num">{{ pvp_total }}</div><div class="label">Total PvP Games</div></div>
+            <div class="card"><div class="num">{{ pvp_white_wins }}</div><div class="label">White Wins</div></div>
+            <div class="card"><div class="num">{{ pvp_black_wins }}</div><div class="label">Black Wins</div></div>
+            <div class="card"><div class="num">{{ pvp_draws }}</div><div class="label">Draws</div></div>
+        </div>
+
         <div style="text-align:center; margin-top:30px; margin-bottom:30px;">
             <a href="{% url 'achievements' %}" class="btn">🏆 View Achievements</a>
         </div>

--- a/game/tests.py
+++ b/game/tests.py
@@ -1351,8 +1351,8 @@ class StatsCleanupTest(TestCase):
         response = self.client.get('/stats/')
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'No Match Records Found')
-        # Summary cards should show 17 cards
-        self.assertContains(response, '<div class="num">0</div>', count=17)
+        # Summary cards should show 21 cards (17 original + 4 PvP cards)
+        self.assertContains(response, '<div class="num">0</div>', count=21)
         # No <tr> should be present in the tbody
         self.assertNotContains(response, '<tr><td>')
 
@@ -1374,10 +1374,32 @@ class StatsCleanupTest(TestCase):
         self.GameResult.objects.create(
             user=self.user_a, mode='ai', winner='draw', player_color='white', end_reason='stalemate'
         )
+        # User A plays PvP games:
+        # 1. White wins
+        self.GameResult.objects.create(
+            user=self.user_a, mode='pvp', winner='white', player_color='white', end_reason='checkmate'
+        )
+        # 2. Black wins
+        self.GameResult.objects.create(
+            user=self.user_a, mode='pvp', winner='black', player_color='white', end_reason='checkmate'
+        )
+        # 3. Black wins
+        self.GameResult.objects.create(
+            user=self.user_a, mode='pvp', winner='black', player_color='white', end_reason='checkmate'
+        )
+        # 4. Draw
+        self.GameResult.objects.create(
+            user=self.user_a, mode='pvp', winner='draw', player_color='white', end_reason='stalemate'
+        )
         # User B has 5 AI wins
         for _ in range(5):
             self.GameResult.objects.create(
                 user=self.user_b, mode='ai', winner='white', player_color='white', end_reason='checkmate'
+            )
+        # User B has 3 PvP games
+        for _ in range(3):
+            self.GameResult.objects.create(
+                user=self.user_b, mode='pvp', winner='white', player_color='white', end_reason='checkmate'
             )
 
         self.client.login(username='usera', password='password123')
@@ -1385,7 +1407,25 @@ class StatsCleanupTest(TestCase):
         self.assertContains(response, '<div class="num">4</div>')  # Total AI Games
         self.assertContains(response, '<div class="num">2</div>')  # User Wins vs AI
         self.assertContains(response, '<div class="num">1</div>')  # AI Wins
-        self.assertContains(response, '<div class="num">1</div>')  # Draws
+        # Assert AI draws and PvP draws count=2
+        self.assertContains(
+            response,
+            '<div class="card"><div class="num">1</div><div class="label">Draws</div></div>',
+            count=2
+        )
+        # Assert PvP specific cards
+        self.assertContains(
+            response,
+            '<div class="card"><div class="num">4</div><div class="label">Total PvP Games</div></div>'
+        )
+        self.assertContains(
+            response,
+            '<div class="card"><div class="num">1</div><div class="label">White Wins</div></div>'
+        )
+        self.assertContains(
+            response,
+            '<div class="card"><div class="num">2</div><div class="label">Black Wins</div></div>'
+        )
 
     def test_filter_invalid_records(self):
         """Records with empty mode should be filtered out."""

--- a/game/views.py
+++ b/game/views.py
@@ -1641,6 +1641,13 @@ def stats_view(request):
     # Handle explicit edge cases (e.g. division by zero for win rate)
     win_percentage = (user_ai_wins / ai_total * 100) if ai_total > 0 else 0
 
+    # PvP Statistics
+    pvp_results = user_results.filter(mode='pvp')
+    pvp_total = pvp_results.count()
+    pvp_white_wins = pvp_results.filter(winner='white').count()
+    pvp_black_wins = pvp_results.filter(winner='black').count()
+    pvp_draws = pvp_results.filter(winner='draw').count()
+
     rating, _ = PlayerRating.objects.get_or_create(
         user=request.user
     )
@@ -1749,6 +1756,11 @@ def stats_view(request):
         'progress': progress,
         'rating': rating,
         'history': recent_history,
+
+        'pvp_total': pvp_total,
+        'pvp_white_wins': pvp_white_wins,
+        'pvp_black_wins': pvp_black_wins,
+        'pvp_draws': pvp_draws,
         
         "total_games": total_games,
         "total_wins": total_wins,


### PR DESCRIPTION
## Description

This PR adds a "PvP Game Summary" section to the `/stats/` page. Currently, PvP (Pass & Play) games are listed in the recent games table but their summary statistics (Total PvP Games, White Wins, Black Wins, Draws) are not shown to the user. This fix aggregates these metrics in `views.stats_view` and displays them in a dedicated card section styled exactly like the existing AI summary cards.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #1911

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

*No visual styles were altered other than adding the PvP cards which follow existing layout rules.*
