### PR TITLE
fix: improve input validation on update_puzzle_stats and secure badge…

### DIFF
--- a/game/tests.py
+++ b/game/tests.py
@@ -3018,6 +3018,18 @@ class UpdatePuzzleStatsViewTest(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(json.loads(response.content), {'error': 'invalid json'})
 
+    def test_non_object_json_returns_400(self):
+        from . import views
+        request = self.factory.post(
+            '/api/puzzle-stats/update/',
+            data=json.dumps([]),
+            content_type='application/json'
+        )
+        request.user = self.user
+        response = views.update_puzzle_stats(request)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('error', json.loads(response.content))
+
     def test_valid_json_updates_stats(self):
         from . import views
         payload = {
@@ -3038,6 +3050,33 @@ class UpdatePuzzleStatsViewTest(TestCase):
         self.assertEqual(stats.current_streak, 3)
         self.assertEqual(stats.best_streak, 5)
         self.assertEqual(stats.daily_completions, 1)
+
+    def test_partial_json_payload_uses_existing_stats(self):
+        from . import views
+        from game.models import PuzzleStats
+        PuzzleStats.objects.create(
+            user=self.user,
+            puzzles_solved=10,
+            current_streak=4,
+            best_streak=10,
+            daily_completions=2
+        )
+        
+        payload = {
+            'current_streak': 5,
+            'best_streak': 12
+        }
+        request = self.factory.post('/api/puzzle-stats/update/', data=json.dumps(payload), content_type='application/json')
+        request.user = self.user
+        response = views.update_puzzle_stats(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content), {'success': True})
+        
+        stats = PuzzleStats.objects.get(user=self.user)
+        self.assertEqual(stats.current_streak, 5)
+        self.assertEqual(stats.best_streak, 12)
+        self.assertEqual(stats.puzzles_solved, 10)
+        self.assertEqual(stats.daily_completions, 2)
 
     def test_negative_values_return_400(self):
         from . import views

--- a/game/tests.py
+++ b/game/tests.py
@@ -2981,3 +2981,117 @@ class LeaderboardAndAchievementsViewOriginalTest(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
+
+
+class UpdatePuzzleStatsViewTest(TestCase):
+    """Test the update_puzzle_stats view function."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='puzzler',
+            password='Password123!',
+            email='puzzler@example.com'
+        )
+        self.factory = RequestFactory()
+
+    def test_anonymous_user_is_redirected(self):
+        from . import views
+        request = self.factory.post('/api/puzzle-stats/update/', data=json.dumps({}), content_type='application/json')
+        from django.contrib.auth.models import AnonymousUser
+        request.user = AnonymousUser()
+        
+        response = views.update_puzzle_stats(request)
+        self.assertEqual(response.status_code, 302)
+
+    def test_non_post_request_returns_405(self):
+        from . import views
+        request = self.factory.get('/api/puzzle-stats/update/')
+        request.user = self.user
+        response = views.update_puzzle_stats(request)
+        self.assertEqual(response.status_code, 405)
+
+    def test_invalid_json_returns_400(self):
+        from . import views
+        request = self.factory.post('/api/puzzle-stats/update/', data="invalid-json", content_type='application/json')
+        request.user = self.user
+        response = views.update_puzzle_stats(request)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(json.loads(response.content), {'error': 'invalid json'})
+
+    def test_valid_json_updates_stats(self):
+        from . import views
+        payload = {
+            'puzzles_solved': 5,
+            'current_streak': 3,
+            'best_streak': 5,
+            'daily_completions': 1
+        }
+        request = self.factory.post('/api/puzzle-stats/update/', data=json.dumps(payload), content_type='application/json')
+        request.user = self.user
+        response = views.update_puzzle_stats(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content), {'success': True})
+        
+        from game.models import PuzzleStats
+        stats = PuzzleStats.objects.get(user=self.user)
+        self.assertEqual(stats.puzzles_solved, 5)
+        self.assertEqual(stats.current_streak, 3)
+        self.assertEqual(stats.best_streak, 5)
+        self.assertEqual(stats.daily_completions, 1)
+
+    def test_negative_values_return_400(self):
+        from . import views
+        payload = {
+            'puzzles_solved': -1,
+            'current_streak': 3,
+            'best_streak': 5,
+            'daily_completions': 1
+        }
+        request = self.factory.post('/api/puzzle-stats/update/', data=json.dumps(payload), content_type='application/json')
+        request.user = self.user
+        response = views.update_puzzle_stats(request)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('error', json.loads(response.content))
+
+    def test_non_integer_values_return_400(self):
+        from . import views
+        payload = {
+            'puzzles_solved': "five",
+            'current_streak': 3,
+            'best_streak': 5,
+            'daily_completions': 1
+        }
+        request = self.factory.post('/api/puzzle-stats/update/', data=json.dumps(payload), content_type='application/json')
+        request.user = self.user
+        response = views.update_puzzle_stats(request)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('error', json.loads(response.content))
+
+    def test_boolean_values_return_400(self):
+        from . import views
+        payload = {
+            'puzzles_solved': True,
+            'current_streak': 3,
+            'best_streak': 5,
+            'daily_completions': 1
+        }
+        request = self.factory.post('/api/puzzle-stats/update/', data=json.dumps(payload), content_type='application/json')
+        request.user = self.user
+        response = views.update_puzzle_stats(request)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('error', json.loads(response.content))
+
+    def test_streak_constraint_failure_returns_400(self):
+        from . import views
+        payload = {
+            'puzzles_solved': 5,
+            'current_streak': 5,
+            'best_streak': 3,
+            'daily_completions': 1
+        }
+        request = self.factory.post('/api/puzzle-stats/update/', data=json.dumps(payload), content_type='application/json')
+        request.user = self.user
+        response = views.update_puzzle_stats(request)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(json.loads(response.content), {'error': 'best_streak must be greater than or equal to current_streak'})
+

--- a/game/tests.py
+++ b/game/tests.py
@@ -3134,3 +3134,16 @@ class UpdatePuzzleStatsViewTest(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(json.loads(response.content), {'error': 'best_streak must be greater than or equal to current_streak'})
 
+    def test_invalid_validation_does_not_create_db_record(self):
+        from . import views
+        from game.models import PuzzleStats
+        self.assertFalse(PuzzleStats.objects.filter(user=self.user).exists())
+        payload = {
+            'puzzles_solved': -5,
+        }
+        request = self.factory.post('/api/puzzle-stats/update/', data=json.dumps(payload), content_type='application/json')
+        request.user = self.user
+        response = views.update_puzzle_stats(request)
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(PuzzleStats.objects.filter(user=self.user).exists())
+

--- a/game/views.py
+++ b/game/views.py
@@ -1818,20 +1818,23 @@ def update_puzzle_stats(request):
     except json.JSONDecodeError:
         return JsonResponse({'error': 'invalid json'}, status=400)
 
+    if not isinstance(data, dict):
+        return JsonResponse({'error': 'invalid json'}, status=400)
+
+    stats, _ = PuzzleStats.objects.get_or_create(
+        user=request.user
+    )
+
     fields = ["puzzles_solved", "current_streak", "best_streak", "daily_completions"]
     validated_data = {}
     for field in fields:
-        val = data.get(field, 0)
+        val = data.get(field, getattr(stats, field))
         if not isinstance(val, int) or isinstance(val, bool) or val < 0:
             return JsonResponse({'error': f'{field} must be a non-negative integer'}, status=400)
         validated_data[field] = val
 
     if validated_data["best_streak"] < validated_data["current_streak"]:
         return JsonResponse({'error': 'best_streak must be greater than or equal to current_streak'}, status=400)
-
-    stats, _ = PuzzleStats.objects.get_or_create(
-        user=request.user
-    )
 
     stats.puzzles_solved = validated_data["puzzles_solved"]
     stats.current_streak = validated_data["current_streak"]

--- a/game/views.py
+++ b/game/views.py
@@ -1813,18 +1813,35 @@ def leaderboard_view(request):
 @login_required
 @require_POST
 def update_puzzle_stats(request):
-    data = json.loads(request.body)
+    try:
+        data = json.loads(request.body or '{}')
+    except json.JSONDecodeError:
+        return JsonResponse({'error': 'invalid json'}, status=400)
+
+    fields = ["puzzles_solved", "current_streak", "best_streak", "daily_completions"]
+    validated_data = {}
+    for field in fields:
+        val = data.get(field, 0)
+        if not isinstance(val, int) or isinstance(val, bool) or val < 0:
+            return JsonResponse({'error': f'{field} must be a non-negative integer'}, status=400)
+        validated_data[field] = val
+
+    if validated_data["best_streak"] < validated_data["current_streak"]:
+        return JsonResponse({'error': 'best_streak must be greater than or equal to current_streak'}, status=400)
 
     stats, _ = PuzzleStats.objects.get_or_create(
         user=request.user
     )
 
-    stats.puzzles_solved = data.get("puzzles_solved", 0)
-    stats.current_streak = data.get("current_streak", 0)
-    stats.best_streak = data.get("best_streak", 0)
-    stats.daily_completions = data.get("daily_completions", 0)
+    stats.puzzles_solved = validated_data["puzzles_solved"]
+    stats.current_streak = validated_data["current_streak"]
+    stats.best_streak = validated_data["best_streak"]
+    stats.daily_completions = validated_data["daily_completions"]
 
-    stats.save()
+    try:
+        stats.save()
+    except IntegrityError:
+        return JsonResponse({'error': 'Integrity validation failed.'}, status=400)
 
     check_puzzle_achievements(
         request.user,
@@ -3424,6 +3441,7 @@ def achievements_view(request):
     )
 
 @login_required
+@require_POST
 def feature_badge(request, achievement_id):
     achievement = get_object_or_404(
         Achievement,
@@ -3464,6 +3482,7 @@ def feature_badge(request, achievement_id):
     return redirect("achievements")
 
 @login_required
+@require_POST
 def remove_featured_badge(request, badge_id):
     FeaturedBadge.objects.filter(
         id=badge_id,

--- a/game/views.py
+++ b/game/views.py
@@ -1821,20 +1821,23 @@ def update_puzzle_stats(request):
     if not isinstance(data, dict):
         return JsonResponse({'error': 'invalid json'}, status=400)
 
-    stats, _ = PuzzleStats.objects.get_or_create(
+    stats = PuzzleStats.objects.filter(
         user=request.user
-    )
+    ).first()
 
     fields = ["puzzles_solved", "current_streak", "best_streak", "daily_completions"]
     validated_data = {}
     for field in fields:
-        val = data.get(field, getattr(stats, field))
+        val = data.get(field, getattr(stats, field) if stats is not None else 0)
         if not isinstance(val, int) or isinstance(val, bool) or val < 0:
             return JsonResponse({'error': f'{field} must be a non-negative integer'}, status=400)
         validated_data[field] = val
 
     if validated_data["best_streak"] < validated_data["current_streak"]:
         return JsonResponse({'error': 'best_streak must be greater than or equal to current_streak'}, status=400)
+
+    if stats is None:
+        stats = PuzzleStats(user=request.user)
 
     stats.puzzles_solved = validated_data["puzzles_solved"]
     stats.current_streak = validated_data["current_streak"]


### PR DESCRIPTION

## Description

This PR introduces layered error handling and input validation for the `update_puzzle_stats` view, and secures the `feature_badge` and `remove_featured_badge` endpoints to `POST` requests only.

### Key Changes:
* **`update_puzzle_stats` view:**
  - Safely parses JSON bodies and returns `400 Bad Request` on invalid JSON.
  - Validates that the fields `puzzles_solved`, `current_streak`, `best_streak`, and `daily_completions` are non-negative integers (rejecting strings, floats, and booleans).
  - Enforces `best_streak >= current_streak` at the Python level.
  - Catches database `IntegrityError` to safely report validation failure without exposing database internals.
* **Badge Endpoints:**
  - Added `@require_POST` to the `feature_badge` and `remove_featured_badge` views to restrict access to POST-only requests, protecting them from unauthorized GET state mutations.
* **Testing:**
  - Added the `UpdatePuzzleStatsViewTest` suite to cover all validation pathways for puzzle stats.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #1966 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

N/A

## Additional Notes

- All 171 tests (including the new unit test suite) and E2E Selenium tests pass successfully locally.
```