### PR TITLE
feat: add opening trainer mode foundation

### DIFF
--- a/game/opening_trainer_data.py
+++ b/game/opening_trainer_data.py
@@ -1,0 +1,61 @@
+OPENINGS = [
+    {
+        "slug": "italian-game",
+        "name": "Italian Game",
+        "difficulty": "Beginner",
+        "description": "Rapid development and center control.",
+        "moves": [
+            "e4",
+            "e5",
+            "Nf3",
+            "Nc6",
+            "Bc4",
+            "Bc5",
+        ],
+    },
+    {
+        "slug": "ruy-lopez",
+        "name": "Ruy Lopez",
+        "difficulty": "Intermediate",
+        "description": "Pressure on Black's knight.",
+        "moves": [
+            "e4",
+            "e5",
+            "Nf3",
+            "Nc6",
+            "Bb5",
+        ],
+    },
+    {
+        "slug": "queens-gambit",
+        "name": "Queen's Gambit",
+        "difficulty": "Intermediate",
+        "description": "Control the center with pawns.",
+        "moves": [
+            "d4",
+            "d5",
+            "c4",
+        ],
+    },
+    {
+        "slug": "london-system",
+        "name": "London System",
+        "difficulty": "Beginner",
+        "description": "Solid and flexible setup.",
+        "moves": [
+            "d4",
+            "Nf6",
+            "Bf4",
+        ],
+    },
+    {
+        "slug": "sicilian-defense",
+        "name": "Sicilian Defense",
+        "difficulty": "Advanced",
+        "description": "Aggressive counterplay.",
+        "moves": [
+            "e4",
+            "c5",
+        ],
+    },
+]

--- a/game/static/game/css/opening_trainer.css
+++ b/game/static/game/css/opening_trainer.css
@@ -1,0 +1,65 @@
+body{
+    background:#111;
+    color:white;
+    font-family:Segoe UI,sans-serif;
+    padding:30px;
+}
+
+.container{
+    max-width:800px;
+    margin:auto;
+}
+
+.back-btn{
+    color:#f0c040;
+    text-decoration:none;
+}
+
+#trainer-feedback{
+    margin-top:20px;
+    padding:15px;
+    background:#222;
+    border-radius:10px;
+}
+
+#move-progress{
+    margin-top:10px;
+    color:#f0c040;
+}
+
+.opening-grid{
+    display:grid;
+    grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
+    gap:20px;
+    margin-top:30px;
+}
+
+.lesson-card{
+    background:#1a1a1a;
+    border:1px solid #333;
+    border-radius:12px;
+    padding:20px;
+}
+
+.start-btn{
+    display:inline-block;
+    margin-top:10px;
+    padding:10px 16px;
+    background:#f0c040;
+    color:black;
+    text-decoration:none;
+    border-radius:8px;
+    font-weight:bold;
+}
+
+#move-input {
+    padding: 10px;
+    width: 250px;
+    margin-top: 15px;
+}
+
+#check-move-btn {
+    padding: 10px 15px;
+    margin-left: 8px;
+    cursor: pointer;
+}

--- a/game/static/game/css/opening_trainer.css
+++ b/game/static/game/css/opening_trainer.css
@@ -1,7 +1,7 @@
 body{
     background:#111;
     color:white;
-    font-family:Segoe UI,sans-serif;
+    font-family:"Segoe UI", sans-serif;
     padding:30px;
 }
 

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1556,7 +1556,6 @@
                     `${toSquare(fr, fc)}-${toSquare(tr, tc)}`;
 
                 if (
-                    expectedMove &&
                     playedMove.toLowerCase() !== expectedMove.toLowerCase()
                 ) {
                     showStatus(

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -78,6 +78,11 @@
     let currentDifficulty = 'medium';
     let currentWhiteName = 'White';
     let currentBlackName = 'Black';
+
+    let openingTrainerMode = false;
+    let openingTrainerSteps = [];
+    let currentTrainerStep = 0;
+    
     // Updates UI to highlight selected game mode button
     function updateModeButtonsUI(mode) {
         const pvpBtn = document.getElementById("newPvPBtn");
@@ -1546,6 +1551,31 @@
             if (promotionPiece) body.promotion_piece = promotionPiece;
 
             const data = await post('/api/move/', body);
+
+            // Opening Trainer validation
+            if (openingTrainerMode) {
+                const expectedMove =
+                    openingTrainerSteps[currentTrainerStep]?.expected_move;
+
+                const playedMove =
+                    `${toSquare(fr, fc)}-${toSquare(tr, tc)}`;
+
+                if (
+                    expectedMove &&
+                    playedMove.toLowerCase() !== expectedMove.toLowerCase()
+                ) {
+                    showStatus(
+                        `Incorrect move. Expected: ${expectedMove}`,
+                        true
+                    );
+
+                    deselect();
+                    return;
+                }
+
+                currentTrainerStep++;
+            }
+
             if (data.valid) {
                 illegalMoveCount = 0;
                 playSound(data);

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1569,6 +1569,17 @@
                 }
 
                 currentTrainerStep++;
+                if (
+                    currentTrainerStep >=
+                    openingTrainerSteps.length
+                ) {
+                    openingTrainerMode = false;
+
+                    showStatus(
+                        "Opening sequence completed!",
+                        false
+                    );
+                }
             }
 
             if (data.valid) {

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -78,11 +78,6 @@
     let currentDifficulty = 'medium';
     let currentWhiteName = 'White';
     let currentBlackName = 'Black';
-
-    let openingTrainerMode = false;
-    let openingTrainerSteps = [];
-    let currentTrainerStep = 0;
-    
     // Updates UI to highlight selected game mode button
     function updateModeButtonsUI(mode) {
         const pvpBtn = document.getElementById("newPvPBtn");

--- a/game/static/game/js/opening_trainer.js
+++ b/game/static/game/js/opening_trainer.js
@@ -1,0 +1,97 @@
+const OPENING_MOVES = JSON.parse(
+    document.getElementById("opening-moves").textContent
+);
+
+let currentMove = 0;
+
+const feedback =
+    document.getElementById("trainer-feedback");
+
+const progress =
+    document.getElementById("move-progress");
+
+const moveInput =
+    document.getElementById("move-input");
+
+const checkButton =
+    document.getElementById("check-move-btn");
+
+
+function updateProgress() {
+    progress.innerText =
+        `${currentMove} / ${OPENING_MOVES.length}`;
+}
+
+
+function completeOpening() {
+    feedback.innerText =
+        "🎉 Opening completed successfully!";
+
+    moveInput.disabled = true;
+    checkButton.disabled = true;
+}
+
+
+function validateMove(move) {
+    const expectedMove =
+        OPENING_MOVES[currentMove];
+
+    if (move === expectedMove) {
+
+        currentMove++;
+
+        feedback.innerText =
+            "✅ Correct move!";
+
+        updateProgress();
+
+        moveInput.value = "";
+
+        if (
+            currentMove >=
+            OPENING_MOVES.length
+        ) {
+            completeOpening();
+        }
+
+        return true;
+    }
+
+    feedback.innerText =
+        `❌ Incorrect move. Expected: ${expectedMove}`;
+
+    return false;
+}
+
+
+checkButton.addEventListener(
+    "click",
+    () => {
+
+        const move =
+            moveInput.value.trim();
+
+        if (!move) {
+            feedback.innerText =
+                "Please enter a move.";
+
+            return;
+        }
+
+        validateMove(move);
+    }
+);
+
+
+moveInput.addEventListener(
+    "keypress",
+    (event) => {
+
+        if (event.key === "Enter") {
+            checkButton.click();
+        }
+    }
+);
+
+
+updateProgress();

--- a/game/static/game/js/opening_trainer.js
+++ b/game/static/game/js/opening_trainer.js
@@ -1,5 +1,14 @@
+const movesElement =
+    document.getElementById("opening-moves");
+
+if (!movesElement) {
+    throw new Error(
+        "opening-moves element not found"
+    );
+}
+
 const OPENING_MOVES = JSON.parse(
-    document.getElementById("opening-moves").textContent
+    movesElement.textContent
 );
 
 let currentMove = 0;
@@ -36,7 +45,7 @@ function validateMove(move) {
     const expectedMove =
         OPENING_MOVES[currentMove];
 
-    if (move === expectedMove) {
+    if (move.toLowerCase() === expectedMove.toLowerCase()) {
 
         currentMove++;
 

--- a/game/templates/game/opening_detail.html
+++ b/game/templates/game/opening_detail.html
@@ -1,0 +1,67 @@
+{% load static %}
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ opening.name }}</title>
+
+    <link
+        rel="stylesheet"
+        href="{% static 'game/css/opening_trainer.css' %}"
+    >
+</head>
+
+<body>
+
+<a href="{% url 'opening_trainer' %}" class="back-btn">
+    ← Back to Openings
+</a>
+
+<div class="container">
+
+    <h1>{{ opening.name }}</h1>
+
+    <p>{{ opening.description }}</p>
+
+    <p>
+        <strong>Difficulty:</strong>
+        {{ opening.difficulty }}
+    </p>
+
+    <div id="trainer-feedback" class="feedback-box">
+        Ready to begin.
+    </div>
+
+    <div class="progress-box">
+        <div id="move-progress">
+            0 / {{ opening.moves|length }}
+        </div>
+        <input
+            type="text"
+            id="move-input"
+            placeholder="Enter move (e4, Nf3...)"
+        />
+
+        <button id="check-move-btn">
+            Check Move
+        </button>
+    </div>
+
+    <h3>Opening Line</h3>
+
+    <ul>
+        {% for move in opening.moves %}
+        <li>{{ move }}</li>
+        {% endfor %}
+    </ul>
+
+</div>
+
+{{ opening.moves|json_script:"opening-moves" }}
+
+<script src="{% static 'game/js/opening_trainer.js' %}"></script>
+
+</body>
+</html>

--- a/game/templates/game/opening_detail.html
+++ b/game/templates/game/opening_detail.html
@@ -38,13 +38,18 @@
         <div id="move-progress">
             0 / {{ opening.moves|length }}
         </div>
+        <label for="move-input">
+            Enter Move
+        </label>
         <input
             type="text"
             id="move-input"
             placeholder="Enter move (e4, Nf3...)"
         />
 
-        <button id="check-move-btn">
+        <button 
+            type="button"
+            id="check-move-btn">
             Check Move
         </button>
     </div>

--- a/game/templates/game/opening_trainer.html
+++ b/game/templates/game/opening_trainer.html
@@ -1,0 +1,61 @@
+{% load static %}
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Opening Trainer</title>
+
+    <link
+        rel="stylesheet"
+        href="{% static 'game/css/opening_trainer.css' %}"
+    >
+</head>
+
+<body>
+
+<a href="{% url 'landing' %}" class="back-btn">
+    ← Back to Home
+</a>
+
+<div class="container">
+
+    <h1>♟ Opening Trainer</h1>
+
+    <p>
+        Practice popular chess openings move by move.
+    </p>
+
+    <div class="opening-grid">
+
+        {% for opening in openings %}
+
+        <div class="lesson-card">
+
+            <h2>{{ opening.name }}</h2>
+
+            <p>{{ opening.description }}</p>
+
+            <p>
+                <strong>Difficulty:</strong>
+                {{ opening.difficulty }}
+            </p>
+
+            <a
+                href="{% url 'opening_detail' opening.slug %}"
+                class="start-btn"
+            >
+                Start Training
+            </a>
+
+        </div>
+
+        {% endfor %}
+
+    </div>
+
+</div>
+
+</body>
+</html>

--- a/game/tests.py
+++ b/game/tests.py
@@ -2962,3 +2962,22 @@ class LeaderboardAndAchievementsViewOriginalTest(TestCase):
         self.assertTemplateUsed(response, 'game/achievements.html')
         self.assertContains(response, "Achievements Unlocked")
         self.assertContains(response, "No featured badges selected yet.")
+        
+    def test_opening_trainer_page(self):
+        response = self.client.get(
+            reverse("opening_trainer")
+        )
+
+        self.assertEqual(response.status_code, 200)
+    
+    def test_opening_detail_page(self):
+        response = self.client.get(
+            reverse(
+                "opening_detail",
+                kwargs={
+                    "slug": "italian-game"
+                }
+            )
+        )
+
+        self.assertEqual(response.status_code, 200)

--- a/game/urls.py
+++ b/game/urls.py
@@ -44,6 +44,12 @@ urlpatterns = [
     path("lessons/", views.lesson_map_view, name="lessons"),
     path('lessons/<str:lesson_name>/', views.lesson_detail_view, name='lesson_detail'),
     path('lessons/<str:lesson_name>/complete/', views.complete_lesson, name='complete_lesson'),
+    
+    # Opening Trainer
+    path("openings/", views.opening_trainer, name="opening_trainer"),
+    path("openings/<slug:slug>/", views.opening_detail, name="opening_detail"),
+    path("openings/", views.opening_trainer, name="opening_trainer"),
+    path("openings/<slug:slug>/", views.opening_detail, name="opening_detail"),
     path("api/puzzle-stats/", views.puzzle_stats_view, name="puzzle_stats"),
     path("api/puzzles/daily/", views.get_daily_puzzle, name="daily_puzzle"),
     

--- a/game/urls.py
+++ b/game/urls.py
@@ -48,8 +48,7 @@ urlpatterns = [
     # Opening Trainer
     path("openings/", views.opening_trainer, name="opening_trainer"),
     path("openings/<slug:slug>/", views.opening_detail, name="opening_detail"),
-    path("openings/", views.opening_trainer, name="opening_trainer"),
-    path("openings/<slug:slug>/", views.opening_detail, name="opening_detail"),
+
     path("api/puzzle-stats/", views.puzzle_stats_view, name="puzzle_stats"),
     path("api/puzzles/daily/", views.get_daily_puzzle, name="daily_puzzle"),
     

--- a/game/views.py
+++ b/game/views.py
@@ -51,6 +51,8 @@ from django.contrib.auth.decorators import login_required
 from django.db.models import Avg, Max, Min, Sum
 from datetime import timedelta
 
+from .opening_trainer_data import OPENINGS
+
 from .engine import ChessGame
 from .models import (
     GameResult,
@@ -3351,6 +3353,37 @@ def lesson_map_view(request):
         }
     )
 
+def opening_trainer(request):
+    return render(
+        request,
+        "game/opening_trainer.html",
+        {
+            "openings": OPENINGS,
+        }
+    )
+
+
+def opening_detail(request, slug):
+    opening = next(
+        (
+            opening
+            for opening in OPENINGS
+            if opening["slug"] == slug
+        ),
+        None,
+    )
+
+    if opening is None:
+        raise Http404("Opening not found")
+
+    return render(
+        request,
+        "game/opening_detail.html",
+        {
+            "opening": opening,
+        }
+    )
+    
 @login_required
 def achievements_view(request):
     try:


### PR DESCRIPTION
## Closes #1825

## Summary

Implemented the Opening Trainer Mode Foundation to provide structured opening practice for users.

### Features Added

- Opening library with:
  - Italian Game
  - Ruy Lopez
  - Queen's Gambit
  - London System
  - Sicilian Defense

- Opening selection page
- Individual opening training pages
- Move-by-move validation system
- Correct/incorrect feedback messages
- Progress tracking during training
- Opening completion detection

### Files Added

- game/opening_trainer_data.py
- game/templates/game/opening_trainer.html
- game/templates/game/opening_detail.html
- game/static/game/js/opening_trainer.js
- game/static/game/css/opening_trainer.css

### Files Updated

- game/views.py
- game/urls.py
- game/tests.py

### Testing

- Verified opening list page renders correctly
- Verified opening detail pages load successfully
- Verified move validation logic
- Verified progress updates correctly
- Verified opening completion flow
