### PR TITLE
fix: restrict feature_badge and remove_featured_badge views to POST only

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -3424,6 +3424,7 @@ def achievements_view(request):
     )
 
 @login_required
+@require_POST
 def feature_badge(request, achievement_id):
     achievement = get_object_or_404(
         Achievement,
@@ -3464,6 +3465,7 @@ def feature_badge(request, achievement_id):
     return redirect("achievements")
 
 @login_required
+@require_POST
 def remove_featured_badge(request, badge_id):
     FeaturedBadge.objects.filter(
         id=badge_id,


### PR DESCRIPTION

## Description

Restricted the `feature_badge` and `remove_featured_badge` views in `game/views.py` to `POST` requests only by adding Django's `@require_POST` decorator. This ensures that state-changing operations cannot be performed using `GET` requests, resolving potential security concerns (such as CSRF vulnerabilities on those endpoints).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #1965 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally