### PR TITLE
fix: conditionally hide custom cursor on default mode

### DIFF
--- a/game/templates/game/landing.html
+++ b/game/templates/game/landing.html
@@ -1809,7 +1809,12 @@
     const cursorTypeLabel = document.getElementById('cursorTypeLabel');
     const cursorOptions = document.querySelectorAll('.cursor-type-option');
     let activeCursor = 'default';
-
+    // Only hide it if it's explicitly set to 'default'
+    if (activeCursor === 'default') {
+        cursor.style.display = 'none';
+    } else {
+        cursor.style.display = 'block';
+    }
     let mouseX = 0;
     let mouseY = 0;
 
@@ -1840,7 +1845,12 @@
       cursorOptions.forEach(option => {
         option.classList.toggle('selected', option.dataset.cursor === type);
       });
+      if (type === 'default') {
+        cursor.style.display = 'none';
+    } else {
+        cursor.style.display = 'block';
     }
+  }
 
     cursorTrigger.addEventListener('click', e => {
       e.stopPropagation();

--- a/game/templates/game/landing.html
+++ b/game/templates/game/landing.html
@@ -1832,26 +1832,24 @@
     updateCursorPosition();
 
     function updateCursorType(type) {
-      activeCursor = type;
-      cursor.className = 'cursor';
-      if (type !== 'default') {
-         cursor.classList.add(type);
-         cursor.style.opacity = '0.98';
-       } else {
-         cursor.style.opacity = '0';
-       }
+    activeCursor = type;
+    cursor.className = 'cursor';
+    
+    if (type !== 'default') {
+        cursor.classList.add(type);
+        cursor.style.opacity = '0.98';
+        cursor.style.display = 'block'; // Centralized!
+    } else {
+        cursor.style.opacity = '0';
+        cursor.style.display = 'none';  // Centralized!
+    }
       cursorTypeLabel.textContent = type.charAt(0).toUpperCase() + type.slice(1);
       document.body.classList.toggle('hide-native-cursor', type !== 'default');
       cursorOptions.forEach(option => {
         option.classList.toggle('selected', option.dataset.cursor === type);
       });
-      if (type === 'default') {
-        cursor.style.display = 'none';
-    } else {
-        cursor.style.display = 'block';
-    }
   }
-
+updateCursorType('default');
     cursorTrigger.addEventListener('click', e => {
       e.stopPropagation();
       cursorDropdown.classList.toggle('active');


### PR DESCRIPTION
## Description

This PR resolves the issue where the custom cursor was visible on page load even when the "Default" cursor mode was selected. The visibility logic has been centralized within the updateCursorType function to ensure consistent behavior across all modes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #2046

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally