### PR TITLE
fix: prevent browser force dark mode from inverting chess pieces

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -1,3 +1,14 @@
+img, 
+.piece, 
+.square, 
+.chessboard, 
+.board-container {
+    color-scheme: only light dark;
+}
+.piece {
+    filter: none !important;
+}
+
 :root {
     --bg-primary: #0f0f1a;
     --card-bg: #16162a;


### PR DESCRIPTION
This PR fixes an accessibility and visual rendering bug where browser-level "Force Dark Mode" or third-party accessibility extensions (like Dark Reader) were incorrectly applying an inversion filter to the chess board and pieces.

By defining the `color-scheme` and explicitly disabling filters on game elements, we ensure the native application styling is respected across all browser environments.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

## Related Issue

Fixes #2006 

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] I have commented my code where necessary
* [ ] I have updated the documentation if needed
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix/feature works
* [ ] New and existing tests pass locally

## Screenshots
<img width="617" height="688" alt="image" src="https://github.com/user-attachments/assets/538adbbb-7ca8-442b-9e79-304195262c9b" />


## Additional Notes

The fix involves adding `color-scheme: only light dark;` to the root and `filter: none !important;` to the `.piece` class. This is a non-invasive CSS change that stabilizes the UI for users with custom browser accessibility settings.
