### PR TITLE
feat: add full keyboard navigation to lesson practice boards

### DIFF
--- a/game/static/game/css/lesson.css
+++ b/game/static/game/css/lesson.css
@@ -371,7 +371,7 @@ h1 {
     pointer-events: none;
     transition: opacity 0.2s ease;
 }
-/*KEYBOARD NAVIGATION */
+/* KEYBOARD NAVIGATION */
 .lesson-square:focus,
 .lesson-square:focus-visible {
     outline: 3px solid #baca2b;

--- a/game/static/game/css/lesson.css
+++ b/game/static/game/css/lesson.css
@@ -371,3 +371,19 @@ h1 {
     pointer-events: none;
     transition: opacity 0.2s ease;
 }
+/*KEYBOARD NAVIGATION */
+.lesson-square:focus,
+.lesson-square:focus-visible {
+    outline: 3px solid #baca2b;
+    outline-offset: -3px;
+    z-index: 10;
+    position: relative;
+    box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.4);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .lesson-square:focus,
+    .lesson-square:focus-visible {
+        transition: none !important;
+    }
+}

--- a/game/static/game/js/lesson_practice.js
+++ b/game/static/game/js/lesson_practice.js
@@ -290,7 +290,7 @@ document.addEventListener(
         };
 
         board.innerHTML = "";
-
+        let selectedSquare = null;
         for (
             let row = 8;
             row >= 1;
@@ -326,6 +326,39 @@ document.addEventListener(
                 square.dataset.square =
                     squareName;
 
+                // --- NEW KEYBOARD NAV CODE ---
+                square.setAttribute("tabindex", "0");
+                square.dataset.r = row;
+                square.dataset.c = col;
+
+                square.addEventListener("keydown", (e) => {
+                    let r = parseInt(square.dataset.r);
+                    let c = parseInt(square.dataset.c);
+                    switch(e.key) {
+                        case 'ArrowUp': e.preventDefault(); r = Math.min(8, r + 1); break;
+                        case 'ArrowDown': e.preventDefault(); r = Math.max(1, r - 1); break;
+                        case 'ArrowLeft': e.preventDefault(); c = Math.max(0, c - 1); break;
+                        case 'ArrowRight': e.preventDefault(); c = Math.min(7, c + 1); break;
+                        case 'Enter':
+                        case ' ':
+                            e.preventDefault();
+                            square.click(); // Trigger standard move logic
+                            return;
+                        case 'Escape':
+                            e.preventDefault();
+                            if (selectedSquare) {
+                                selectedSquare.classList.remove("selected-square");
+                                document.querySelectorAll(".valid-move").forEach(sq => sq.classList.remove("valid-move"));
+                                selectedSquare = null;
+                                currentLegalMoves = [];
+                            }
+                            return;
+                        default: return;
+                    }
+                    // Move visual focus to the new square
+                    const target = board.querySelector(`.lesson-square[data-r="${r}"][data-c="${c}"]`);
+                    if (target) target.focus();
+                });
                 if (
                     position[squareName]
                 ) {
@@ -344,7 +377,7 @@ document.addEventListener(
             }
         }
 
-        let selectedSquare = null;
+        // let selectedSquare = null;
 
         board.addEventListener(
             "click",


### PR DESCRIPTION
## Description

This PR introduces full keyboard-driven navigation to the interactive lesson practice boards, bringing them to parity with the main game board's accessibility features.

Key changes include:
* **Grid Navigation:** Added `keydown` event listeners in `lesson_practice.js` to allow traversing the lesson board squares using the Arrow Keys (↑,↓,←,→).
* **Action Controls:** Users can now select and execute piece moves using `Enter` or `Spacebar`, and cleanly cancel selections using the `Escape` key.
* **Visual Focus Indicators:** Implemented high-contrast `:focus` and `:focus-visible` outlines (with a subtle inner box-shadow) in `lesson.css` so users can clearly track their active position.
* **Accessibility:** Added `@media (prefers-reduced-motion: reduce)` support to disable transitions on focus states for users who prefer reduced motion.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #1952 
Extends the accessibility enhancements discussed and implemented in #1952 to the lesson practice boards.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

https://github.com/user-attachments/assets/09ad5b09-cf8d-4be0-acc3-1e6ace1e9c5a


## Additional Notes

I'm a GSSOC contributor.
Expected labels to apply 
enhancement quality:clean type:performance 
