### PR TITLE
Update setup flow to prompt for names after mode selection

### DIFF
--- a/game/selenium_tests/base.py
+++ b/game/selenium_tests/base.py
@@ -77,27 +77,35 @@ class BaseE2ETest(StaticLiveServerTestCase):
         super().tearDownClass()
 
     def _start_pvp_game(self):
-        """Helper: navigate to homepage and start a PvP game."""
-        log_info(f"Starting PvP game at {self.live_server_url}/play/")
+        """Helper to navigate to /play/ and start a PvP game."""
         self.driver.get(self.live_server_url + '/play/')
-
         self.wait.until(
             EC.presence_of_element_located((By.ID, 'welcomeOverlay'))
         )
+        
+        # --- NEW LOGIC START ---
+        # 1. Click the mode selection button first to reveal the inputs
+        welcome_pvp_btn = self.wait.until(EC.element_to_be_clickable((By.ID, "welcomePvPBtn")))
+        welcome_pvp_btn.click()
+        
+        # 2. Wait for the new "Start Pass & Play" button to appear (meaning inputs are now visible)
+        start_pvp_btn = self.wait.until(EC.element_to_be_clickable((By.ID, "startPvPBtn")))
+        # --- NEW LOGIC END ---
 
+        # Now Selenium can safely interact with the inputs
         white_input = self.driver.find_element(By.ID, 'whiteNameInput')
         black_input = self.driver.find_element(By.ID, 'blackNameInput')
         white_input.clear()
+        white_input.send_keys('TestWhite')
         black_input.clear()
-        white_input.send_keys('Alice')
-        black_input.send_keys('Bob')
+        black_input.send_keys('TestBlack')
 
-        self.driver.find_element(By.ID, 'welcomePvPBtn').click()
+        # 3. Click the NEW start button instead of the old one
+        start_pvp_btn.click()
 
         self.wait.until(
-            EC.visibility_of_element_located((By.ID, 'board'))
+            EC.invisibility_of_element_located((By.ID, 'welcomeOverlay'))
         )
-        log_ok("PvP game started — board visible")
 
     def _js_click(self, element):
         """Helper: click element via JavaScript (more reliable than Selenium click)."""

--- a/game/selenium_tests/test_navigation.py
+++ b/game/selenium_tests/test_navigation.py
@@ -245,16 +245,30 @@ class NavigationTest(BaseE2ETest):
     # Test 11: Name Validation Error Shows on Empty Submit
     # ───────────────────────────────────────────────────────────────
     def test_11_name_validation_error_on_empty_submit(self):
+        """Clicking PvP without entering names shows validation error."""
+        log_info("Testing name validation...")
+        
+        # MUST KEEP: Navigate to the page and wait for it to load
+        self.driver.get(self.live_server_url + '/play/')
+        self.wait.until(
+            EC.presence_of_element_located((By.ID, 'welcomeOverlay'))
+        )
+
         # 1. Click the mode selection button first (Step 1)
         welcome_pvp_btn = self.wait.until(EC.element_to_be_clickable((By.ID, "welcomePvPBtn")))
         welcome_pvp_btn.click()
-        
+
         # 2. Wait for the new "Start Pass & Play" button to appear (Step 2)
         start_pvp_btn = self.wait.until(EC.element_to_be_clickable((By.ID, "startPvPBtn")))
-        
+
         # 3. Click start WITHOUT entering names to trigger the error
         start_pvp_btn.click()
-        
+
         # 4. Now check for your specific validation error div
-        error_div = self.wait.until(EC.visibility_of_element_located((By.ID, "nameError")))
+        error_div = self.wait.until(
+            EC.visibility_of_element_located((By.ID, 'nameError')),
+            message="Validation error not shown after empty name submit"
+        )
+        
         self.assertTrue(error_div.is_displayed())
+        log_ok(f"Validation error shown: '{error_div.text}'")

--- a/game/selenium_tests/test_navigation.py
+++ b/game/selenium_tests/test_navigation.py
@@ -245,22 +245,16 @@ class NavigationTest(BaseE2ETest):
     # Test 11: Name Validation Error Shows on Empty Submit
     # ───────────────────────────────────────────────────────────────
     def test_11_name_validation_error_on_empty_submit(self):
-        """Clicking PvP without entering names shows validation error."""
-        log_info("Testing name validation...")
-        self.driver.get(self.live_server_url + '/play/')
-
-        self.wait.until(
-            EC.presence_of_element_located((By.ID, 'welcomeOverlay'))
-        )
-
-        # Click PvP without entering names
-        pvp_btn = self.driver.find_element(By.ID, 'welcomePvPBtn')
-        pvp_btn.click()
-
-        # Error div should be visible
-        error_div = self.wait.until(
-            EC.visibility_of_element_located((By.ID, 'nameError')),
-            message="Validation error not shown after empty name submit"
-        )
+        # 1. Click the mode selection button first (Step 1)
+        welcome_pvp_btn = self.wait.until(EC.element_to_be_clickable((By.ID, "welcomePvPBtn")))
+        welcome_pvp_btn.click()
+        
+        # 2. Wait for the new "Start Pass & Play" button to appear (Step 2)
+        start_pvp_btn = self.wait.until(EC.element_to_be_clickable((By.ID, "startPvPBtn")))
+        
+        # 3. Click start WITHOUT entering names to trigger the error
+        start_pvp_btn.click()
+        
+        # 4. Now check for your specific validation error div
+        error_div = self.wait.until(EC.visibility_of_element_located((By.ID, "nameError")))
         self.assertTrue(error_div.is_displayed())
-        log_ok(f"Validation error shown: '{error_div.text}'")

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -81,7 +81,7 @@
     // Updates UI to highlight selected game mode button
     function updateModeButtonsUI(mode) {
         const pvpBtn = document.getElementById("newPvPBtn");
-        const aiBtn = document.getElementById("newAIBtn");
+        const aiBtn = document.getElementById("newAIBtn"); 
 
         if (!pvpBtn || !aiBtn) return;
 
@@ -555,6 +555,8 @@
     const welcomeResumeBtn = document.getElementById('welcomeResumeBtn');
     const welcomePvPBtn = document.getElementById('welcomePvPBtn');
     const welcomeAIBtn = document.getElementById('welcomeAIBtn');
+    const startPvPBtn = document.getElementById('startPvPBtn');
+    const backToModesFromPvP = document.getElementById('backToModesFromPvP');
     const welcomeDailyPuzzleBtn = document.getElementById("welcomeDailyPuzzleBtn");
     const welcomeFenInput = document.getElementById('welcomeFenInput');
     const welcomeFenError = document.getElementById('welcomeFenError');
@@ -3395,7 +3397,7 @@
 
         pveOptions.style.display = 'none';
         modeSelection.style.display = 'flex';
-        nameInputs.style.display = 'flex';
+        nameInputs.style.display = 'none';
 
         if (whiteInput) {
             whiteInput.style.display = 'block';
@@ -3469,9 +3471,25 @@
             welcomeOverlay.classList.remove('active');
             gameLayout.style.visibility = 'visible';
         });
-    }
-
-    if (welcomePvPBtn) welcomePvPBtn.onclick = async () => {
+    }// 1. Advance to Name Entry when clicking Pass & Play
+    if (welcomePvPBtn) welcomePvPBtn.onclick = () => {
+        if (modeSelection) modeSelection.style.display = 'none';
+        if (nameInputs) nameInputs.style.display = 'flex';
+        
+        // Show PvP specific buttons
+        if (startPvPBtn) startPvPBtn.style.display = 'block';
+        if (backToModesFromPvP) backToModesFromPvP.style.display = 'block';
+        
+        // Make sure the second name input is visible
+        const blackInput = document.getElementById('blackNameInput');
+        if (blackInput) {
+            blackInput.style.display = 'block';
+            if (blackInput.value === 'AI') blackInput.value = ''; 
+        }
+    };
+    
+    // 2. NEW: Actually validate names and start the PvP game
+    if (startPvPBtn) startPvPBtn.onclick = async () => {
         if (!validatePlayerNames()) return;
         const fen = welcomeFenInput?.value?.trim() || null;
         const started = await startNewGame('pvp', 'white', 'medium', fen);
@@ -3479,41 +3497,44 @@
         welcomeOverlay.classList.remove('active');
         gameLayout.style.visibility = 'visible';
     };
-
-    if (welcomeDailyPuzzleBtn) {
-        welcomeDailyPuzzleBtn.onclick = async () => {
-
-            await startDailyPuzzle();
-
-            welcomeOverlay.classList.remove('active');
-            gameLayout.style.visibility = 'visible';
-        };
-    }
-
+    
+    // 3. NEW: Allow backing out of the PvP name entry screen
+    if (backToModesFromPvP) backToModesFromPvP.onclick = () => {
+        if (nameInputs) nameInputs.style.display = 'none';
+        if (startPvPBtn) startPvPBtn.style.display = 'none';
+        if (backToModesFromPvP) backToModesFromPvP.style.display = 'none';
+        if (modeSelection) modeSelection.style.display = 'flex';
+    };
+    
+    // 4. Update AI flow to hide the new PvP buttons just in case
     if (welcomeAIBtn) welcomeAIBtn.onclick = () => {
         modeSelection.style.display = 'none';
         pveOptions.style.display = 'flex';
-
+    
+        // Hide PvP specific buttons
+        if (startPvPBtn) startPvPBtn.style.display = 'none';
+        if (backToModesFromPvP) backToModesFromPvP.style.display = 'none';
+    
         const whiteInput = document.getElementById('whiteNameInput');
         const blackInput = document.getElementById('blackNameInput');
         const errorDiv = document.getElementById('nameError');
-
+    
         if (whiteInput) {
             whiteInput.style.display = 'block';
             whiteInput.placeholder = 'Your Name';
             whiteInput.classList.remove('input-error');
         }
-
+    
         if (blackInput) {
             blackInput.style.display = 'none';
             blackInput.value = 'AI';
             blackInput.classList.remove('input-error');
         }
-
+    
         if (errorDiv) {
             errorDiv.style.display = 'none';
         }
-
+    
         nameInputs.style.display = 'flex';
     };
 

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -11,7 +11,6 @@
     <link rel="icon" type="image/jpeg" href="{% static 'game/favicon.jpeg' %}">
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
 
-    <!-- Vercel Speed Insights -->
     <script>
         window.si = window.si || function () { (window.siq = window.siq || []).push(arguments); };
     </script>
@@ -20,7 +19,6 @@
     <link rel="stylesheet" href="{% static 'game/css/board.css' %}">
     <link rel="stylesheet" href="{% static 'game/css/toast.css' %}">
 
-    <!-- Vercel Web Analytics -->
     <script>
         window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
     </script>
@@ -71,40 +69,23 @@
 <body>
     <div style="display:none" aria-hidden="true">{% csrf_token %}</div>
 
-    <!-- MOBILE FAB -->
-<div class="m-fab" id="mFab">
-  <button
-  type="button"
-  class="m-fab-btn"
-  id="pauseFab"
-  title="Pause"
-  onclick="document.getElementById('pauseBtn').click()">
-
-  <svg id="pauseFabIcon" width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-    <rect x="5" y="3" width="4" height="18" rx="1.5"/>
-    <rect x="15" y="3" width="4" height="18" rx="1.5"/>
-  </svg>
-
-  <svg id="playFabIcon"
-       width="16"
-       height="16"
-       viewBox="0 0 24 24"
-       fill="currentColor"
-       style="display:none;">
-    <path d="M8 5v14l11-7z"/>
-  </svg>
-
-</button>
-  <button class="m-fab-btn m-fab-resign" title="Resign"
-    onclick="document.getElementById('resignBtn').click()">
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-      <path d="M4 3h14l-4 4.5 4 4.5H4V3z"/>
-      <line x1="4" y1="21" x2="4" y2="3" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-    </svg>
-  </button>
-</div>
-
-    <!-- ========== WELCOME MESSAGE ========== -->
+    <div class="m-fab" id="mFab">
+        <button type="button" class="m-fab-btn" id="pauseFab" title="Pause" onclick="document.getElementById('pauseBtn').click()">
+            <svg id="pauseFabIcon" width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                <rect x="5" y="3" width="4" height="18" rx="1.5" />
+                <rect x="15" y="3" width="4" height="18" rx="1.5" />
+            </svg>
+            <svg id="playFabIcon" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style="display:none;">
+                <path d="M8 5v14l11-7z" />
+            </svg>
+        </button>
+        <button class="m-fab-btn m-fab-resign" title="Resign" onclick="document.getElementById('resignBtn').click()">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M4 3h14l-4 4.5 4 4.5H4V3z" />
+                <line x1="4" y1="21" x2="4" y2="3" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+            </svg>
+        </button>
+    </div>
 
     <div class="promo-overlay active" id="welcomeOverlay" style="background: var(--page-bg); z-index: 10000;">
         <div class="promo-dialog">
@@ -112,33 +93,25 @@
                 <a href="/" class="back-btn">← Back to Home</a>
                 <button type="button" id="themeToggle" class="theme-toggle" title="Toggle light / dark theme">🌙</button>
             </div>
-            <div class="promo-title"
-                style="font-size: 1.6rem; margin-bottom: 10px; display: flex; align-items: center; justify-content: center; gap: 8px;">
+            
+            <div class="promo-title" style="font-size: 1.6rem; margin-bottom: 10px; display: flex; align-items: center; justify-content: center; gap: 8px;">
                 <div class="promo-title promo-logo">
-    <img src="{% static 'game/checkora_icon_only.png' %}"
-         style="height: 3rem; width: auto; object-fit: contain;"
-         alt="Checkora">
-
-    <span class="logo-text">
-        <span class="logo-white">CHECK</span><span class="logo-gold">ORA</span>
-    </span>
-</div>
-
+                    <img src="{% static 'game/checkora_icon_only.png' %}" style="height: 3rem; width: auto; object-fit: contain;" alt="Checkora">
+                    <span class="logo-text">
+                        <span class="logo-white">CHECK</span><span class="logo-gold">ORA</span>
+                    </span>
+                </div>
             </div>
+            
             <p style="color: #aaa; margin-bottom: 30px; font-size: 0.95rem;">Enter names and select a game mode.</p>
 
-            <div id="nameInputs" style="display: flex; flex-direction: column; gap: 10px; margin-bottom: 25px;">
-                <input type="text" id="whiteNameInput" placeholder="White Player Name" aria-label="White Player Name" maxlength="17" required
-                    minlength="1"
-                    style="padding: 10px; border-radius: 5px; border: 1px solid #444; background: #1a1a2e; color: #fff; transition: all 0.3s ease;">
+            <div id="nameInputs" style="display: none; flex-direction: column; gap: 10px; margin-bottom: 25px;">
+                
+                <input type="text" id="whiteNameInput" placeholder="White Player Name" aria-label="White Player Name" maxlength="17" required minlength="1" style="padding: 10px; border-radius: 5px; border: 1px solid #444; background: #1a1a2e; color: #fff; transition: all 0.3s ease;">
 
-                <input type="text" id="blackNameInput" placeholder="Black Player Name" aria-label="Black Player Name" maxlength="17" required
-                    minlength="1"
-                    style="padding: 10px; border-radius: 5px; border: 1px solid #444; background: #1a1a2e; color: #fff; transition: all 0.3s ease;">
+                <input type="text" id="blackNameInput" placeholder="Black Player Name" aria-label="Black Player Name" maxlength="17" required minlength="1" style="padding: 10px; border-radius: 5px; border: 1px solid #444; background: #1a1a2e; color: #fff; transition: all 0.3s ease;">
 
-                <!-- Error message div -->
-                <div id="nameError"
-                    style="display: none; color: #ff6b6b; font-size: 0.85rem; text-align: center; padding: 8px; background: rgba(255, 107, 107, 0.1); border-radius: 4px; border: 1px solid rgba(255, 107, 107, 0.3);">
+                <div id="nameError" style="display: none; color: #ff6b6b; font-size: 0.85rem; text-align: center; padding: 8px; background: rgba(255, 107, 107, 0.1); border-radius: 4px; border: 1px solid rgba(255, 107, 107, 0.3);">
                     ⚠️ Please enter both player names
                 </div>
 
@@ -152,7 +125,6 @@
                         <span class="tc-chevron" style="font-size: 0.75rem; opacity: 0.7;">▼</span>
                     </button>
                     
-                    <!-- Popover / dropdown panel -->
                     <div class="time-control-popover" id="timeControlPopover" style="display: none; flex-direction: column; background: #16162a; border: 1px solid #f0c040; border-radius: 8px; margin-top: 6px; padding: 12px; z-index: 1000; box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5); position: absolute; left: 0; right: 0;">
                         <div class="tc-tabs" style="display: flex; gap: 4px; border-bottom: 1px solid #252545; padding-bottom: 8px; margin-bottom: 12px; overflow-x: auto; white-space: nowrap;">
                             <button type="button" class="tc-tab-btn" data-tab="bullet" style="background: none; border: none; color: #8a8aaa; padding: 6px 12px; cursor: pointer; font-size: 0.85rem; font-weight: 600; border-radius: 4px; transition: all 0.2s;">Bullet</button>
@@ -216,21 +188,18 @@
                         </div>
                     </div>
                 </div>
+
+                <button type="button" class="btn btn-gold" id="startPvPBtn" style="padding: 12px; font-size: 1.05rem; display: none; margin-top: 10px;">Start Pass & Play</button>
+                <button type="button" class="btn" id="backToModesFromPvP" style="padding: 12px; font-size: 1.05rem; background: #333; color: #fff; display: none;">Back</button>
+
             </div>
 
-            <!-- Rest stays the same -->
             <div id="modeSelection" style="display: flex; flex-direction: column; gap: 14px;">
                 
-                <button class="btn btn-gold" id="welcomePvPBtn" style="padding: 12px; font-size: 1.05rem;">Pass & Play
-                    (PvP)</button>
-                <button class="btn btn-gold" id="welcomeAIBtn" style="padding: 12px; font-size: 1.05rem;">Play vs
-                    AI</button>
-                <button type="button" 
-                        class="btn btn-gold"
-                        id="welcomeDailyPuzzleBtn"
-                        style="padding: 12px; font-size: 1.05rem;">
-                    Daily Puzzle Challenge
-                </button>
+                <button type="button" class="btn btn-gold" id="welcomePvPBtn" style="padding: 12px; font-size: 1.05rem;">Pass & Play (PvP)</button>
+                <button type="button" class="btn btn-gold" id="welcomeAIBtn" style="padding: 12px; font-size: 1.05rem;">Play vs AI</button>
+                <button type="button" class="btn btn-gold" id="welcomeDailyPuzzleBtn" style="padding: 12px; font-size: 1.05rem;">Daily Puzzle Challenge</button>
+                
                 <div class="fen-input-group">
                     <label class="fen-label" for="welcomeFenInput">Optional FEN</label>
                     <input type="text" id="welcomeFenInput" class="fen-input" placeholder="Paste FEN to start from a custom position">
@@ -238,111 +207,69 @@
                     <div class="fen-error" id="welcomeFenError"></div>
                 </div>
 
-                <button class="btn" id="welcomeResumeBtn"
-                    style="padding: 12px; font-size: 1.05rem; background: #333; color: #fff; display: none;">Resume
-                    Game</button>
+                <button type="button" class="btn" id="welcomeResumeBtn" style="padding: 12px; font-size: 1.05rem; background: #333; color: #fff; display: none;">Resume Game</button>
             </div>
 
             <div id="pveOptions" style="display: none; flex-direction: column; gap: 14px;">
                 <div style="color: #fff; font-size: 1.1rem; text-align: center; margin-bottom: 5px;">Play as:</div>
                 <div style="display: flex; gap: 10px; justify-content: center; margin-bottom: 10px;">
-                    <button class="btn color-choice active" id="pveWhiteBtn" data-color="white"
-                        style="padding: 12px; flex: 1; border: 2px solid #f0c040; background: #fff; color: #000; transition: all 0.2s;">White</button>
-                    <button type="button" class="btn color-choice" id="pveRandomBtn" data-color="random" aria-label="Random color selection" 
-                        style="padding: 12px; flex: 1; border: 1px solid #444; background: linear-gradient(to right, #fff 50%, #000 50%); color: #666; transition: all 0.2s; font-weight: 500;">
-            🎲 Random
-        </button>    
-                    <button class="btn color-choice" id="pveBlackBtn" data-color="black"
-                        style="padding: 12px; flex: 1; border: 2px solid #444; background: #000; color: #fff; transition: all 0.2s;">Black</button>
+                    <button class="btn color-choice active" id="pveWhiteBtn" data-color="white" style="padding: 12px; flex: 1; border: 2px solid #f0c040; background: #fff; color: #000; transition: all 0.2s;">White</button>
+                    <button type="button" class="btn color-choice" id="pveRandomBtn" data-color="random" aria-label="Random color selection" style="padding: 12px; flex: 1; border: 1px solid #444; background: linear-gradient(to right, #fff 50%, #000 50%); color: #666; transition: all 0.2s; font-weight: 500;">🎲 Random</button>    
+                    <button class="btn color-choice" id="pveBlackBtn" data-color="black" style="padding: 12px; flex: 1; border: 2px solid #444; background: #000; color: #fff; transition: all 0.2s;">Black</button>
                 </div>
 
                 <div id="aiDifficultyContainer" style="margin-bottom: 10px;">
-                    <label
-                        style="color: #ccc; display: block; margin-bottom: 5px; font-size: 0.9rem; text-align: center;">AI
-                        Difficulty</label>
-                    <select id="welcomeDifficultySelect"
-                        style="width: 100%; padding: 10px; border-radius: 5px; border: 1px solid #444; background: #1a1a2e; color: #fff;">
+                    <label style="color: #ccc; display: block; margin-bottom: 5px; font-size: 0.9rem; text-align: center;">AI Difficulty</label>
+                    <select id="welcomeDifficultySelect" style="width: 100%; padding: 10px; border-radius: 5px; border: 1px solid #444; background: #1a1a2e; color: #fff;">
                         <option value="easy">Easy</option>
                         <option value="medium" selected>Medium</option>
                         <option value="hard">Hard</option>
                     </select>
                 </div>
-                <button class="btn btn-gold" id="startAIBtn" style="padding: 12px; font-size: 1.05rem;">Start
-                    Game</button>
-                <button class="btn" id="backToModes"
-                    style="padding: 12px; font-size: 1.05rem; background: #333; color: #fff;">Back</button>
+                <button class="btn btn-gold" id="startAIBtn" style="padding: 12px; font-size: 1.05rem;">Start Game</button>
+                <button class="btn" id="backToModes" style="padding: 12px; font-size: 1.05rem; background: #333; color: #fff;">Back</button>
             </div>
         </div>
     </div>
     
-    <!-- ========== HEADER ========== -->
-    
     <div class="header">
-        
         <div class="logo-container">
             <a href="{% url 'landing' %}" class="logo-link">
                 <img src="{% static 'game/checkora_icon_only.png' %}" class="logo-icon-img" alt="Checkora">
                 <span class="logo-text">
-    <span class="logo-white">CHECK</span><span class="logo-gold">ORA</span>
-</span>
+                    <span class="logo-white">CHECK</span><span class="logo-gold">ORA</span>
+                </span>
             </a>
             <span class="badge" id="modeBadge">PVP</span>
         </div>
         
         <div class="auth-buttons">
             {% if user.is_authenticated %}
-
             <div class="profile-dropdown">
                 <button class="profile-btn">
                     {{ user.username }} ⌄
                 </button>
-
                 <div class="dropdown-content">
-                    <a href="/stats/">
-                        Stats
-                    </a>
-
-                    <a href="{% url 'leaderboard' %}">
-                        Leaderboard
-                    </a>
-
-                    <a href="{% url 'achievements' %}">
-                        Achievements
-                    </a>
-
-                    <a href="{% url 'opening_trainer' %}">
-                        ♟ Opening Trainer
-                    </a>
-
+                    <a href="/stats/">Stats</a>
+                    <a href="{% url 'leaderboard' %}">Leaderboard</a>
+                    <a href="{% url 'achievements' %}">Achievements</a>
+                    <a href="{% url 'opening_trainer' %}">♟ Opening Trainer</a>
                     <a href="{% url 'delete_account' %}" class="delete-option"> Delete Account </a>
-                    <form
-                        method="post"
-                        action="{% url 'logout' %}"
-                        style="margin:0;"
-                    >
+                    <form method="post" action="{% url 'logout' %}" style="margin:0;">
                         {% csrf_token %}
-
-                        <button
-                            type="submit"
-                            class="logout-option"
-                        >
-                            Logout
-                        </button>
+                        <button type="submit" class="logout-option">Logout</button>
                     </form>
                 </div>
             </div>
             {% else %}
-
             <a href="{% url 'login' %}" class="btn-signin">Sign In</a>
             <a href="{% url 'register' %}" class="btn-register">Register</a>
             {% endif %}
         </div>
     </div>
     
-    <!-- ========== GAME ========== -->
     <div class="game-layout" style="visibility: hidden;">
 
-        <!-- Left Panel -->
         <div class="panel">
             <div class="card">
                 <div class="card-title">Captured by <span id="whiteCapturedName">White</span></div>
@@ -373,7 +300,6 @@
             </div>
         </div>
 
-        <!-- Board -->
         <div class="board-container">
             <div class="turn-badge white" id="turnBadge">
                 <span id="turnBadgeText">White</span>'s Turn
@@ -382,8 +308,7 @@
                 <div id="whiteClock" class="clock white active">
                     <span class="label">
                         <span id="whiteNameLabel">WHITE</span>
-                        <span id="whiteYouTag"
-                            style="display: none; color: #f0c040; margin-left: 4px; font-size: 0.8em;">(YOU)</span>
+                        <span id="whiteYouTag" style="display: none; color: #f0c040; margin-left: 4px; font-size: 0.8em;">(YOU)</span>
                     </span>
                     <span class="time" id="whiteTime">10:00</span>
                 </div>
@@ -399,8 +324,7 @@
                 <div id="blackClock" class="clock black">
                     <span class="label">
                         <span id="blackNameLabel">BLACK</span>
-                        <span id="blackYouTag"
-                            style="display: none; color: #f0c040; margin-left: 4px; font-size: 0.8em;">(YOU)</span>
+                        <span id="blackYouTag" style="display: none; color: #f0c040; margin-left: 4px; font-size: 0.8em;">(YOU)</span>
                     </span>
                     <span class="time" id="blackTime">10:00</span>
                 </div>
@@ -432,24 +356,21 @@
                     <button id="nextReplayBtn" aria-label="Go to next move">▶▶</button>
                     <button id="lastReplayBtn" aria-label="Go to last move">⏭</button>
                 </div>
-                <!--Score bar-->
-                  <div id="game-status">Game started</div>
-                   <div class="score-panel">
-                   <div class="score-box">
-                       <span class="score-label">White</span>
-                       <span id="whiteScore">0</span>
-                   </div>
-           
-                   <div class="score-box">
-                       <span class="score-label">Black</span>
-                       <span id="blackScore">0</span>
-                   </div>
-               </div>
-                
+                <div id="game-status">Game started</div>
+                <div class="score-panel">
+                    <div class="score-box">
+                        <span class="score-label">White</span>
+                        <span id="whiteScore">0</span>
+                    </div>
+            
+                    <div class="score-box">
+                        <span class="score-label">Black</span>
+                        <span id="blackScore">0</span>
+                    </div>
+                </div>
             </div>
         </div>
         
-<!-- Right Panel: Controls -->
         <div class="panel">
             <div class="card">
                 <div class="card-title">Board Theme</div>
@@ -483,9 +404,8 @@
             <div class="card">
                 <div class="card-title">Game Controls</div>
                 <div style="display: flex; flex-direction: column; gap: 8px;">
-
                     <button type="button" class="btn btn-gold" id="flipBtn" title="Shortcut: F">Flip Board<span class="btn-shortcut">F</span></button>
-                   <button class="btn btn-gold" id="blindfoldBtn">Blindfold: OFF</button>
+                    <button class="btn btn-gold" id="blindfoldBtn">Blindfold: OFF</button>
                     <button class="btn btn-gold" id="newPvPBtn">Pass & Play (PvP)</button>
                     <button class="btn btn-gold" id="newAIBtn">Play vs AI</button>
                     <button type="button" class="btn btn-gold" id="dailyPuzzleBtn">Daily Puzzle</button>
@@ -502,17 +422,14 @@
                     <button type="button" class="btn btn-gold" id="drawBtn" title="Shortcut: D">Offer Draw<span class="btn-shortcut">D</span></button>
                     <button type="button" class="btn btn-warning" id="pauseBtn" title="Shortcut: P">Pause<span class="btn-shortcut">P</span></button>
                     <button type="button" class="btn btn-danger" id="resignBtn" title="Shortcut: R">Resign<span class="btn-shortcut">R</span></button>
-                    <button class="btn btn-gold" style="width: 100%;"
-                        onclick="document.getElementById('rulebookModal').style.display='flex'">📖 Rulebook</button>
+                    <button class="btn btn-gold" style="width: 100%;" onclick="document.getElementById('rulebookModal').style.display='flex'">📖 Rulebook</button>
                 </div>
-                <a href="/" class="btn" 
-   style="background: #2a1414; color: #ff6b6b;margin-top: 1rem;margin-bottom: 1.5rem; border: 1px solid #632424; text-decoration: none; text-align: center; display: block; line-height: 2.5;">
-    EXIT TO HOME
-</a>
+                <a href="/" class="btn" style="background: #2a1414; color: #ff6b6b;margin-top: 1rem;margin-bottom: 1.5rem; border: 1px solid #632424; text-decoration: none; text-align: center; display: block; line-height: 2.5;">
+                    EXIT TO HOME
+                </a>
             </div>
         </div>
 
-        <!-- Right Panel: Move History -->
         <div class="panel">
             <div class="card" style="height: 100%;">
                 <div class="card-title">Move History</div>
@@ -532,8 +449,7 @@
             </p>
             <div id="confirmTimerContainer" style="display: none; margin-bottom: 20px; text-align: left;">
                 <label style="color: #ccc; display: block; margin-bottom: 5px; font-size: 0.9rem;">Game Timer</label>
-                <select id="confirmTimerSelect"
-                    style="width: 100%; padding: 10px; border-radius: 5px; border: 1px solid #444; background: #1a1a2e; color: #fff; cursor: pointer;">
+                <select id="confirmTimerSelect" style="width: 100%; padding: 10px; border-radius: 5px; border: 1px solid #444; background: #1a1a2e; color: #fff; cursor: pointer;">
                     <option value="1|0">Bullet (1 min)</option>
                     <option value="1|1">Bullet (1 | 1)</option>
                     <option value="2|1">Bullet (2 | 1)</option>
@@ -553,8 +469,7 @@
             </div>
             <div id="confirmDifficultyContainer" style="display: none; margin-bottom: 20px; text-align: left;">
                 <label style="color: #ccc; display: block; margin-bottom: 5px; font-size: 0.9rem;">AI Difficulty</label>
-                <select id="confirmDifficultySelect"
-                    style="width: 100%; padding: 10px; border-radius: 5px; border: 1px solid #444; background: #1a1a2e; color: #fff;">
+                <select id="confirmDifficultySelect" style="width: 100%; padding: 10px; border-radius: 5px; border: 1px solid #444; background: #1a1a2e; color: #fff;">
                     <option value="easy">Easy</option>
                     <option value="medium" selected>Medium</option>
                     <option value="hard">Hard</option>
@@ -562,8 +477,7 @@
             </div>
             <div style="display: flex; gap: 12px; justify-content: center;">
                 <button class="btn btn-gold" id="confirmYesBtn" style="width: 90px;">Yes</button>
-                <button class="btn" id="confirmNoBtn"
-                    style="width: 90px; background: #333; color: #fff;">Cancel</button>
+                <button class="btn" id="confirmNoBtn" style="width: 90px; background: #333; color: #fff;">Cancel</button>
             </div>
         </div>
     </div>
@@ -574,13 +488,11 @@
             <p id="drawMessage" style="color: #ccc; margin-bottom: 20px; font-size: 1rem;"></p>
             <div style="display: flex; gap: 12px; justify-content: center;">
                 <button class="btn btn-gold" id="drawAcceptBtn" style="width: 90px;">Accept</button>
-                <button class="btn" id="drawDeclineBtn"
-                    style="width: 90px; background: #333; color: #fff;">Decline</button>
+                <button class="btn" id="drawDeclineBtn" style="width: 90px; background: #333; color: #fff;">Decline</button>
             </div>
         </div>
     </div>
 
-    <!-- ========== FEN MODAL ========== -->
     <div class="promo-overlay" id="fenOverlay">
         <div class="promo-dialog">
             <div class="promo-title">Start from FEN</div>
@@ -593,7 +505,6 @@
         </div>
     </div>
 
-    <!-- ========== PROMOTION MODAL ========== -->
     <div class="promo-overlay" id="promoOverlay">
         <div class="promo-dialog">
             <div class="promo-title">Promote Pawn</div>
@@ -601,44 +512,33 @@
         </div>
     </div>
 
-   <!-- ========== LEAVE GAME CONFIRMATION MODAL ========== -->
-<div class="promo-overlay" id="leaveConfirmOverlay" role="dialog" aria-modal="true" aria-labelledby="leaveConfirmTitle" aria-describedby="leaveConfirmMessage" aria-hidden="true">
-    <div class="promo-dialog" id="leaveConfirmDialog" tabindex="-1" style="max-width: 340px; text-align: center;">
-        <div class="promo-title" id="leaveConfirmTitle" style="font-size: 1.3rem; color: #f0c040; margin-bottom: 10px;">
-            Leave the Game?
+   <div class="promo-overlay" id="leaveConfirmOverlay" role="dialog" aria-modal="true" aria-labelledby="leaveConfirmTitle" aria-describedby="leaveConfirmMessage" aria-hidden="true">
+        <div class="promo-dialog" id="leaveConfirmDialog" tabindex="-1" style="max-width: 340px; text-align: center;">
+            <div class="promo-title" id="leaveConfirmTitle" style="font-size: 1.3rem; color: #f0c040; margin-bottom: 10px;">
+                Leave the Game?
+            </div>
+            <p id="leaveConfirmMessage" style="color: #ccc; margin-bottom: 25px; font-size: 0.95rem;">
+                Are you sure you want to go back to Home? Your current game progress will be lost.
+            </p>
+            <div style="display: flex; gap: 12px; justify-content: center;">
+                <button type="button" class="btn" id="leaveConfirmNo" style="background: #333; color: #fff; flex: 1;">Cancel</button>
+                <button type="button" class="btn btn-gold" id="leaveConfirmYes" style="flex: 1;">Back to Home</button>
+            </div>
         </div>
-        <p id="leaveConfirmMessage" style="color: #ccc; margin-bottom: 25px; font-size: 0.95rem;">
-            Are you sure you want to go back to Home? Your current game progress will be lost.
-        </p>
-        <div style="display: flex; gap: 12px; justify-content: center;">
-            <button type="button" class="btn" id="leaveConfirmNo"
-                style="background: #333; color: #fff; flex: 1;">
-                Cancel
-            </button>
-            <button type="button" class="btn btn-gold" id="leaveConfirmYes"
-                style="flex: 1;">
-                Back to Home
-            </button>
-        </div>
-    </div>
-</div> 
-    <!-- ========== GAME OVER MODAL ========== -->
+    </div> 
+
     <div class="promo-overlay" id="gameOverOverlay" style="z-index: 10000;">
         <div class="promo-dialog premium-result-dialog" role="dialog" aria-modal="true" aria-labelledby="gameOverTitle" aria-describedby="gameOverMessage">
             <div class="result-modal-columns">
-                <!-- Left Column: Banner, Illustration & Buttons -->
                 <div class="result-column-left">
-                    <!-- Dynamic Result Banner -->
                     <div id="gameOverBanner" class="result-banner">
                         <span class="banner-icon" id="bannerIcon">🏆</span>
                         <div class="promo-title" id="gameOverTitle" style="font-size: 1.6rem; margin-bottom: 2px;">Game Over</div>
                         <div class="banner-subtitle" id="gameOverMessage">Victory!</div>
                     </div>
 
-                    <!-- Result Illustration -->
                     <div id="gameOverIllustration" class="result-illustration"></div>
 
-                    <!-- Improved Action Buttons -->
                     <div class="modal-actions-container">
                         <button type="button" class="btn btn-gold action-btn-glow" id="resRematchBtn">
                             <span class="btn-icon">▶</span> Rematch
@@ -665,9 +565,7 @@
                     </div>
                 </div>
 
-                <!-- Right Column: Stats, Achievements & Review -->
                 <div class="result-column-right">
-                    <!-- Enhanced Match Summary Card -->
                     <div class="result-summary-card">
                         <div class="stats-grid">
                             <div class="stat-item">
@@ -704,7 +602,6 @@
                             </div>
                         </div>
 
-                        <!-- Material difference and captured pieces summary -->
                         <div class="summary-material-section">
                             <div class="captured-preview-container">
                                 <div class="captured-row-mini">
@@ -719,15 +616,12 @@
                         </div>
                     </div>
 
-                    <!-- Achievements & Highlights Section -->
                     <div class="achievements-section" id="resAchievementsSection">
                         <div class="section-subtitle">Notable Achievements</div>
                         <div class="achievements-list" id="resAchievementsList">
-                            <!-- Badges injected dynamically by board.js -->
-                        </div>
+                            </div>
                     </div>
 
-                    <!-- Game Review Preview -->
                     <div class="game-review-preview">
                         <div class="opening-row">
                             <span class="opening-icon">📖</span>
@@ -750,87 +644,69 @@
         </div>
     </div>
 
-    <!-- ========== SIDE SELECTION MODAL ========== -->
     <div class="promo-overlay" id="sideModal" style="display: none;">
         <div class="promo-dialog">
-            <div class="promo-title" style="font-size: 1.4rem; color: #f0c040; margin-bottom: 10px;">Choose Your Side
-            </div>
+            <div class="promo-title" style="font-size: 1.4rem; color: #f0c040; margin-bottom: 10px;">Choose Your Side</div>
             <p style="color: #aaa; margin-bottom: 25px; font-size: 0.9rem;">Which color do you want to play?</p>
             <div style="display: flex; flex-direction: column; gap: 12px;">
-                <button class="btn" id="chooseWhite"
-                    style="padding: 12px; background: #fff; color: #000; font-size: 1rem; border-radius: 6px;">
-                    Play as White
-                </button>
-                <button class="btn" id="chooseBlack"
-                    style="padding: 12px; background: #000; color: #fff; font-size: 1rem; border-radius: 6px; border: 1px solid #555;">
-                    Play as Black
-                </button>
-                <button class="btn btn-gold" id="chooseRandom" style="padding: 12px; font-size: 1rem;">
-                    Random
-                </button>
+                <button class="btn" id="chooseWhite" style="padding: 12px; background: #fff; color: #000; font-size: 1rem; border-radius: 6px;">Play as White</button>
+                <button class="btn" id="chooseBlack" style="padding: 12px; background: #000; color: #fff; font-size: 1rem; border-radius: 6px; border: 1px solid #555;">Play as Black</button>
+                <button class="btn btn-gold" id="chooseRandom" style="padding: 12px; font-size: 1rem;">Random</button>
             </div>
         </div>
     </div>
 
-    <!-- RULEBOOK MODAL -->
-    <div id="rulebookModal"
-        style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.85); z-index:9999; align-items:center; justify-content:center;">
-        <div
-            style="position:relative; width:min(95vw, 1400px); height:90vh; background:#13161e; border-radius:12px; overflow:hidden; padding-top:48px;">
-            <button type="button" aria-label="Close rulebook" onclick="document.getElementById('rulebookModal').style.display='none'"
-                style="position:absolute; top: 16px; right:16px; z-index:10; background:#333; border:none; color:#fff; width:32px; height:32px; border-radius:50%; cursor:pointer; font-size:1rem;">✕</button>
+    <div id="rulebookModal" style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.85); z-index:9999; align-items:center; justify-content:center;">
+        <div style="position:relative; width:min(95vw, 1400px); height:90vh; background:#13161e; border-radius:12px; overflow:hidden; padding-top:48px;">
+            <button type="button" aria-label="Close rulebook" onclick="document.getElementById('rulebookModal').style.display='none'" style="position:absolute; top: 16px; right:16px; z-index:10; background:#333; border:none; color:#fff; width:32px; height:32px; border-radius:50%; cursor:pointer; font-size:1rem;">✕</button>
             <iframe src="/rules/" style="width:100%; height:100%; border:none;"></iframe>
         </div>
     </div>
+    
     <div id="toast-container" class="toast-container"></div>
 
-
-<!-- ========== SHARE MODAL ========== -->
-<div id="shareModal" style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.75); z-index:99999; align-items:center; justify-content:center;">
-    <div style="background:#1a1a2e; border:1px solid #f0c040; border-radius:16px; padding:28px; max-width:380px; width:90%; text-align:center;">
-        <div style="font-size:1.1rem; color:#f0c040; font-weight:bold; margin-bottom:20px; letter-spacing:1px;">📤 Share Result</div>
-        <div id="resultCard" style="background:#0d0d1a; border:1px solid #333; border-radius:12px; padding:20px; margin-bottom:20px;">
-            <div style="font-size:1.3rem; font-weight:bold; color:#f0c040; margin-bottom:4px;">♟️ Checkora Chess</div>
-            <div style="height:1px; background:#333; margin:10px 0;"></div>
-            <div id="cardTitle" style="font-size:1.2rem; font-weight:bold; color:#fff; margin-bottom:6px;"></div>
-            <div id="cardMessage" style="font-size:0.9rem; color:#aaa; margin-bottom:14px;"></div>
-            <div style="display:flex; justify-content:center; gap:20px; margin-bottom:14px;">
-                <div style="background:#1a1a2e; border:1px solid #444; border-radius:8px; padding:10px 18px;">
-                    <div style="font-size:0.75rem; color:#888; margin-bottom:2px;">WHITE</div>
-                    <div id="cardWhite" style="font-size:1rem; color:#fff; font-weight:bold;"></div>
+    <div id="shareModal" style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.75); z-index:99999; align-items:center; justify-content:center;">
+        <div style="background:#1a1a2e; border:1px solid #f0c040; border-radius:16px; padding:28px; max-width:380px; width:90%; text-align:center;">
+            <div style="font-size:1.1rem; color:#f0c040; font-weight:bold; margin-bottom:20px; letter-spacing:1px;">📤 Share Result</div>
+            <div id="resultCard" style="background:#0d0d1a; border:1px solid #333; border-radius:12px; padding:20px; margin-bottom:20px;">
+                <div style="font-size:1.3rem; font-weight:bold; color:#f0c040; margin-bottom:4px;">♟️ Checkora Chess</div>
+                <div style="height:1px; background:#333; margin:10px 0;"></div>
+                <div id="cardTitle" style="font-size:1.2rem; font-weight:bold; color:#fff; margin-bottom:6px;"></div>
+                <div id="cardMessage" style="font-size:0.9rem; color:#aaa; margin-bottom:14px;"></div>
+                <div style="display:flex; justify-content:center; gap:20px; margin-bottom:14px;">
+                    <div style="background:#1a1a2e; border:1px solid #444; border-radius:8px; padding:10px 18px;">
+                        <div style="font-size:0.75rem; color:#888; margin-bottom:2px;">WHITE</div>
+                        <div id="cardWhite" style="font-size:1rem; color:#fff; font-weight:bold;"></div>
+                    </div>
+                    <div style="font-size:1.4rem; color:#f0c040; align-self:center;">vs</div>
+                    <div style="background:#1a1a2e; border:1px solid #444; border-radius:8px; padding:10px 18px;">
+                        <div style="font-size:0.75rem; color:#888; margin-bottom:2px;">BLACK</div>
+                        <div id="cardBlack" style="font-size:1rem; color:#fff; font-weight:bold;"></div>
+                    </div>
                 </div>
-                <div style="font-size:1.4rem; color:#f0c040; align-self:center;">vs</div>
-                <div style="background:#1a1a2e; border:1px solid #444; border-radius:8px; padding:10px 18px;">
-                    <div style="font-size:0.75rem; color:#888; margin-bottom:2px;">BLACK</div>
-                    <div id="cardBlack" style="font-size:1rem; color:#fff; font-weight:bold;"></div>
+                <div style="background:#1a1a2e; border:1px solid #333; border-radius:8px; padding:8px; font-size:0.85rem; color:#aaa;">
+                    🔢 Moves played: <span id="cardMoves" style="color:#f0c040; font-weight:bold;"></span>
                 </div>
+                <div style="height:1px; background:#333; margin:12px 0;"></div>
+                <div style="font-size:0.78rem; color:#555;">🎮 checkora.vercel.app</div>
             </div>
-            <div style="background:#1a1a2e; border:1px solid #333; border-radius:8px; padding:8px; font-size:0.85rem; color:#aaa;">
-                🔢 Moves played: <span id="cardMoves" style="color:#f0c040; font-weight:bold;"></span>
+            <div style="display:flex; flex-direction:column; gap:10px;">
+                <div style="display:flex; gap:10px;">
+                    <button type="button" id="copyTextBtn" class="btn btn-gold" style="padding:10px; flex:1;">📋 Copy Text</button>
+                    <button type="button" id="copyLinkBtn" class="btn btn-gold" style="padding:10px; flex:1;">🔗 Copy Link</button>
+                </div>
+                <button type="button" id="whatsappBtn" style="padding:10px; border-radius:8px; background:#25D366; color:#fff; border:none; font-size:0.95rem; cursor:pointer; font-weight:bold;">💬 Share on WhatsApp</button>
+                <button type="button" id="twitterBtn" style="padding:10px; border-radius:8px; background:#1DA1F2; color:#fff; border:none; font-size:0.95rem; cursor:pointer; font-weight:bold; display:flex; align-items:center; justify-content:center; gap:8px;">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" style="display:inline-block; vertical-align:middle;">
+                        <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+                    </svg>
+                    Share on X (Twitter)
+                </button>
+                <button type="button" id="closeShareBtn" class="btn" style="padding:10px; background:#333; color:#fff;">Close</button>
             </div>
-            <div style="height:1px; background:#333; margin:12px 0;"></div>
-            <div style="font-size:0.78rem; color:#555;">🎮 checkora.vercel.app</div>
-        </div>
-        <div style="display:flex; flex-direction:column; gap:10px;">
-            <div style="display:flex; gap:10px;">
-                <button type="button" id="copyTextBtn" class="btn btn-gold" style="padding:10px; flex:1;">📋 Copy Text</button>
-                <button type="button" id="copyLinkBtn" class="btn btn-gold" style="padding:10px; flex:1;">🔗 Copy Link</button>
-            </div>
-            <button type="button" id="whatsappBtn" style="padding:10px; border-radius:8px; background:#25D366; color:#fff; border:none; font-size:0.95rem; cursor:pointer; font-weight:bold;">💬 Share on WhatsApp</button>
-            <button type="button" id="twitterBtn" style="padding:10px; border-radius:8px; background:#1DA1F2; color:#fff; border:none; font-size:0.95rem; cursor:pointer; font-weight:bold; display:flex; align-items:center; justify-content:center; gap:8px;">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" style="display:inline-block; vertical-align:middle;">
-                    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
-                </svg>
-                Share on X (Twitter)
-            </button>
-            <button type="button" id="closeShareBtn" class="btn" style="padding:10px; background:#333; color:#fff;">Close</button>
         </div>
     </div>
-</div>
 
-    <!-- ========================================================
-         JAVASCRIPT
-         ======================================================== -->
     <script src="{% static 'game/js/toast.js' %}"></script>
     <script src="{% static 'game/js/dropdown.js' %}"></script>
     <script>
@@ -840,66 +716,55 @@
     <script src="{% static 'game/js/board.js' %}"></script>
 
     <script>
-document.getElementById('shareResultBtn').addEventListener('click', function () {
-    const title = document.getElementById('gameOverTitle').innerText.trim();
-    const message = document.getElementById('gameOverMessage').innerText.trim();
-    const whiteName = document.getElementById('whiteNameLabel').innerText.trim();
-    const blackName = document.getElementById('blackNameLabel').innerText.trim();
-    const movesList = document.getElementById('movesList');
-    const moveCount = movesList.querySelectorAll('span:not(.placeholder)').length ||
-                      movesList.innerText.split('\n').filter(x => x.trim()).length;
+        document.getElementById('shareResultBtn').addEventListener('click', function () {
+            const title = document.getElementById('gameOverTitle').innerText.trim();
+            const message = document.getElementById('gameOverMessage').innerText.trim();
+            const whiteName = document.getElementById('whiteNameLabel').innerText.trim();
+            const blackName = document.getElementById('blackNameLabel').innerText.trim();
+            const movesList = document.getElementById('movesList');
+            const moveCount = movesList.querySelectorAll('span:not(.placeholder)').length ||
+                              movesList.innerText.split('\n').filter(x => x.trim()).length;
 
-    document.getElementById('cardTitle').innerText = title;
-    document.getElementById('cardMessage').innerText = message;
-    document.getElementById('cardWhite').innerText = whiteName;
-    document.getElementById('cardBlack').innerText = blackName;
-    document.getElementById('cardMoves').innerText = moveCount;
+            document.getElementById('cardTitle').innerText = title;
+            document.getElementById('cardMessage').innerText = message;
+            document.getElementById('cardWhite').innerText = whiteName;
+            document.getElementById('cardBlack').innerText = blackName;
+            document.getElementById('cardMoves').innerText = moveCount;
 
-    const shareText =
-`♟️ Checkora Chess
-─────────────────
-${title}
-${message}
+            const shareText = `♟️ Checkora Chess\n─────────────────\n${title}\n${message}\n\n⚪ ${whiteName} vs ⚫ ${blackName}\n🔢 Moves played: ${moveCount}\n─────────────────\n🎮 Play at: https://checkora.vercel.app`;
 
-⚪ ${whiteName} vs ⚫ ${blackName}
-🔢 Moves played: ${moveCount}
-─────────────────
-🎮 Play at: https://checkora.vercel.app`;
+            const modal = document.getElementById('shareModal');
+            modal.style.display = 'flex';
 
-    const modal = document.getElementById('shareModal');
-    modal.style.display = 'flex';
+            document.getElementById('copyTextBtn').onclick = function () {
+                navigator.clipboard.writeText(shareText).then(() => {
+                    this.innerText = '✅ Copied!';
+                    setTimeout(() => this.innerText = '📋 Copy Text', 2000);
+                });
+            };
 
-    document.getElementById('copyTextBtn').onclick = function () {
-        navigator.clipboard.writeText(shareText).then(() => {
-            this.innerText = '✅ Copied!';
-            setTimeout(() => this.innerText = '📋 Copy Text', 2000);
+            document.getElementById('copyLinkBtn').onclick = function () {
+                navigator.clipboard.writeText('https://checkora.vercel.app').then(() => {
+                    this.innerText = '✅ Link Copied!';
+                    setTimeout(() => this.innerText = '🔗 Copy Link', 2000);
+                });
+            };
+
+            document.getElementById('whatsappBtn').onclick = function () {
+                const encoded = encodeURIComponent(shareText);
+                window.open(`https://wa.me/?text=${encoded}`, '_blank', 'noopener,noreferrer');
+            };
+
+            document.getElementById('twitterBtn').onclick = function () {
+                const encoded = encodeURIComponent(shareText);
+                window.open(`https://twitter.com/intent/tweet?text=${encoded}`, '_blank', 'noopener,noreferrer');
+            };
+
+            document.getElementById('closeShareBtn').onclick = function () {
+                modal.style.display = 'none';
+            };
         });
-    };
-
-    document.getElementById('copyLinkBtn').onclick = function () {
-        navigator.clipboard.writeText('https://checkora.vercel.app').then(() => {
-            this.innerText = '✅ Link Copied!';
-            setTimeout(() => this.innerText = '🔗 Copy Link', 2000);
-        });
-    };
-
-    document.getElementById('whatsappBtn').onclick = function () {
-        const encoded = encodeURIComponent(shareText);
-        window.open(`https://wa.me/?text=${encoded}`, '_blank', 'noopener,noreferrer');
-    };
-
-    document.getElementById('twitterBtn').onclick = function () {
-        const encoded = encodeURIComponent(shareText);
-        window.open(`https://twitter.com/intent/tweet?text=${encoded}`, '_blank', 'noopener,noreferrer');
-    };
-
-    document.getElementById('closeShareBtn').onclick = function () {
-        modal.style.display = 'none';
-    };
-});
-</script>
-<script src="{% static 'game/js/theme.js' %}?v=1"></script>
+    </script>
+    <script src="{% static 'game/js/theme.js' %}?v=1"></script>
 </body>
-
-
 </html>


### PR DESCRIPTION
## Description

Refactored the welcome screen UI to provide a clearer, two-step game setup process, resolving the confusing UX where all inputs and mode buttons were displayed simultaneously.

**Key Changes:**
* Hid the `#nameInputs` container by default on initial load.
* Implemented a multi-step flow in `board.js`: users now select their game mode first, which dynamically reveals the appropriate setup inputs (e.g., hiding the Black player name input for AI games).
* Added a dedicated `Start Pass & Play` button to initialize the board instead of using the mode selector button.
* Added a `Back` button to allow users to return to the mode selection screen.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #1653

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)
<img width="1070" height="718" alt="Screenshot 2026-06-20 at 11 26 27 PM" src="https://github.com/user-attachments/assets/f1a50847-60ed-4376-bd93-cf6bac760320" />


