### PR TITLE
fix: Dark/Light mode toggle button is overflowing

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -1651,7 +1651,7 @@ body {
     position: absolute !important;
     top: 37px !important;
     right: 0 !important;
-    transform: 0 !important;
+     !important;
 }
 
 .promo-overlay .btn-gold {

--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -1649,9 +1649,9 @@ body {
 
 .promo-overlay .theme-toggle {
     position: absolute !important;
-    top: 0 !important;
+    top: 37px !important;
     right: 0 !important;
-    transform: translateY(-4px) !important;
+    transform: 0 !important;
 }
 
 .promo-overlay .btn-gold {


### PR DESCRIPTION
## Description
Fixed the Dark/Light mode toggle button overflowing outside the promo dialog container.

The issue was caused by a negative vertical transform that pushed the toggle button beyond the visible bounds of its parent container. The positioning has been adjusted to keep the button fully visible while preserving the existing layout and styling behavior.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

## Related Issue

Fixes #1916 

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [ ] I have commented my code where necessary
* [ ] I have updated the documentation if needed
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix/feature works
* [x] New and existing tests pass locally

## Screenshots 
<img width="665" height="190" alt="theme toggle fix" src="https://github.com/user-attachments/assets/8ee9bc08-c7cc-4344-a9b4-93fbd6750ede" />


## Additional Notes

This change only affects the positioning of the theme toggle button and does not modify any existing functionality or styling outside the affected component.
