### PR TITLE
fix(ui): prevent browser force dark mode from inverting chess pieces

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -574,6 +574,7 @@ body {
     max-width: 100%;
     box-sizing: content-box;
     position: relative;
+    color-scheme: light dark;
 }
 
 /* ============================================================


### PR DESCRIPTION
## Description

This PR fixes an issue where browser-level Force Dark Mode (or similar browser features) can incorrectly invert the colors of the playable chess board and pieces.

### Changes

* Added `color-scheme: light dark;` to the `.chessboard` container in `game/static/game/css/board.css`.
* This informs compatible browsers that the chessboard natively supports both light and dark color schemes, helping prevent unwanted automatic color inversion while preserving the application's intended styling.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

## Related Issue

Fixes #2006

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [ ] I have commented my code where necessary (not applicable)
* [ ] I have updated the documentation if needed (not applicable)
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix/feature works (not applicable for this CSS-only change)
* [x] New and existing tests pass locally

## Screenshots (if applicable)

N/A (CSS-only change)

## Additional Notes

* The fix is intentionally minimal and scoped only to the playable chessboard.
* Only `game/static/game/css/board.css` was modified.
* No unrelated changes are included in this PR.
