### PR TITLE
Fix rulebook logo navigation from iframe

### DIFF
--- a/game/templates/game/rules.html
+++ b/game/templates/game/rules.html
@@ -913,7 +913,7 @@
 
     <header>
         <div class="header-left">
-            <a href="{% url 'landing' %}" class="logo">
+            <a href="{% url 'landing' %}" class="logo" target="_top">
                 <img src="{% static 'game/checkora_icon_only.png' %}" 
                     style="height: 2rem; width: auto; object-fit: contain;" alt="Checkora">
                 <span>Checkora</span>


### PR DESCRIPTION
## Description

This PR fixes the navigation behavior of the Checkora logo on the Rulebook page.
Previously, clicking the Checkora logo while the Rulebook was open inside the in-game modal attempted to load the homepage within the embedded iframe, resulting in a **"127.0.0.1 refused to connect"** error.
This change updates the logo navigation to redirect the **top-level window** to the homepage, ensuring consistent behavior with the rest of the application.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #2118 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

### Before
Clicking the Checkora logo inside the Rulebook modal displayed a "127.0.0.1 refused to connect" error because the homepage was being loaded inside the iframe.

<img width="1403" height="860" alt="Screenshot 2026-06-26 at 6 06 08 PM" src="https://github.com/user-attachments/assets/2aab07da-2ae6-4180-a08d-fa2de9257746" />

### After
Clicking the Checkora logo now correctly navigates users to the homepage in the top-level window, matching the behavior on the Game page.

https://github.com/user-attachments/assets/7fd21128-6278-4892-848b-a083a80fbd9d

## Additional Notes

This change only updates the navigation behavior of the Rulebook logo and does not affect other Rulebook functionality.
