### PR TITLE
fix: user-piece-animation

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1636,8 +1636,8 @@
             const data = await post('/api/move/', body);
 
             // Opening Trainer validation
-            if (openingTrainerMode) {
-                const expectedMove =
+            if (typeof openingTrainerMode !== 'undefined' && openingTrainerMode) {
+                    const expectedMove =
                     openingTrainerSteps[currentTrainerStep]?.expected_move;
 
                 const playedMove =


### PR DESCRIPTION
## Description

This PR fixes a bug where the user's pieces weren't being animated and move indicators wouldn't disappear even after playing the move.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #2112

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally