### PR TITLE
Fix light theme CSS rendering on lesson map page

### DIFF
--- a/game/templates/game/lesson_map.html
+++ b/game/templates/game/lesson_map.html
@@ -332,7 +332,7 @@ background-size:60px 60px;
     from { opacity: 0; transform: translateY(-10px); }
     to { opacity: 1; transform: translateY(0); }
 }
-</style>
+
 
 /* Light Theme Overrides */
 [data-theme="light"] body {


### PR DESCRIPTION
## Description

This PR fixes an issue where raw CSS was rendered as visible text at the top of the **Chess Learning Journey** page. The page now renders correctly without exposing stylesheet content to users.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

## Related Issue

Fixes #2105

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [ ] I have commented my code where necessary
* [ ] I have updated the documentation if needed
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix/feature works
* [x] New and existing tests pass locally

## Screenshots (if applicable)

### Before

Raw CSS was displayed at the top of the Chess Learning Journey page.

*<img width="698" height="559" alt="Screenshot 2026-06-26 at 12 26 00 AM" src="*[*https://github.com/user-attachments/assets/67ec8244-153c-4af4-88fe-1c8f5fd0e95d*](https://github.com/user-attachments/assets/67ec8244-153c-4af4-88fe-1c8f5fd0e95d)*" />*

### After

The Chess Learning Journey page renders correctly without displaying stylesheet content.

*<img width="933" height="684" alt="Screenshot 2026-06-26 at 12 24 26 AM" src="*[*https://github.com/user-attachments/assets/ead16138-21c0-4f22-abe6-a141f5cb1291*](https://github.com/user-attachments/assets/ead16138-21c0-4f22-abe6-a141f5cb1291)*" />*

## Additional Notes

* Verified the fix locally by running the application.
* Confirmed that the Chess Learning Journey page renders correctly after the change.
* Verified that no raw CSS is displayed and the existing page styling remains intact.
