### PR TITLE
fix(engine): restrict Elo rating updates to AI games

### DIFF
--- a/game/tests.py
+++ b/game/tests.py
@@ -3490,3 +3490,49 @@ class AvatarViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         # Should stay on avatar page with an error message
         self.assertTemplateUsed(response, 'game/avatar.html')
+
+
+class GameResultRatingTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='ratingplayer', password='password123')
+        from game.models import PlayerRating, GameResult, UserAchievement, Achievement
+        self.PlayerRating = PlayerRating
+        self.GameResult = GameResult
+        self.UserAchievement = UserAchievement
+        Achievement.objects.create(code='FIRST_WIN', title='First Win', description='Win a game', icon='🏆', category='game', rarity='common')
+
+    def test_record_game_result_updates_rating_and_achievements_for_ai(self):
+        from game.views import record_game_result
+        factory = RequestFactory()
+        request = factory.post('/dummy/')
+        request.user = self.user
+        request.session = {}
+
+        record_game_result(request, 'ai', 'white', 'checkmate', 'white')
+
+        rating = self.PlayerRating.objects.get(user=self.user)
+        self.assertEqual(rating.games_played, 1)
+        self.assertEqual(rating.wins, 1)
+        self.assertTrue(self.UserAchievement.objects.filter(user=self.user).exists())
+        
+        self.assertEqual(self.GameResult.objects.count(), 1)
+        res = self.GameResult.objects.first()
+        self.assertEqual(res.mode, 'ai')
+        self.assertEqual(res.winner, 'white')
+
+    def test_record_game_result_does_not_update_rating_or_achievements_for_pvp(self):
+        from game.views import record_game_result
+        factory = RequestFactory()
+        request = factory.post('/dummy/')
+        request.user = self.user
+        request.session = {}
+
+        record_game_result(request, 'pvp', 'white', 'checkmate', 'white')
+
+        self.assertFalse(self.PlayerRating.objects.filter(user=self.user).exists())
+        self.assertFalse(self.UserAchievement.objects.filter(user=self.user).exists())
+
+        self.assertEqual(self.GameResult.objects.count(), 1)
+        res = self.GameResult.objects.first()
+        self.assertEqual(res.mode, 'pvp')
+        self.assertEqual(res.winner, 'white')

--- a/game/views.py
+++ b/game/views.py
@@ -191,7 +191,7 @@ def record_game_result(request, mode, winner, reason, player_color='white', move
     result.full_clean()
     result.save()
 
-    if user:
+    if user and mode == 'ai':
         update_player_rating(
             user,
             winner,


### PR DESCRIPTION
## Description

This PR fixes a logic issue where local Pass-and-Play (PvP) games incorrectly updated a logged-in user's Elo rating and unlocked achievements.

The fix ensures that rating updates and achievement checks are only performed for competitive AI games, while still saving PvP games to the game history.

**Fixes #2150**

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

## Related Issue

Fixes #2150

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] I have commented my code where necessary
* [ ] I have updated the documentation if needed
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix works
* [ ] New and existing tests pass locally

## Screenshots 

N/A

## Additional Notes

### Changes made

* Restricted rating updates and achievement checks to AI games only.
* Preserved game history recording for local PvP matches.
* Added regression tests covering:

  * AI games continue to update ratings and achievements.
  * Local PvP games no longer update ratings or unlock achievements.
