### PR TITLE
fix(security): add rate limiting to opening lookup endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,3 +47,8 @@ TRUSTED_PROXY_IPS=127.0.0.1
 # ANALYZE_GAME_RATE_WINDOW_SECONDS=60
 # ANALYZE_GAME_USER_MAX_REQUESTS=10
 # ANALYZE_GAME_IP_MAX_REQUESTS=20
+
+# Opening Lookup Rate Limiting (Optional Overrides)
+# Uncomment to tune the opening lookup rate limits for abuse prevention
+# OPENING_RATE_LIMIT_WINDOW_SECONDS=60
+# OPENING_RATE_LIMIT_MAX_REQUESTS=60

--- a/core/settings.py
+++ b/core/settings.py
@@ -182,6 +182,10 @@ ANALYZE_GAME_USER_MAX_REQUESTS = _positive_int_env('ANALYZE_GAME_USER_MAX_REQUES
 # Max requests that can originate from a single IP address in the time window
 ANALYZE_GAME_IP_MAX_REQUESTS = _positive_int_env('ANALYZE_GAME_IP_MAX_REQUESTS', 20)
 
+# Rate limiting for opening lookup
+OPENING_RATE_LIMIT_WINDOW_SECONDS = 60
+OPENING_RATE_LIMIT_MAX_REQUESTS = 60
+
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/6.0/howto/static-files/
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -183,8 +183,8 @@ ANALYZE_GAME_USER_MAX_REQUESTS = _positive_int_env('ANALYZE_GAME_USER_MAX_REQUES
 ANALYZE_GAME_IP_MAX_REQUESTS = _positive_int_env('ANALYZE_GAME_IP_MAX_REQUESTS', 20)
 
 # Rate limiting for opening lookup
-OPENING_RATE_LIMIT_WINDOW_SECONDS = 60
-OPENING_RATE_LIMIT_MAX_REQUESTS = 60
+OPENING_RATE_LIMIT_WINDOW_SECONDS = _positive_int_env('OPENING_RATE_LIMIT_WINDOW_SECONDS', 60)
+OPENING_RATE_LIMIT_MAX_REQUESTS = _positive_int_env('OPENING_RATE_LIMIT_MAX_REQUESTS', 60)
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/6.0/howto/static-files/

--- a/core/settings.py
+++ b/core/settings.py
@@ -183,8 +183,12 @@ ANALYZE_GAME_USER_MAX_REQUESTS = _positive_int_env('ANALYZE_GAME_USER_MAX_REQUES
 ANALYZE_GAME_IP_MAX_REQUESTS = _positive_int_env('ANALYZE_GAME_IP_MAX_REQUESTS', 20)
 
 # Rate limiting for opening lookup
-OPENING_RATE_LIMIT_WINDOW_SECONDS = _positive_int_env('OPENING_RATE_LIMIT_WINDOW_SECONDS', 60)
-OPENING_RATE_LIMIT_MAX_REQUESTS = _positive_int_env('OPENING_RATE_LIMIT_MAX_REQUESTS', 60)
+OPENING_RATE_LIMIT_WINDOW_SECONDS = _positive_int_env(
+    'OPENING_RATE_LIMIT_WINDOW_SECONDS', 60
+)
+OPENING_RATE_LIMIT_MAX_REQUESTS = _positive_int_env(
+    'OPENING_RATE_LIMIT_MAX_REQUESTS', 60
+)
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/6.0/howto/static-files/

--- a/game/tests.py
+++ b/game/tests.py
@@ -3589,9 +3589,13 @@ class OpeningLookupRateLimitTest(TestCase):
         res2 = self.client.get(self.trainer_url)
         self.assertEqual(res2.status_code, 200)
         
-        res3 = self.client.get(self.trainer_url)
+        res3 = self.client.get(self.trainer_url, HTTP_ACCEPT='application/json')
         self.assertEqual(res3.status_code, 429)
         self.assertEqual(res3.json(), {"error": "Opening lookup rate limit reached. Please try again shortly."})
+
+        res_html = self.client.get(self.trainer_url, HTTP_ACCEPT='text/html')
+        self.assertEqual(res_html.status_code, 429)
+        self.assertIn(b"429 Too Many Requests", res_html.content)
 
     def test_opening_detail_rate_limit(self):
         res1 = self.client.get(self.detail_url)
@@ -3600,7 +3604,7 @@ class OpeningLookupRateLimitTest(TestCase):
         res2 = self.client.get(self.detail_url)
         self.assertEqual(res2.status_code, 200)
         
-        res3 = self.client.get(self.detail_url)
+        res3 = self.client.get(self.detail_url, HTTP_ACCEPT='application/json')
         self.assertEqual(res3.status_code, 429)
         self.assertEqual(res3.json(), {"error": "Opening lookup rate limit reached. Please try again shortly."})
 
@@ -3612,7 +3616,7 @@ class OpeningLookupRateLimitTest(TestCase):
         res2 = self.client.get(self.trainer_url)
         self.assertEqual(res2.status_code, 200)
         
-        res3 = self.client.get(self.trainer_url)
+        res3 = self.client.get(self.trainer_url, HTTP_ACCEPT='application/json')
         self.assertEqual(res3.status_code, 429)
         self.assertEqual(res3.json(), {"error": "Opening lookup rate limit reached. Please try again shortly."})
 
@@ -3630,6 +3634,6 @@ class OpeningLookupRateLimitTest(TestCase):
         res5 = self.client.get(self.trainer_url)
         self.assertEqual(res5.status_code, 200)
         
-        res6 = self.client.get(self.trainer_url)
+        res6 = self.client.get(self.trainer_url, HTTP_ACCEPT='application/json')
         self.assertEqual(res6.status_code, 429)
         self.assertEqual(res6.json(), {"error": "Opening lookup rate limit reached. Please try again shortly."})

--- a/game/tests.py
+++ b/game/tests.py
@@ -3565,3 +3565,59 @@ class GameResultRatingTest(TestCase):
         res = self.GameResult.objects.first()
         self.assertEqual(res.mode, 'pvp')
         self.assertEqual(res.winner, 'white')
+
+
+@override_settings(
+    OPENING_RATE_LIMIT_WINDOW_SECONDS=60,
+    OPENING_RATE_LIMIT_MAX_REQUESTS=2,
+)
+class OpeningLookupRateLimitTest(TestCase):
+    """Opening lookup requests should be throttled."""
+
+    def setUp(self):
+        cache.clear()
+        self.trainer_url = reverse('opening_trainer')
+        self.detail_url = reverse('opening_detail', kwargs={'slug': 'italian-game'})
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_opening_trainer_rate_limit(self):
+        res1 = self.client.get(self.trainer_url)
+        self.assertEqual(res1.status_code, 200)
+        
+        res2 = self.client.get(self.trainer_url)
+        self.assertEqual(res2.status_code, 200)
+        
+        res3 = self.client.get(self.trainer_url)
+        self.assertEqual(res3.status_code, 429)
+        self.assertEqual(res3.json(), {"error": "Opening lookup rate limit reached. Please try again shortly."})
+
+    def test_opening_detail_rate_limit(self):
+        res1 = self.client.get(self.detail_url)
+        self.assertEqual(res1.status_code, 200)
+        
+        res2 = self.client.get(self.detail_url)
+        self.assertEqual(res2.status_code, 200)
+        
+        res3 = self.client.get(self.detail_url)
+        self.assertEqual(res3.status_code, 429)
+        self.assertEqual(res3.json(), {"error": "Opening lookup rate limit reached. Please try again shortly."})
+
+    def test_opening_trainer_rate_limit_authenticated(self):
+        User.objects.create_user(
+            username='testuser_rl',
+            password='Password123!',
+            email='testuser_rl@example.com'
+        )
+        self.client.login(username='testuser_rl', password='Password123!')
+        
+        res1 = self.client.get(self.trainer_url)
+        self.assertEqual(res1.status_code, 200)
+        
+        res2 = self.client.get(self.trainer_url)
+        self.assertEqual(res2.status_code, 200)
+        
+        res3 = self.client.get(self.trainer_url)
+        self.assertEqual(res3.status_code, 429)
+        self.assertEqual(res3.json(), {"error": "Opening lookup rate limit reached. Please try again shortly."})

--- a/game/tests.py
+++ b/game/tests.py
@@ -3605,13 +3605,7 @@ class OpeningLookupRateLimitTest(TestCase):
         self.assertEqual(res3.json(), {"error": "Opening lookup rate limit reached. Please try again shortly."})
 
     def test_opening_trainer_rate_limit_authenticated(self):
-        User.objects.create_user(
-            username='testuser_rl',
-            password='Password123!',
-            email='testuser_rl@example.com'
-        )
-        self.client.login(username='testuser_rl', password='Password123!')
-        
+        # First exhaust the anonymous limit (IP based)
         res1 = self.client.get(self.trainer_url)
         self.assertEqual(res1.status_code, 200)
         
@@ -3621,3 +3615,21 @@ class OpeningLookupRateLimitTest(TestCase):
         res3 = self.client.get(self.trainer_url)
         self.assertEqual(res3.status_code, 429)
         self.assertEqual(res3.json(), {"error": "Opening lookup rate limit reached. Please try again shortly."})
+
+        # Now authenticate and verify we get a fresh allowance (User ID based)
+        User.objects.create_user(
+            username='testuser_rl',
+            password='Password123!',
+            email='testuser_rl@example.com'
+        )
+        self.client.login(username='testuser_rl', password='Password123!')
+        
+        res4 = self.client.get(self.trainer_url)
+        self.assertEqual(res4.status_code, 200)
+        
+        res5 = self.client.get(self.trainer_url)
+        self.assertEqual(res5.status_code, 200)
+        
+        res6 = self.client.get(self.trainer_url)
+        self.assertEqual(res6.status_code, 429)
+        self.assertEqual(res6.json(), {"error": "Opening lookup rate limit reached. Please try again shortly."})

--- a/game/views.py
+++ b/game/views.py
@@ -1583,6 +1583,15 @@ def rate_limit(window_setting, max_setting, prefix, error_message="Rate limit re
             current = increment_counter(cache_key, window_seconds)
             
             if current > max_requests:
+                if request.accepts("text/html"):
+                    from django.http import HttpResponse
+                    return HttpResponse(
+                        (
+                            "<h1>429 Too Many Requests</h1>"
+                            f"<p>{error_message}</p>"
+                        ),
+                        status=429
+                    )
                 return JsonResponse({"error": error_message}, status=429)
                 
             return view_func(request, *args, **kwargs)

--- a/game/views.py
+++ b/game/views.py
@@ -2,6 +2,7 @@
 import logging
 import json
 import time
+from functools import wraps
 import hashlib
 import math
 import io
@@ -1556,6 +1557,30 @@ def increment_counter(key, timeout):
     finally:
         if acquired:
             cache.delete(lock_key)
+
+
+def rate_limit(window_setting, max_setting, prefix, error_message="Rate limit reached. Please try again shortly."):
+    """
+    Reusable rate limit decorator based on cache throttle.
+    Limits requests to max_setting within window_setting seconds per user/IP.
+    """
+    def decorator(view_func):
+        @wraps(view_func)
+        def _wrapped_view(request, *args, **kwargs):
+            key_id = request.user.id if request.user.is_authenticated else get_client_ip(request)
+            cache_key = f"rate_limit:{prefix}:{key_id}"
+            
+            window_seconds = getattr(settings, window_setting, 60)
+            max_requests = getattr(settings, max_setting, 60)
+            
+            current = increment_counter(cache_key, window_seconds)
+            
+            if current > max_requests:
+                return JsonResponse({"error": error_message}, status=429)
+                
+            return view_func(request, *args, **kwargs)
+        return _wrapped_view
+    return decorator
 
 
 def login_view(request):
@@ -3590,6 +3615,12 @@ def lesson_map_view(request):
         }
     )
 
+@rate_limit(
+    window_setting="OPENING_RATE_LIMIT_WINDOW_SECONDS",
+    max_setting="OPENING_RATE_LIMIT_MAX_REQUESTS",
+    prefix="opening_lookup",
+    error_message="Opening lookup rate limit reached. Please try again shortly."
+)
 def opening_trainer(request):
     return render(
         request,
@@ -3600,6 +3631,12 @@ def opening_trainer(request):
     )
 
 
+@rate_limit(
+    window_setting="OPENING_RATE_LIMIT_WINDOW_SECONDS",
+    max_setting="OPENING_RATE_LIMIT_MAX_REQUESTS",
+    prefix="opening_lookup",
+    error_message="Opening lookup rate limit reached. Please try again shortly."
+)
 def opening_detail(request, slug):
     opening = next(
         (

--- a/game/views.py
+++ b/game/views.py
@@ -1568,7 +1568,8 @@ def rate_limit(window_setting, max_setting, prefix, error_message="Rate limit re
         @wraps(view_func)
         def _wrapped_view(request, *args, **kwargs):
             key_id = request.user.id if request.user.is_authenticated else get_client_ip(request)
-            cache_key = f"rate_limit:{prefix}:{key_id}"
+            key_digest = hashlib.sha256(str(key_id).encode('utf-8')).hexdigest()
+            cache_key = f"rate_limit:{prefix}:{key_digest}"
             
             window_seconds = getattr(settings, window_setting, 60)
             max_requests = getattr(settings, max_setting, 60)

--- a/game/views.py
+++ b/game/views.py
@@ -1567,8 +1567,14 @@ def rate_limit(window_setting, max_setting, prefix, error_message="Rate limit re
     def decorator(view_func):
         @wraps(view_func)
         def _wrapped_view(request, *args, **kwargs):
-            key_id = request.user.id if request.user.is_authenticated else get_client_ip(request)
-            key_digest = hashlib.sha256(str(key_id).encode('utf-8')).hexdigest()
+            if request.user.is_authenticated:
+                key_id = request.user.id
+            else:
+                key_id = get_client_ip(request)
+            
+            key_digest = hashlib.sha256(
+                str(key_id).encode('utf-8')
+            ).hexdigest()
             cache_key = f"rate_limit:{prefix}:{key_digest}"
             
             window_seconds = getattr(settings, window_setting, 60)
@@ -3616,11 +3622,14 @@ def lesson_map_view(request):
         }
     )
 
+
 @rate_limit(
     window_setting="OPENING_RATE_LIMIT_WINDOW_SECONDS",
     max_setting="OPENING_RATE_LIMIT_MAX_REQUESTS",
     prefix="opening_lookup",
-    error_message="Opening lookup rate limit reached. Please try again shortly."
+    error_message=(
+        "Opening lookup rate limit reached. Please try again shortly."
+    )
 )
 def opening_trainer(request):
     return render(
@@ -3636,7 +3645,9 @@ def opening_trainer(request):
     window_setting="OPENING_RATE_LIMIT_WINDOW_SECONDS",
     max_setting="OPENING_RATE_LIMIT_MAX_REQUESTS",
     prefix="opening_lookup",
-    error_message="Opening lookup rate limit reached. Please try again shortly."
+    error_message=(
+        "Opening lookup rate limit reached. Please try again shortly."
+    )
 )
 def opening_detail(request, slug):
     opening = next(


### PR DESCRIPTION
## Description

This PR adds rate limiting to the opening book lookup endpoints to prevent automated enumeration of the opening database.

### Changes

* Added configurable rate limit settings for opening lookups.
* Implemented a reusable cache-based `@rate_limit` decorator using the existing throttling mechanism.
* Applied rate limiting to the `opening_trainer` and `opening_detail` endpoints.
* Used the authenticated user's ID as the rate limit key, falling back to the client IP for anonymous users.
* Added unit tests covering both authenticated and anonymous rate limiting behavior.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

## Related Issue

Fixes #2136

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] I have commented my code where necessary
* [x] I have updated the documentation if needed
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix works
* [x] New and existing tests pass locally

## Screenshots 

N/A

## Additional Notes

The rate limit is implemented using the project's existing cache-backed throttling mechanism to maintain consistency with the current architecture. Both opening lookup endpoints share the same rate limit budget to prevent bypassing the limit by alternating between endpoints.
