### PR TITLE
fix: UI elements hidden at 100% browser zoom

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -970,8 +970,8 @@ body {
 .btn-pause:active { transform: translateY(0); }
 .back-btn {
     font-size: small;
-    background: var(--bg);
-    color: var(--bg) !important;
+    background: transparent;
+    color: var(--text-primary);
     font-weight: bold;
     margin-bottom: 2rem;
     text-decoration: none;


### PR DESCRIPTION
## Pull Request Description

Fixes UI elements being hidden/invisible at 100% browser zoom on the board page.

## Changes

- Fixed `.back-btn` color being set to `var(--bg) !important` which made the "← Back to Home" link invisible against the background
- Changed to `color: var(--text-primary)` with `background: transparent`

## Related Issue
Closes #1957

## Type of Change
- [x] 🐛 Bug fix

## Testing
- Visual inspection at 100% and 75% zoom
- All 17 existing tests pass