### PR TITLE
fix: remove duplicate theme.js import causing theme toggle issues

### DIFF
--- a/game/templates/game/landing.html
+++ b/game/templates/game/landing.html
@@ -1196,7 +1196,7 @@
     });
   })();
   </script>
-  <script src="{% static 'game/js/theme.js' %}"></script>
+  <!-- <script src="{% static 'game/js/theme.js' %}"></script> -->
 
   <div id="disclaimerModal" role="dialog" aria-modal="true" aria-labelledby="disclaimerModalTitle"
       style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.85); z-index:9999; align-items:center; justify-content:center;">


### PR DESCRIPTION
## Description

This PR fixes a landing page issue where the theme toggle was not functioning correctly due to duplicate imports of `theme.js`.

During investigation of Issue #2052, it was found that `game/templates/game/landing.html` imported `theme.js` twice:

* `{% static 'game/js/theme.js' %}`
* `{% static 'game/js/theme.js' %}?v=1`

This caused duplicate initialization of the theme toggle functionality and multiple click listeners to be attached to `#themeToggle`, resulting in inconsistent theme switching behavior.

The duplicate import has been removed, leaving a single versioned import.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

## Related Issue

Fixes #2052

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [ ] I have commented my code where necessary (not applicable for this change)
* [ ] I have updated the documentation if needed (not applicable for this change)
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix/feature works
* [x] New and existing tests pass locally

## Screenshots (if applicable)

### Before

* The theme toggle was not functioning correctly on the landing page.
* Duplicate initialization resulted in multiple click listeners being attached to `#themeToggle`.

### After

* Only one instance of `theme.js` is loaded.
* The theme toggle correctly switches between light and dark modes.

<img width="1512" height="831" alt="Screenshot 2026-06-24 at 1 39 49 AM" src="https://github.com/user-attachments/assets/44fcec0c-8e53-4d0a-8e5b-076340aecf62" />

<img width="1512" height="822" alt="Screenshot 2026-06-24 at 1 40 04 AM" src="https://github.com/user-attachments/assets/cb91d55f-4089-4516-9796-9ad80ddc671e" />

## Testing

* Verified only one `theme.js` import remains on the landing page.
* Verified only one click listener is attached to `#themeToggle`.
* Verified the theme toggle correctly switches between light and dark modes.
* Verified theme changes persist correctly after toggling.

## Additional Notes

The root cause was a duplicate import of `theme.js` in `game/templates/game/landing.html`. Removing the redundant import resolved the issue and restored expected theme toggle behavior.
