### PR TITLE
feat: implement smooth theme switch transitions and toast notifications

### DIFF
--- a/game/static/game/css/theme.css
+++ b/game/static/game/css/theme.css
@@ -186,10 +186,12 @@
     color: var(--accent-gold) !important;
 }
 
-/* Enable smooth transitions only during theme toggles */
-html.theme-transition,
-html.theme-transition *,
-html.theme-transition ::before,
-html.theme-transition ::after {
-    transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease !important;
+/* Enable smooth transitions only during theme toggles (respecting reduced motion preferences) */
+@media (prefers-reduced-motion: no-preference) {
+    html.theme-transition,
+    html.theme-transition *,
+    html.theme-transition ::before,
+    html.theme-transition ::after {
+        transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease !important;
+    }
 }

--- a/game/static/game/css/theme.css
+++ b/game/static/game/css/theme.css
@@ -186,38 +186,10 @@
     color: var(--accent-gold) !important;
 }
 
-/* Enable smooth transitions for theme switches */
-body,
-header,
-nav,
-.navbar,
-main,
-footer,
-.card,
-.about-bento-card,
-.profile-btn,
-.dropdown-content,
-.btn-primary-gold,
-.btn-register,
-.btn-primary,
-.btn-secondary-ghost,
-.btn-signin,
-.nav-links a,
-.m-fab-btn,
-h1, h2, h3, h4, h5, h6,
-p,
-span,
-a,
-input,
-textarea,
-select,
-table,
-th,
-td,
-tr,
-.leaderboard-container,
-.tabs-container,
-.tab-button,
-.search-input {
-    transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+/* Enable smooth transitions only during theme toggles */
+html.theme-transition,
+html.theme-transition *,
+html.theme-transition ::before,
+html.theme-transition ::after {
+    transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease !important;
 }

--- a/game/static/game/css/theme.css
+++ b/game/static/game/css/theme.css
@@ -185,3 +185,39 @@
     background: #f3f4f6 !important;
     color: var(--accent-gold) !important;
 }
+
+/* Enable smooth transitions for theme switches */
+body,
+header,
+nav,
+.navbar,
+main,
+footer,
+.card,
+.about-bento-card,
+.profile-btn,
+.dropdown-content,
+.btn-primary-gold,
+.btn-register,
+.btn-primary,
+.btn-secondary-ghost,
+.btn-signin,
+.nav-links a,
+.m-fab-btn,
+h1, h2, h3, h4, h5, h6,
+p,
+span,
+a,
+input,
+textarea,
+select,
+table,
+th,
+td,
+tr,
+.leaderboard-container,
+.tabs-container,
+.tab-button,
+.search-input {
+    transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}

--- a/game/static/game/js/theme.js
+++ b/game/static/game/js/theme.js
@@ -88,10 +88,17 @@ document.addEventListener("DOMContentLoaded", () => {
 
     updateToggleState(savedTheme);
 
+    let transitionTimeout = null;
+
     if (toggle) {
         toggle.addEventListener("click", () => {
             const currentTheme = document.documentElement.getAttribute("data-theme");
             const newTheme = currentTheme === "light" ? "dark" : "light";
+
+            // Clear any active transition timeout to handle rapid toggles
+            if (transitionTimeout) {
+                clearTimeout(transitionTimeout);
+            }
 
             // Temporarily enable theme transitions
             document.documentElement.classList.add("theme-transition");
@@ -103,8 +110,9 @@ document.addEventListener("DOMContentLoaded", () => {
             showThemeToast(`Switched to ${newTheme === "light" ? "Light" : "Dark"} Mode`, "info");
 
             // Remove the class after the transition finishes (0.3s)
-            setTimeout(() => {
+            transitionTimeout = setTimeout(() => {
                 document.documentElement.classList.remove("theme-transition");
+                transitionTimeout = null;
             }, 300);
         });
     }

--- a/game/static/game/js/theme.js
+++ b/game/static/game/js/theme.js
@@ -63,7 +63,8 @@ document.addEventListener("DOMContentLoaded", () => {
                 document.head.appendChild(link);
             }
             // Dynamically load toast.js if not present
-            if (!document.getElementById("toast-js-dynamic")) {
+            const existingScript = document.getElementById("toast-js-dynamic");
+            if (!existingScript) {
                 const script = document.createElement("script");
                 script.id = "toast-js-dynamic";
                 script.src = "/static/game/js/toast.js";
@@ -73,6 +74,14 @@ document.addEventListener("DOMContentLoaded", () => {
                     }
                 };
                 document.body.appendChild(script);
+            } else {
+                // If script exists but window.showToast is not yet defined, it means the script is currently loading.
+                // We attach the callback to the existing script's load event.
+                existingScript.addEventListener("load", () => {
+                    if (typeof window.showToast === "function") {
+                        window.showToast(message, type);
+                    }
+                });
             }
         }
     };
@@ -84,12 +93,19 @@ document.addEventListener("DOMContentLoaded", () => {
             const currentTheme = document.documentElement.getAttribute("data-theme");
             const newTheme = currentTheme === "light" ? "dark" : "light";
 
+            // Temporarily enable theme transitions
+            document.documentElement.classList.add("theme-transition");
             document.documentElement.setAttribute("data-theme", newTheme);
             safeLocalStorage.set("theme", newTheme);
             updateToggleState(newTheme);
 
             // Trigger the toast notification
             showThemeToast(`Switched to ${newTheme === "light" ? "Light" : "Dark"} Mode`, "info");
+
+            // Remove the class after the transition finishes (0.3s)
+            setTimeout(() => {
+                document.documentElement.classList.remove("theme-transition");
+            }, 300);
         });
     }
 });

--- a/game/static/game/js/theme.js
+++ b/game/static/game/js/theme.js
@@ -1,34 +1,37 @@
-document.addEventListener("DOMContentLoaded", () => {
-    const safeLocalStorage = {
-        get(key) {
-            try {
-                return window.localStorage.getItem(key);
-            } catch (error) {
-                return null;
-            }
-        },
-        set(key, value) {
-            try {
-                window.localStorage.setItem(key, value);
-            } catch (error) {
-                // ignore restricted storage environments
-            }
+// 1. Theme detection and attribute setting run immediately at the top-level.
+// This prevents layout flashes and transition animations on initial page load.
+const safeLocalStorage = {
+    get(key) {
+        try {
+            return window.localStorage.getItem(key);
+        } catch (error) {
+            return null;
         }
-    };
+    },
+    set(key, value) {
+        try {
+            window.localStorage.setItem(key, value);
+        } catch (error) {
+            // ignore restricted storage environments
+        }
+    }
+};
 
-    const storedTheme = safeLocalStorage.get("theme");
-    const legacyTheme = safeLocalStorage.get("chessBoardTheme");
-    const validStoredTheme = storedTheme === "light" || storedTheme === "dark" ? storedTheme : null;
-    const savedTheme =
-        validStoredTheme ||
-        (legacyTheme === "light" || legacyTheme === "dark" ? legacyTheme : null) ||
-        "dark";
+const storedTheme = safeLocalStorage.get("theme");
+const legacyTheme = safeLocalStorage.get("chessBoardTheme");
+const validStoredTheme = storedTheme === "light" || storedTheme === "dark" ? storedTheme : null;
+const savedTheme =
+    validStoredTheme ||
+    (legacyTheme === "light" || legacyTheme === "dark" ? legacyTheme : null) ||
+    "dark";
 
-    document.documentElement.setAttribute(
-        "data-theme",
-        savedTheme
-    );
+document.documentElement.setAttribute(
+    "data-theme",
+    savedTheme
+);
 
+// 2. DOM-dependent logic runs after content is loaded.
+document.addEventListener("DOMContentLoaded", () => {
     const toggle = document.getElementById("themeToggle");
 
     const updateToggleState = (theme) => {
@@ -44,7 +47,38 @@ document.addEventListener("DOMContentLoaded", () => {
         );
         toggle.textContent = theme === "light" ? "☀️" : "🌙";
     };
+
+    // Helper to safely trigger toast notifications, dynamically loading
+    // toast.js and toast.css on demand if they aren't statically loaded on the page.
+    const showThemeToast = (message, type = "info") => {
+        if (typeof window.showToast === "function") {
+            window.showToast(message, type);
+        } else {
+            // Dynamically load toast.css if not present
+            if (!document.getElementById("toast-css-dynamic")) {
+                const link = document.createElement("link");
+                link.id = "toast-css-dynamic";
+                link.rel = "stylesheet";
+                link.href = "/static/game/css/toast.css";
+                document.head.appendChild(link);
+            }
+            // Dynamically load toast.js if not present
+            if (!document.getElementById("toast-js-dynamic")) {
+                const script = document.createElement("script");
+                script.id = "toast-js-dynamic";
+                script.src = "/static/game/js/toast.js";
+                script.onload = () => {
+                    if (typeof window.showToast === "function") {
+                        window.showToast(message, type);
+                    }
+                };
+                document.body.appendChild(script);
+            }
+        }
+    };
+
     updateToggleState(savedTheme);
+
     if (toggle) {
         toggle.addEventListener("click", () => {
             const currentTheme = document.documentElement.getAttribute("data-theme");
@@ -53,6 +87,9 @@ document.addEventListener("DOMContentLoaded", () => {
             document.documentElement.setAttribute("data-theme", newTheme);
             safeLocalStorage.set("theme", newTheme);
             updateToggleState(newTheme);
+
+            // Trigger the toast notification
+            showThemeToast(`Switched to ${newTheme === "light" ? "Light" : "Dark"} Mode`, "info");
         });
     }
 });


### PR DESCRIPTION
### Description

This Pull Request resolves #2083 by introducing smooth CSS transitions when toggling between dark and light modes, and triggering a toast notification indicating the newly active theme mode.

---

### Goals & Solution

1. **Smooth CSS Transitions:**
   - Added transition properties (`background-color`, `color`, `border-color`, and `box-shadow` over `0.3s ease`) to global structural selectors (body, navbar, cards, forms, buttons, dropdowns, headers, and text elements) in `theme.css`.
   
2. **Toast Notifications on Theme Toggle:**
   - Modified `theme.js` to call the toast component when toggling the theme.
   - Implemented **on-demand dynamic loading** of the toast system (`toast.js` & `toast.css`) inside `theme.js`. This guarantees that theme switches trigger toast notifications even on pages where the toast assets are not statically loaded (like the landing/homepage), without bloating initial page load times.

3. **No Page Flash / Load Flash Prevention:**
   - Moved the initial theme detection and `setAttribute` operations to the top-level scope of `theme.js` (outside `DOMContentLoaded`). Because `theme.js` is loaded synchronously in the `<head>` of HTML templates, setting the attribute early ensures the page is parsed and rendered with the correct theme on the very first paint. This eliminates layout flash and prevents transitions from triggering on page load/refresh.

---
Fixes #2083 