### PR TITLE
test(progression): add unit test coverage for calculate_level

### DIFF
--- a/game/test_progression.py
+++ b/game/test_progression.py
@@ -1,0 +1,36 @@
+from django.test import TestCase
+from game.progression import calculate_level, LEVEL_THRESHOLDS
+
+class ProgressionTests(TestCase):
+    def test_calculate_level_standard_values(self):
+        """Test that standard XP values return the correct level based on thresholds."""
+        self.assertEqual(calculate_level(0), 1)
+        self.assertEqual(calculate_level(50), 1)
+        self.assertEqual(calculate_level(100), 2)
+        self.assertEqual(calculate_level(150), 2)
+        self.assertEqual(calculate_level(250), 3)
+        self.assertEqual(calculate_level(1000), 5)
+        self.assertEqual(calculate_level(1500), 6)
+
+    def test_calculate_level_exact_boundaries(self):
+        """Test the exact inclusive threshold boundaries."""
+        for level, threshold in LEVEL_THRESHOLDS.items():
+            self.assertEqual(calculate_level(threshold), level)
+
+    def test_calculate_level_max_cap(self):
+        """Test XP values exceeding the highest threshold correctly cap at max level."""
+        max_level = max(LEVEL_THRESHOLDS.keys())
+        highest_threshold = max(LEVEL_THRESHOLDS.values())
+        
+        self.assertEqual(calculate_level(highest_threshold), max_level)
+        self.assertEqual(calculate_level(highest_threshold + 5000), max_level)
+        self.assertEqual(calculate_level(999999), max_level)
+
+    def test_calculate_level_negative_xp(self):
+        """Test that passing a negative XP value raises a ValueError."""
+        with self.assertRaises(ValueError) as context:
+            calculate_level(-1)
+        self.assertEqual(str(context.exception), "xp must be non-negative, got -1")
+        
+        with self.assertRaises(ValueError):
+            calculate_level(-1000)


### PR DESCRIPTION
## Description

Adds dedicated unit test coverage for `calculate_level()` in `game/progression.py`.

### Changes Made

* Added tests for standard XP values
* Added tests for exact level threshold boundaries
* Added tests for maximum level cap handling
* Added tests for negative XP exception handling

### Test Coverage

The new test suite verifies:

* Correct level calculation for typical XP values
* Inclusive behavior at exact threshold boundaries
* Proper capping at Level 8 for very large XP values
* Correct `ValueError` raising for negative XP inputs

## Type of Change

* [x] Documentation update

## Related Issue

Fixes #2062

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [ ] I have commented my code where necessary
* [ ] I have updated the documentation if needed
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix/feature works
* [x] New and existing tests pass locally

## Screenshots (if applicable)

N/A

## Additional Notes

This PR improves test coverage for the progression system by adding isolated unit tests for the `calculate_level()` utility function.
