### PR TITLE
fix(ui): improve FAQ hover text contrast in light mode (Issue #2000)

### DIFF
--- a/game/static/game/css/landing.css
+++ b/game/static/game/css/landing.css
@@ -2523,6 +2523,10 @@ body {
     color: #111827;
 }
 
+[data-theme="light"] .faq-item:hover .faq-question {
+    color: var(--accent-gold);
+}
+
 [data-theme="light"] .faq-answer-content {
     color: #374151;
 }


### PR DESCRIPTION
## Description

This PR fixes the FAQ hover text contrast issue in Light Mode.

### Changes

* Added a Light Mode-specific hover style for FAQ question text in `game/static/game/css/landing.css`.
* Uses `var(--accent-gold)` to provide sufficient contrast while maintaining the existing design.
* Preserves the existing Dark Mode hover behavior without modification.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

## Related Issue

Fixes #2000

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [ ] I have commented my code where necessary (not applicable)
* [ ] I have updated the documentation if needed (not applicable)
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix/feature works (not applicable – CSS-only change)
* [x] New and existing tests pass locally



## Additional Notes

This is a minimal, issue-focused fix. Only `game/static/game/css/landing.css` was modified, and no unrelated changes are included in this PR.
