### PR TITLE
fix: improve move history readability on desktop

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -409,6 +409,17 @@ body {
     gap: 12px;
     box-sizing: border-box;
 }
+/* Give Move History panel a bit more room on desktop */
+@media (min-width: 1024px) {
+    .move-history-panel {
+        width: 240px;
+        max-width: 240px;
+    }
+
+    .move-history-panel .move-row {
+        grid-template-columns: 36px minmax(56px, 1fr) minmax(56px, 1fr);
+    }
+}
 
 .panel input,
 .panel select,

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -577,7 +577,7 @@
         </div>
 
         <!-- Right Panel: Move History -->
-        <div class="panel">
+        <div class="panel move-history-panel">
             <div class="card" style="height: 100%;">
                 <div class="card-title">Move History</div>
                 <div class="moves-list" id="movesList">


### PR DESCRIPTION
## Description

Improves the readability of the Move History panel on desktop screens by increasing its available width and adjusting the move row layout. This prevents chess moves from being unnecessarily truncated while keeping the mobile layout unchanged.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

## Related Issue

Fixes #2029

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [ ] I have commented my code where necessary
* [ ] I have updated the documentation if needed
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix/feature works
* [x] New and existing tests pass locally

## Screenshots 

**Before:** Move history entries such as `Qxh4` and `Nxb4` were truncated even when there was sufficient space.

<img width="636" height="503" alt="image" src="https://github.com/user-attachments/assets/66edacf0-ecb8-40e0-8114-af5482b41d64" />


**After:** The Move History panel displays complete move notation on desktop screens without affecting the mobile layout.

<img width="442" height="577" alt="image" src="https://github.com/user-attachments/assets/64cd3263-8e7d-437a-b069-35e38c916d08" />

<img width="1276" height="883" alt="image" src="https://github.com/user-attachments/assets/a9789fb0-d1e0-4948-85ce-d07b6ecebaee" />

<img width="807" height="1058" alt="image" src="https://github.com/user-attachments/assets/45579ba0-d81a-4c84-bd5c-1f8cd3edb4ab" />


## Additional Notes

The width adjustment is scoped to desktop screens (`min-width: 1024px`) to preserve the existing responsive behavior on smaller devices.
