### PR TITLE
feat: surface player rating during gameplay and in Game Over modal

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -537,6 +537,21 @@
         }
     }
 
+    function updateRatingBadge(currentRating) {
+        const whiteBadge = document.getElementById('whiteRatingBadge');
+        const blackBadge = document.getElementById('blackRatingBadge');
+        if (whiteBadge) whiteBadge.style.display = 'none';
+        if (blackBadge) blackBadge.style.display = 'none';
+
+        if (currentRating == null) return;
+
+        const myBadge = playerColor === 'black' ? blackBadge : whiteBadge;
+        if (myBadge) {
+            myBadge.textContent = `(${currentRating})`;
+            myBadge.style.display = 'inline';
+        }
+    }
+
 
     /* ==========================================================
     DOM REFERENCES
@@ -1125,6 +1140,7 @@
         }
 
         updatePlayerNames(data);
+        updateRatingBadge(data.current_rating);
         updateTurn();
         updateMoves(data.move_history);
         updateCaptured(data.captured_pieces);
@@ -1144,7 +1160,7 @@
         }
 
         if (data.game_status && data.game_status !== 'active' && data.game_status !== 'ok') {
-            handleGameStatus(data.game_status, data.draw_reason);
+            handleGameStatus(data.game_status, data.draw_reason, data.rating);
         }
         if (!welcomeOverlay.classList.contains('active')) {
             queueAIMoveIfNeeded();
@@ -1793,6 +1809,7 @@
                 selected = null;
                 hints = [];
                 updatePlayerNames(data);
+                updateRatingBadge(data.current_rating ?? data.rating?.new_rating);
                 updateTurn();
                 updateMoves(data.move_history);
                 updateCaptured(data.captured_pieces);
@@ -1817,7 +1834,7 @@
                     a11yMsg = `${playedColor} played ${lastMove}. `;
                 }
 
-                const gameEnded = handleGameStatus(data.game_status, data.draw_reason);
+                const gameEnded = handleGameStatus(data.game_status, data.draw_reason, data.rating);
                 if (!gameEnded) {
                     if (data.game_status === 'check') {
                         applyCheckHighlight();
@@ -1906,6 +1923,7 @@
                 selected = null;
                 hints = [];
                 updatePlayerNames(data);
+                updateRatingBadge(data.current_rating ?? data.rating?.new_rating);
                 updateTurn();
                 updateMoves(data.move_history);
                 updateCaptured(data.captured_pieces);
@@ -1930,7 +1948,7 @@
                     a11yMsg = `AI played ${lastMove}. `;
                 }
 
-                const gameEnded = handleGameStatus(data.game_status, data.draw_reason);
+                const gameEnded = handleGameStatus(data.game_status, data.draw_reason, data.rating);
                 if (!gameEnded) {
                     if (data.game_status === 'check') {
                         applyCheckHighlight();
@@ -2255,26 +2273,26 @@
         statusEl.className = 'status-bar' + (err ? ' error' : '');
     }
 
-    function handleGameStatus(status, drawReason) {
+    function handleGameStatus(status, drawReason, ratingInfo) {
         if (dailyPuzzleMode) {
             return false;
         }
         if (status === 'checkmate') {
-            endGame('checkmate', turn);
+            endGame('checkmate', turn, null, ratingInfo);
             return true;
         }
         if (status === 'stalemate') {
-            endGame('stalemate', turn);
+            endGame('stalemate', turn, null, ratingInfo);
             return true;
         }
         if (status === 'draw') {
-            endGame('draw', turn, drawReason);
+            endGame('draw', turn, drawReason, ratingInfo);
             return true;
         }
         return false;
     }
 
-    async function endGame(reason, color, drawReason = null) {
+    async function endGame(reason, color, drawReason = null, ratingInfo = null) {
         if (gameOver) return;
         gameOver = true;
         const frozenPlayerColor = playerColor;
@@ -2550,6 +2568,17 @@
             } else {
                 resMatDiffEl.textContent = `Black +${blackMat - whiteMat}`;
             }
+        }
+
+        const resRatingItem = document.getElementById('resRatingItem');
+        const resRatingEl = document.getElementById('resRatingChange');
+        if (ratingInfo && resRatingItem && resRatingEl) {
+            const sign = ratingInfo.rating_change >= 0 ? '+' : '';
+            resRatingEl.textContent = `${sign}${ratingInfo.rating_change} (${ratingInfo.new_rating})`;
+            resRatingEl.style.color = ratingInfo.rating_change >= 0 ? '#4ade80' : '#f87171';
+            resRatingItem.style.display = '';
+        } else if (resRatingItem) {
+            resRatingItem.style.display = 'none';
         }
 
         const modalWhiteCap = document.getElementById('modalWhiteCaptured');
@@ -3906,7 +3935,7 @@
                     if (result.valid) {
                         if (soundEnabled) { sounds.draw.currentTime = 0; sounds.draw.play().catch(() => { }); }
                         const loserColor = result.winner === 'white' ? 'black' : 'white';
-                        endGame('resign', loserColor);
+                        endGame('resign', loserColor, null, result.rating);
                     } else {
                         showStatus('Resign failed. Please try again.', true);
                     }
@@ -3923,7 +3952,7 @@
         const data = await post('/api/draw/', { action: 'accept' });
         if (data.success) {
             if (soundEnabled) { sounds.draw.currentTime = 0; sounds.draw.play().catch(() => { }); }
-            endGame('draw', turn, data.draw_reason);
+            endGame('draw', turn, data.draw_reason, data.rating);
         }
     };
     if (drawDeclineBtn) drawDeclineBtn.onclick = () => {

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -434,9 +434,12 @@
                 <div id="whiteClock" class="clock white active">
                     <span class="label">
                         <img id="whitePlayerAvatar" class="nav-avatar" src="" style="display:none; width:20px; height:20px; border-radius:50%; object-fit:cover;">
+                        <!-- NEW -->
                         <span id="whiteNameLabel">WHITE</span>
                         <span id="whiteYouTag"
                             style="display: none; color: #f0c040; margin-left: 4px; font-size: 0.8em;">(YOU)</span>
+                        <span id="whiteRatingBadge"
+                            style="display: none; color: #9aa0c0; margin-left: 4px; font-size: 0.8em;"></span>
                     </span>
                     <span class="time" id="whiteTime">10:00</span>
                 </div>
@@ -453,8 +456,10 @@
                     <span class="label">
                         <img id="blackPlayerAvatar" class="nav-avatar" src="" style="display:none; width:20px; height:20px; border-radius:50%; object-fit:cover;">
                         <span id="blackNameLabel">BLACK</span>
-                        <span id="blackYouTag"
+                         <span id="blackYouTag"
                             style="display: none; color: #f0c040; margin-left: 4px; font-size: 0.8em;">(YOU)</span>
+                        <span id="blackRatingBadge"
+                            style="display: none; color: #9aa0c0; margin-left: 4px; font-size: 0.8em;"></span>
                     </span>
                     <span class="time" id="blackTime">10:00</span>
                 </div>
@@ -736,10 +741,16 @@
                                 <span class="stat-label">Duration</span>
                                 <span class="stat-value" id="gameDurationText">00:00</span>
                             </div>
+                            <!-- NEW -->
                             <div class="stat-item">
                                 <span class="stat-label">Material</span>
                                 <span class="stat-value" id="resMaterialDiff">Even</span>
                             </div>
+                            <div class="stat-item" id="resRatingItem" style="display:none;">
+                                <span class="stat-label">Rating</span>
+                                <span class="stat-value" id="resRatingChange">+0</span>
+                            </div>
+                            
                             <div class="stat-item">
                                 <span class="stat-label">Captures</span>
                                 <span class="stat-value" id="resAnalysisCaptures">0</span>

--- a/game/views.py
+++ b/game/views.py
@@ -121,6 +121,8 @@ def index(request):
     return render(request, 'game/board.html')
 
 
+
+# NEW
 def update_player_rating(user, winner, player_color):
     rating, _ = PlayerRating.objects.get_or_create(
         user=user
@@ -169,8 +171,15 @@ def update_player_rating(user, winner, player_color):
         rating_change=actual_change,
         result=result
     )
-    
 
+    return {
+        "old_rating": old_rating,
+        "new_rating": rating.rating,
+        "rating_change": actual_change,
+        "result": result,
+    }
+
+# NEW
 def record_game_result(request, mode, winner, reason, player_color='white', moves=None):
     """Save a completed game result to the database."""
     user = request.user if request.user.is_authenticated else None
@@ -191,13 +200,14 @@ def record_game_result(request, mode, winner, reason, player_color='white', move
     result.full_clean()
     result.save()
 
+    result.rating_info = None
     if user:
-        update_player_rating(
+        result.rating_info = update_player_rating(
             user,
             winner,
             player_color
         )
-        
+
         check_game_achievements(user)
     return result
 
@@ -243,6 +253,8 @@ def make_move(request):
         from_row, from_col, to_row, to_col, promotion_piece,
     )
 
+    # NEW
+    rating_payload = None
     if success:
         request.session['game'] = game.to_dict()
         request.session.modified = True
@@ -253,12 +265,14 @@ def make_move(request):
             if game_result is not None:
                 game_result.replay_record = replay_record
                 game_result.save(update_fields=['replay_record'])
+                rating_payload = getattr(game_result, 'rating_info', None)
         elif game_status in ('stalemate', 'draw'):
             game_result = record_game_result(request, game.mode, 'draw', game.draw_reason or 'stalemate', game.player_color, moves=game.move_history)            
             replay_record = save_game_record(request, pgn=game.generate_pgn(request.session.get('white_name', 'White'), request.session.get('black_name', 'Black')), result='1/2-1/2', termination=game.draw_reason or 'stalemate', white_label=request.session.get('white_name', 'White'), black_label=request.session.get('black_name', 'Black'))
             if game_result is not None:
                 game_result.replay_record = replay_record
                 game_result.save(update_fields=['replay_record'])
+                rating_payload = getattr(game_result, 'rating_info', None)
 
     return JsonResponse({
         'valid': success,
@@ -279,7 +293,11 @@ def make_move(request):
         'pgn': game.generate_pgn(request.session.get('white_name', 'White'), request.session.get('black_name', 'Black')),
         'white_name': request.session.get('white_name', 'White'),
         'black_name': request.session.get('black_name', 'Black'),
+        'rating': rating_payload,
     })
+
+
+   
 
 
 @require_GET
@@ -482,7 +500,13 @@ def get_state(request):
     request.session['game'] = game.to_dict()
     request.session.modified = True
 
+    current_rating = None
+    if request.user.is_authenticated:
+        rating_obj, _ = PlayerRating.objects.get_or_create(user=request.user)
+        current_rating = rating_obj.rating
+
     return JsonResponse({
+        'current_rating': current_rating,
         'board': game.board,
         'current_turn': game.current_turn,
         'white_time': game.white_time,
@@ -562,13 +586,14 @@ def ai_move(request):
 
     best = game.get_ai_move(depth=depth)
 
+    # NEW
     if not best:
         if game.game_status == 'checkmate':
             winner = 'black' if game.current_turn == 'white' else 'white'
-            record_game_result(request, game.mode, winner, 'checkmate', game.player_color, moves=game.move_history)
+            no_move_result = record_game_result(request, game.mode, winner, 'checkmate', game.player_color, moves=game.move_history)
             game_status = 'checkmate'
         else:
-            record_game_result(request, game.mode, 'draw', 'stalemate', game.player_color, moves=game.move_history)
+            no_move_result = record_game_result(request, game.mode, 'draw', 'stalemate', game.player_color, moves=game.move_history)
             game_status = 'stalemate'
 
         game.game_status = game_status
@@ -585,6 +610,7 @@ def ai_move(request):
             'move_history': game.move_history,
             'captured_pieces': game.captured,
             'message': '',
+            'rating': getattr(no_move_result, 'rating_info', None),
         })
 
     success, message, captured, game_status = game.make_move(
@@ -592,6 +618,8 @@ def ai_move(request):
         best['to_row'],   best['to_col'],
     )
 
+    # NEW
+    rating_payload = None
     if success:
         request.session['game'] = game.to_dict()
         request.session.modified = True
@@ -603,12 +631,14 @@ def ai_move(request):
             if game_result is not None:
                 game_result.replay_record = replay_record
                 game_result.save(update_fields=['replay_record'])
+                rating_payload = getattr(game_result, 'rating_info', None)
         elif game_status in ('stalemate', 'draw'):
             game_result = record_game_result(request, game.mode, 'draw', game.draw_reason or 'stalemate', game.player_color, moves=game.move_history)
             replay_record = save_game_record(request, pgn=game.generate_pgn(request.session.get('white_name', 'White'), request.session.get('black_name', 'Black')), result='1/2-1/2', termination=game.draw_reason or 'stalemate', white_label=request.session.get('white_name', 'White'), black_label=request.session.get('black_name', 'Black'))
             if game_result is not None:
                 game_result.replay_record = replay_record
                 game_result.save(update_fields=['replay_record'])
+                rating_payload = getattr(game_result, 'rating_info', None)
 
     return JsonResponse({
         'valid': success,
@@ -630,7 +660,12 @@ def ai_move(request):
         'pgn': game.generate_pgn(request.session.get('white_name', 'White'), request.session.get('black_name', 'Black')),
         'white_name': request.session.get('white_name', 'White'),
         'black_name': request.session.get('black_name', 'Black'),
+        'rating': rating_payload,
     })
+
+
+    
+    
 
 @require_POST
 def offer_draw(request):
@@ -655,6 +690,7 @@ def offer_draw(request):
             {'success': False, 'message': 'Invalid action.'}, status=400
         )
 
+    # NEW
     if action == 'accept':
         game = ChessGame.from_dict(game_data)
         if game.game_status != 'active':
@@ -665,11 +701,12 @@ def offer_draw(request):
         game.draw_reason = 'agreement'
         request.session['game'] = game.to_dict()
         request.session.modified = True
-        record_game_result(request, game.mode, 'draw', 'agreement', game.player_color, moves=game.move_history)
+        draw_result = record_game_result(request, game.mode, 'draw', 'agreement', game.player_color, moves=game.move_history)
         return JsonResponse({
             'success': True,
             'game_status': game.game_status,
             'draw_reason': game.draw_reason,
+            'rating': getattr(draw_result, 'rating_info', None),
         })
 
     return JsonResponse({'success': True})
@@ -694,6 +731,8 @@ def resign_game(request):
     request.session['game'] = game.to_dict()
     request.session.modified = True
 
+    # NEW
+    rating_payload = None
     try:
         game_result = record_game_result(request, game.mode, winner, 'resign', game.player_color, moves=game.move_history)
         pgn_str = game.generate_pgn(request.session.get('white_name', 'White'), request.session.get('black_name', 'Black'))
@@ -702,6 +741,7 @@ def resign_game(request):
         if game_result is not None:
             game_result.replay_record = replay_record
             game_result.save(update_fields=['replay_record'])
+            rating_payload = getattr(game_result, 'rating_info', None)
     except Exception as e:
         logger.error('Failed to record resign result: %s', e)
 
@@ -709,7 +749,8 @@ def resign_game(request):
         'valid': True,
         'message': f'{resigning_player.capitalize()} resigned.',
         'winner': winner,
-        'game_status': game_status
+        'game_status': game_status,
+        'rating': rating_payload,
     })
 
 @require_GET


### PR DESCRIPTION
Display player rating during gameplay and in Game Over modal
Closes #2024

## Changes
- Backend: propagate rating change data through move/ai-move/resign/draw responses and get_state
- Frontend: rating badge next to player name on play screen; rating delta shown in Game Over modal

## Testing
- Ran full test suite: python manage.py test game — all passing
- Manually verified rating display for authenticated users in PvP and AI modes
- Verified no rating shown for unauthenticated/guest sessions"