### PR TITLE
fix: return actual puzzle stats instead of hardcoded values

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -1912,10 +1912,13 @@ def update_puzzle_stats(request):
     return JsonResponse({"success": True})
 
 
+@login_required
+@require_GET
 def puzzle_stats_view(request):
+    stats, _ = PuzzleStats.objects.get_or_create(user=request.user)
     return JsonResponse({
-        "streak": 0,
-        "longest_streak": 0
+        "streak": stats.current_streak,
+        "longest_streak": stats.best_streak
     })
 
 

--- a/game/views.py
+++ b/game/views.py
@@ -1912,9 +1912,12 @@ def update_puzzle_stats(request):
     return JsonResponse({"success": True})
 
 
-@login_required
-@require_GET
 def puzzle_stats_view(request):
+    if not request.user.is_authenticated:
+        return JsonResponse({
+            "streak": 0,
+            "longest_streak": 0
+        })
     stats, _ = PuzzleStats.objects.get_or_create(user=request.user)
     return JsonResponse({
         "streak": stats.current_streak,


### PR DESCRIPTION
## Description

Fixed Issue #1964 by replacing the hardcoded puzzle statistics response in `puzzle_stats_view` with the authenticated user's actual puzzle statistics from the database.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

## Related Issue

Fixes #1964

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [ ] I have commented my code where necessary
* [ ] I have updated the documentation if needed
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix/feature works
* [x] New and existing tests pass locally

## Screenshots (if applicable)

N/A

## Additional Notes

Updated `puzzle_stats_view` to retrieve puzzle statistics using `PuzzleStats.objects.get_or_create()` and return actual user progress instead of hardcoded values.
