### PR TITLE
Experiment with theme-aware rulebook modal background

### DIFF
--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -842,7 +842,7 @@
     <div id="rulebookModal"
         style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.85); z-index:10001; align-items:center; justify-content:center;">
         <div
-            style="position:relative; width:min(95vw, 1400px); height:90vh; background:#13161e; border-radius:12px; overflow:hidden; padding-top:48px;">
+            style="position:relative; width:min(95vw, 1400px); height:90vh; background:var(--page-bg); border-radius:12px; overflow:hidden; padding-top:48px;">
             <button type="button" aria-label="Close rulebook" onclick="document.getElementById('rulebookModal').style.display='none'"
                 style="position:absolute; top: 16px; right:16px; z-index:10; background:#333; border:none; color:#fff; width:32px; height:32px; border-radius:50%; cursor:pointer; font-size:1rem;">✕</button>
             <iframe src="/rules/" style="width:100%; height:100%; border:none;"></iframe>


### PR DESCRIPTION
## Description

Updated the Rulebook modal container to use the application's theme background variable instead of a hardcoded background color. This is intended to make the modal respond to the active application theme and improve theme consistency.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #2116 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

<img width="1395" height="914" alt="Screenshot 2026-06-26 at 5 41 52 PM" src="https://github.com/user-attachments/assets/f00f103f-9cd6-498e-ae1d-3ec8cdc8b599" />

## Additional Notes

The modal background now references the application's theme variable instead of a hardcoded color to better align with the active theme.


