### PR TITLE
fix: prevent move history entries from being truncated on desktop

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -409,6 +409,17 @@ body {
     gap: 12px;
     box-sizing: border-box;
 }
+/* Give Move History panel a bit more room on desktop */
+@media (min-width: 1024px) {
+    .move-history-panel {
+        width: 240px;
+        max-width: 240px;
+    }
+
+    .move-history-panel .move-row {
+        grid-template-columns: 36px minmax(56px, 1fr) minmax(56px, 1fr);
+    }
+}
 
 .panel input,
 .panel select,

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -577,7 +577,7 @@
         </div>
 
         <!-- Right Panel: Move History -->
-        <div class="panel">
+        <div class="panel move-history-panel">
             <div class="card" style="height: 100%;">
                 <div class="card-title">Move History</div>
                 <div class="moves-list" id="movesList">


### PR DESCRIPTION
## Description

Improves the readability of the Move History panel on desktop screens by increasing its available width and adjusting the move row layout. This prevents chess move notation from being unnecessarily truncated while keeping the mobile layout unchanged.

## Type of Change

- [x] Bug fix

## Related Issue

Closes #2029

## Testing

- Tested on desktop (1920×1080)
- Tested on desktop (1366×768)
- Verified mobile layout remains unaffected

## Screenshots

### Before:

<img width="636" height="503" alt="image" src="https://github.com/user-attachments/assets/b87d8c0b-258d-4dfd-b0fa-163d5b0b4fb3" />

### After:

<img width="442" height="577" alt="image" src="https://github.com/user-attachments/assets/49859f9a-2def-40fb-815c-e06e0b24369b" />

<img width="1276" height="883" alt="image" src="https://github.com/user-attachments/assets/26c26906-fa77-4f87-9b6d-3565eaa05092" />
