### PR TITLE
Fix rulebook modal overlap with mobile FAB controls

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -1796,7 +1796,7 @@ body {
 }
 
   .m-fab {
-  display: flex;
+  display: none;
   flex-direction: column;
   gap: 10px;
   position: fixed;

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -774,7 +774,7 @@
 
     <!-- RULEBOOK MODAL -->
     <div id="rulebookModal"
-        style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.85); z-index:9999; align-items:center; justify-content:center;">
+        style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.85); z-index:10001; align-items:center; justify-content:center;">
         <div
             style="position:relative; width:min(95vw, 1400px); height:90vh; background:#13161e; border-radius:12px; overflow:hidden; padding-top:48px;">
             <button type="button" aria-label="Close rulebook" onclick="document.getElementById('rulebookModal').style.display='none'"

--- a/game/templates/game/rules.html
+++ b/game/templates/game/rules.html
@@ -53,6 +53,7 @@
             width: 100%;
             z-index: 100;
         }
+        
 
         .header-left {
             display: flex;


### PR DESCRIPTION
## Description

This PR fixes the overlap issue between the Rulebook modal and the floating action buttons (Resume/Resign) on the game board.

### Changes made:

* Increased the Rulebook modal z-index so it properly appears above the floating action buttons.
* Fixed a CSS cascade issue in `.m-fab` where duplicate declarations caused the mobile floating action buttons to appear on all screen sizes.
* Restored the intended mobile-only behavior for the FAB controls.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

## Related Issue

Fixes #1818 

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [ ] I have commented my code where necessary
* [ ] I have updated the documentation if needed
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix/feature works
* [x] New and existing tests pass locally

Before:

* Rulebook modal appeared below the floating action buttons, causing visual overlap.

After:

* Rulebook modal correctly overlays the floating action buttons.
* FAB controls are displayed only on mobile devices as intended.

## Additional Notes

This change is limited to CSS and modal layering behavior and does not affect game logic or existing functionality.
