### PR TITLE
fix: correct Google Fonts URLs on landing page

### DIFF
--- a/game/templates/game/landing.html
+++ b/game/templates/game/landing.html
@@ -81,14 +81,12 @@
       type="image/jpeg"
       href="{% static 'game/favicon.jpeg' %}"
     />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Cinzel:wght=400;700&display=swap"
-      rel="stylesheet"
-    />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght=400;500;600;700&display=swap"
-      rel="stylesheet"
-    />
+   
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
+
+    
+
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@600&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Description

This PR corrects the Google Fonts stylesheet URLs used on the landing page.

The updated URLs ensure the required font stylesheets are loaded successfully, allowing the intended typography to be applied consistently across the landing page.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #2076

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] No additional code comments were required for this change
- [x] No documentation updates were required for this change
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

### Before
<img width="1512" height="860" alt="Screenshot 2026-06-25 at 3 41 13 PM" src="https://github.com/user-attachments/assets/d571987a-6081-4df9-9e9b-db684e40c63c" />
- Font stylesheet requests for the landing page did not load successfully.
- The intended fonts were not applied consistently.

### After
<img width="1512" height="812" alt="Screenshot 2026-06-25 at 3 38 54 PM" src="https://github.com/user-attachments/assets/e8b18af7-2c78-4aa4-a31e-9c49870bff75" />
- Font stylesheet requests load successfully.
- The landing page renders with the intended typography.

## Verification

- Verified the landing page loads successfully.
- Verified the Google Fonts stylesheet requests return **HTTP 200** in the browser Network tab.
- Verified the Cinzel and Inter fonts are applied correctly after the update.

## Additional Notes

This change is limited to updating the Google Fonts stylesheet URLs and does not affect any other application functionality.