### PR TITLE
feat: add opening trainer shortcut to profile dropdown

### DIFF
--- a/game/static/game/js/dropdown.js
+++ b/game/static/game/js/dropdown.js
@@ -1,4 +1,5 @@
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', function () {
+    console.log("dropdown.js loaded");
     const dropdown = document.querySelector('.profile-dropdown');
     if (!dropdown) return;
 
@@ -6,9 +7,14 @@ document.addEventListener('DOMContentLoaded', function() {
     const content = dropdown.querySelector('.dropdown-content');
 
     if (btn && content) {
-        btn.addEventListener('click', function(e) {
+        btn.addEventListener('click', function (e) {
+            console.log("dropdown button clicked");
             e.stopPropagation();
             dropdown.classList.toggle('active');
+            console.log(
+                "active:",
+                dropdown.classList.contains('active')
+            );
         });
 
         // Close dropdown when clicking outside

--- a/game/static/game/js/dropdown.js
+++ b/game/static/game/js/dropdown.js
@@ -1,5 +1,5 @@
 document.addEventListener('DOMContentLoaded', function () {
-    console.log("dropdown.js loaded");
+    
     const dropdown = document.querySelector('.profile-dropdown');
     if (!dropdown) return;
 
@@ -8,13 +8,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
     if (btn && content) {
         btn.addEventListener('click', function (e) {
-            console.log("dropdown button clicked");
             e.stopPropagation();
             dropdown.classList.toggle('active');
-            console.log(
-                "active:",
-                dropdown.classList.contains('active')
-            );
+        
         });
 
         // Close dropdown when clicking outside

--- a/game/templates/game/forum_detail.html
+++ b/game/templates/game/forum_detail.html
@@ -36,6 +36,7 @@
 
                 <div class="dropdown-content">
                     <a href="/play/">Dashboard</a>
+                    <a href="{% url 'opening_trainer' %}">Opening Trainer</a>
                     <a href="/stats/">Stats</a>
                     <a href="{% url 'leaderboard' %}">Leaderboard</a>
                     <a href="{% url 'achievements' %}">Achievements</a>
@@ -121,5 +122,6 @@
         <a href="{% url 'login' %}">Login</a> to join the discussion.
     </div>
     {% endif %}
+<script src="{% static 'game/js/dropdown.js' %}"></script>
 </body>
 </html>

--- a/game/templates/game/forum_list.html
+++ b/game/templates/game/forum_list.html
@@ -94,5 +94,6 @@
         <a href="{% url 'forum_new' %}" class="forum-fab-new">+ New Discussion</a>
         {% endif %}
     </div>
+    <script src="{% static 'game/js/dropdown.js' %}"></script>
 </body>
 </html>

--- a/game/templates/game/forum_new.html
+++ b/game/templates/game/forum_new.html
@@ -81,5 +81,6 @@
             </form>
         </div>
     </div>
+    <script src="{% static 'game/js/dropdown.js' %}"></script>
 </body>
 </html>

--- a/game/templates/game/landing.html
+++ b/game/templates/game/landing.html
@@ -125,6 +125,10 @@
           <div class="dropdown-content">
             <a href="/play/"> Dashboard </a>
 
+            <a href="{% url 'opening_trainer' %}">
+                Opening Trainer
+            </a>
+
             <a href="/stats/"> Stats </a>
 
             <a href="{% url 'leaderboard' %}"> Leaderboard </a>
@@ -1630,7 +1634,6 @@
         if (!isCorrect) { fb.style.color = '#ef4444'; fb.textContent = '✗ Not quite — 2.Nf3 is the key move.'; }
     }
   </script>
-      <script src="{% static 'game/js/dropdown.js' %}"></script>
   <!-- Keyboard Shortcuts Modal -->
 <div
   id="shortcutsModal"
@@ -1780,6 +1783,6 @@
 
 })();
 </script>
-    <script src="{% static 'game/js/dropdown.js' %}"></script>
+  <script src="{% static 'game/js/dropdown.js' %}"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Fixes the username dropdown menu not opening on forum pages and improves navigation by adding a direct Opening Trainer shortcut.

## Changes Made

### Dropdown Fixes
- Added missing `dropdown.js` include to forum templates
- Added dropdown initialization support on discussion detail pages
- Removed duplicate `dropdown.js` inclusion from landing page
- Ensured dropdown behavior works consistently across pages

### Navigation Improvement
- Added **Opening Trainer** link to the profile dropdown menu
- Allows users to directly access opening training from any page

## Testing

- Verified dropdown opens on Landing page
- Verified dropdown opens on Forum page
- Verified dropdown opens on Discussion Detail page
- Verified dropdown opens on New Discussion page
- Verified Opening Trainer link redirects correctly
- Verified outside-click closing behavior
- Verified Escape key closing behavior

Fixes #1982