### PR TITLE
fix: remove duplicate theme.js import causing theme toggle issues

### DIFF
--- a/game/templates/game/landing.html
+++ b/game/templates/game/landing.html
@@ -1196,7 +1196,7 @@
     });
   })();
   </script>
-  <script src="{% static 'game/js/theme.js' %}"></script>
+  <!-- <script src="{% static 'game/js/theme.js' %}"></script> -->
 
   <div id="disclaimerModal" role="dialog" aria-modal="true" aria-labelledby="disclaimerModalTitle"
       style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.85); z-index:9999; align-items:center; justify-content:center;">


### PR DESCRIPTION
## Description

This PR fixes a landing page issue where the theme toggle was not functioning correctly due to duplicate imports of `theme.js`.

During investigation of Issue #2052, it was found that `game/templates/game/landing.html` imported `theme.js` twice:

* `{% static 'game/js/theme.js' %}`
* `{% static 'game/js/theme.js' %}?v=1`

This caused duplicate initialization of the theme toggle functionality and multiple click listeners to be attached to `#themeToggle`, resulting in inconsistent theme switching behavior.

The duplicate import has been removed, leaving a single versioned import and ensuring the theme toggle is initialized only once.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

## Related Issue

Fixes #2052

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] No additional code comments were required for this change
* [x] No documentation updates were required for this change
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix/feature works
* [x] New and existing tests pass locally

## Screenshots (if applicable)

### Before

* The landing page loaded `theme.js` twice.
* Multiple click listeners were attached to `#themeToggle`.
* Theme switching behavior was inconsistent due to duplicate initialization.

### After

* Only one `theme.js` import remains on the landing page.
* Only one click listener is attached to `#themeToggle`.
* Theme toggle correctly switches between light and dark modes.
* Theme preference persists correctly through localStorage.

### Verification Screenshots
<img width="1512" height="860" alt="Screenshot 2026-06-24 at 3 32 46 PM" src="https://github.com/user-attachments/assets/360d6c9c-c4ba-431c-bab2-0d2b8e763e48" />
<img width="1512" height="861" alt="Screenshot 2026-06-24 at 3 33 08 PM" src="https://github.com/user-attachments/assets/57cc5164-2628-414b-84b4-b967e7a8fc78" />


## Verification

* Verified only one `theme.js` import remains in `game/templates/game/landing.html`.
* Verified the theme toggle correctly switches between light and dark modes.
* Verified theme preference persists after page refresh.
* Verified duplicate initialization no longer occurs.

## Additional Notes

The root cause was a duplicate import of `theme.js` in `game/templates/game/landing.html`. Removing the redundant import resolved the issue and restored expected theme toggle behavior without affecting other functionality.
