### PR TITLE
fix: resolve issue assignment notification workflow failure

### DIFF
--- a/.github/workflows/issue-assignment-notify.yml
+++ b/.github/workflows/issue-assignment-notify.yml
@@ -10,7 +10,7 @@ permissions: {}
 jobs:
   notify:
     permissions:
-        issues: write
+      issues: write
     runs-on: ubuntu-latest
 
     steps:
@@ -22,27 +22,30 @@ jobs:
             const issue = context.payload.issue;
             const assignee = context.payload.assignee.login;
 
+             if (!assignee) {
+                core.setFailed("No assignee found in payload.");
+                return;
+              }
+
+            const message = [
+              `👋 Hi @${assignee},`,
+              "",
+              "Thank you for taking up this issue.",
+              "",
+              "⏳ Please open a pull request within **36 hours** of assignment to indicate active work.",
+              "",
+              "📢 A reminder will be posted after 24 hours if no PR has been opened.",
+              "",
+              "⚠️ If no pull request is opened within 36 hours, the issue may be automatically unassigned and made available for reassignment.",
+              "",
+              "If you need additional time, please leave a progress update comment on this issue.",
+              "",
+              "Happy coding! 🚀",
+            ].join("\n");
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issue.number,
-             await github.rest.issues.createComment({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               issue_number: issue.number,
-               body: [
-                 `👋 hi @${assignee},`,
-                 "",
-                 "thank you for taking up this issue.",
-                 "",
-                 "⏳ please open a pull request within **36 hours** of assignment to indicate active work.",
-                 "",
-                 "📢 a reminder will be posted after 24 hours if no pr has been opened.",
-                 "",
-                 "⚠️ if no pull request is opened within 36 hours, the issue may be automatically unassigned and made available for reassignment.",
-                 "",
-                 "if you need additional time, please leave a progress update comment on this issue.",
-                 "",
-                 "happy coding! 🚀",
-               ].join("\n")
-             });
+              body: message,
+            });

--- a/.github/workflows/issue-assignment-notify.yml
+++ b/.github/workflows/issue-assignment-notify.yml
@@ -20,12 +20,14 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const issue = context.payload.issue;
-            const assignee = context.payload.assignee.login;
+            const assigneeObj = context.payload.assignee;
 
-             if (!assignee) {
-                core.setFailed("No assignee found in payload.");
-                return;
-              }
+            if (!assigneeObj || !assigneeObj.login) {
+              core.setFailed("No assignee found in payload.");
+              return;
+            }
+
+            const assignee = assigneeObj.login;
 
             const message = [
               `👋 Hi @${assignee},`,


### PR DESCRIPTION
## Summary

This PR fixes the Issue Assignment Notification workflow that was failing to execute when an issue was assigned to a contributor.

## Changes Made

* Removed duplicate `createComment()` invocation from the workflow script.
* Cleaned up the GitHub Actions script structure.
* Added assignee validation before attempting to post a notification.
* Preserved the existing assignment reminder flow:

  * Immediate assignment notification
  * 24-hour reminder
  * 36-hour reassignment policy

## Problem

The workflow was throwing a JavaScript syntax error and failing before posting the assignment notification comment.

As a result, contributors were not receiving the intended notification when an issue was assigned.

## Testing

* Verified workflow YAML structure.
* Verified GitHub Script syntax.
* Confirmed that only a single comment creation request is executed.
* Confirmed assignee validation is handled safely.

## Related Issue

Closes #2067
