### PR TITLE
Fix profile dropdown missing on homepage (#2047)

### DIFF
--- a/game/static/game/css/landing.css
+++ b/game/static/game/css/landing.css
@@ -484,13 +484,6 @@ body.hide-native-cursor * {
     transition-delay: 0s;
 }
 
-.profile-dropdown:hover .dropdown-content {
-    display: block;
-}
-
-.profile-dropdown:focus-within .dropdown-content {
-    display: block;
-}
 .profile-dropdown:not(.active) .dropdown-content {
     transition-delay: 0.15s;
 }

--- a/game/templates/game/landing.html
+++ b/game/templates/game/landing.html
@@ -1799,7 +1799,6 @@
 
 })();
 </script>
-  <script src="{% static 'game/js/dropdown.js' %}"></script>
   <div class="cursor"></div>
   <script>
     const cursor = document.querySelector('.cursor');


### PR DESCRIPTION
## Description

Fixes #2047 - User Profile Dropdown Missing on Home Page While Available on Game Page.

### Root Cause

The profile dropdown functionality already existed on the Home Page, but it was not working correctly because:

1. `dropdown.js` was loaded twice in `landing.html`, causing duplicate click event handlers.
2. Clicking the profile button triggered both handlers, which immediately toggled the dropdown open and then closed it.
3. Additional hover/focus CSS rules conflicted with the click-based dropdown behavior used on the Game Page.

### Changes Made

- Removed the duplicate `dropdown.js` script inclusion.
- Removed conflicting hover/focus dropdown CSS rules.
- Reused the existing dropdown implementation instead of introducing new code.
- Ensured the Home Page behavior matches the Game Page.

### Testing

- Logged into a local development environment.
- Verified the profile dropdown opens on click.
- Verified clicking outside closes the dropdown.
- Verified keyboard interactions still work.
- Confirmed behavior is now consistent between Home Page and Game Page.

Fixes #2047