### PR TITLE
Refactor/replace print with logging

### DIFF
--- a/game/analysis.py
+++ b/game/analysis.py
@@ -1,5 +1,8 @@
 import os
 import json
+import logging
+
+logger = logging.getLogger(__name__)
 
 # Load the opening book JSON once on startup
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -10,8 +13,7 @@ try:
         OPENINGS = json.load(f)
 except FileNotFoundError:
     OPENINGS = {}
-    # TODO: replace with project logger
-    print(f"warning: opening book not found at {OPENINGS_JSON_PATH}")
+    logger.warning("Opening book not found at %s", OPENINGS_JSON_PATH)
 except json.JSONDecodeError as exc:
     raise RuntimeError(f"invalid openings.json: {exc}") from exc
 


### PR DESCRIPTION
### Description

This PR refactors `game/analysis.py` to replace a standard `print()` statement with Django's logging configuration, resolving the existing `# TODO: replace with project logger` comment on line 13.

Currently, if `openings.json` is not found, the warning is printed using a standard `print()` statement, which is not captured by Django's configured logging system. This refactor ensures warnings are correctly captured.

### Changes

- Imported the `logging` module in `game/analysis.py`.
- Instantiated the logger using `logger = logging.getLogger(__name__)`.
- Replaced the `print(f"warning: opening book not found at {OPENINGS_JSON_PATH}")` statement with:
  ```python
  logger.warning("Opening book not found at %s", OPENINGS_JSON_PATH)
- Removed the `# TODO: replace with project logger` comment.

### Related Issue
Closes #1950