### PR TITLE
feat: add interactive move navigation stepper and reset buttons

### DIFF
--- a/game/static/game/css/opening_trainer.css
+++ b/game/static/game/css/opening_trainer.css
@@ -157,3 +157,76 @@ body{
 .square.highlight-to {
     background: rgba(129, 199, 132, 0.75) !important;
 }
+
+/* Navigation Controls Container */
+.nav-controls {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 12px;
+    margin: 15px auto 25px auto;
+    max-width: 480px;
+    background: rgba(30, 30, 30, 0.45);
+    border: 1px solid rgba(240, 192, 64, 0.15);
+    border-radius: 12px;
+    padding: 12px;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+}
+
+/* Glassmorphic Nav Buttons */
+.nav-btn {
+    flex: 1;
+    padding: 10px 16px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #f0c040;
+    background: rgba(240, 192, 64, 0.08);
+    border: 1px solid rgba(240, 192, 64, 0.25);
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    outline: none;
+}
+
+.nav-btn:focus-visible {
+    outline: 2px solid #f0c040;
+    outline-offset: 2px;
+}
+
+.nav-btn:hover:not(:disabled) {
+    background: rgba(240, 192, 64, 0.18);
+    border-color: rgba(240, 192, 64, 0.45);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(240, 192, 64, 0.1);
+}
+
+.nav-btn:active:not(:disabled) {
+    transform: translateY(0);
+    box-shadow: none;
+}
+
+.nav-btn:disabled {
+    color: rgba(255, 255, 255, 0.25);
+    background: rgba(255, 255, 255, 0.03);
+    border-color: rgba(255, 255, 255, 0.05);
+    cursor: not-allowed;
+}
+
+/* Reset button specific override */
+#reset-trainer-btn {
+    border-color: rgba(255, 255, 255, 0.15);
+    color: #e0e0e0;
+    background: rgba(255, 255, 255, 0.05);
+}
+
+#reset-trainer-btn:hover:not(:disabled) {
+    background: rgba(255, 255, 255, 0.12);
+    border-color: rgba(255, 255, 255, 0.3);
+    color: #ffffff;
+}
+

--- a/game/static/game/js/opening_trainer.js
+++ b/game/static/game/js/opening_trainer.js
@@ -234,25 +234,28 @@ function parseSAN(san, color) {
     return null;
 }
 
-function applyMoveOnBoard(fromRow, fromCol, toRow, toCol) {
-    const piece = boardState[fromRow][fromCol];
-    boardState[fromRow][fromCol] = "";
-    boardState[toRow][toCol] = piece;
+function applyMoveToBoardState(state, fromRow, fromCol, toRow, toCol) {
+    const piece = state[fromRow][fromCol];
+    state[fromRow][fromCol] = "";
+    state[toRow][toCol] = piece;
 
     // Castling rook movement
     const pieceType = piece.slice(1);
     if (pieceType === "k" && Math.abs(fromCol - toCol) === 2) {
         if (toCol === 6) {
-            const rook = boardState[toRow][7];
-            boardState[toRow][7] = "";
-            boardState[toRow][5] = rook;
+            const rook = state[toRow][7];
+            state[toRow][7] = "";
+            state[toRow][5] = rook;
         } else if (toCol === 2) {
-            const rook = boardState[toRow][0];
-            boardState[toRow][0] = "";
-            boardState[toRow][3] = rook;
+            const rook = state[toRow][0];
+            state[toRow][0] = "";
+            state[toRow][3] = rook;
         }
     }
+}
 
+function applyMoveOnBoard(fromRow, fromCol, toRow, toCol) {
+    applyMoveToBoardState(boardState, fromRow, fromCol, toRow, toCol);
     renderBoard();
 }
 
@@ -452,22 +455,7 @@ function showMoveAt(index) {
         const moveParsed = parseSAN(moveStr, color);
 
         if (moveParsed) {
-            const piece = boardState[moveParsed.fromRow][moveParsed.fromCol];
-            boardState[moveParsed.fromRow][moveParsed.fromCol] = "";
-            boardState[moveParsed.toRow][moveParsed.toCol] = piece;
-
-            const pieceType = piece.slice(1);
-            if (pieceType === "k" && Math.abs(moveParsed.fromCol - moveParsed.toCol) === 2) {
-                if (moveParsed.toCol === 6) {
-                    const rook = boardState[moveParsed.toRow][7];
-                    boardState[moveParsed.toRow][7] = "";
-                    boardState[moveParsed.toRow][5] = rook;
-                } else if (moveParsed.toCol === 2) {
-                    const rook = boardState[moveParsed.toRow][0];
-                    boardState[moveParsed.toRow][0] = "";
-                    boardState[moveParsed.toRow][3] = rook;
-                }
-            }
+            applyMoveToBoardState(boardState, moveParsed.fromRow, moveParsed.fromCol, moveParsed.toRow, moveParsed.toCol);
 
             lastMoveHighlight = {
                 fromRow: moveParsed.fromRow,

--- a/game/static/game/js/opening_trainer.js
+++ b/game/static/game/js/opening_trainer.js
@@ -28,15 +28,7 @@ function csrf() {
     return m ? decodeURIComponent(m[1]) : "";
 }
 
-let currentMove = 0;
-let userColor = "w"; // 'w' or 'b'
-let selectedSquare = null;
-let lastMoveHighlight = null;
-let opponentReplyTimeout = null;
-const files = ["a", "b", "c", "d", "e", "f", "g", "h"];
-
-// Standard 8x8 starting setup
-let boardState = [
+const STARTING_BOARD_STATE = [
     ["br", "bn", "bb", "bq", "bk", "bb", "bn", "br"],
     ["bp", "bp", "bp", "bp", "bp", "bp", "bp", "bp"],
     ["", "", "", "", "", "", "", ""],
@@ -47,6 +39,15 @@ let boardState = [
     ["wr", "wn", "wb", "wq", "wk", "wb", "wn", "wr"]
 ];
 
+let boardState = STARTING_BOARD_STATE.map(row => [...row]);
+let currentMove = 0;
+let viewingMoveIndex = 0;
+let userColor = "w"; // 'w' or 'b'
+let selectedSquare = null;
+let lastMoveHighlight = null;
+let opponentReplyTimeout = null;
+const files = ["a", "b", "c", "d", "e", "f", "g", "h"];
+
 const feedback = document.getElementById("trainer-feedback");
 const progress = document.getElementById("move-progress");
 const moveInput = document.getElementById("move-input");
@@ -56,8 +57,9 @@ const playWhiteBtn = document.getElementById("play-white-btn");
 const playBlackBtn = document.getElementById("play-black-btn");
 
 function updateProgress() {
-    progress.innerText = `${currentMove} / ${OPENING_MOVES.length}`;
+    progress.innerText = `${viewingMoveIndex} / ${OPENING_MOVES.length}`;
 }
+
 
 async function persistOpeningProgress() {
     const token = csrf();
@@ -262,6 +264,9 @@ function highlightLastMove(fromRow, fromCol, toRow, toCol) {
 function playOpponentMove() {
     if (currentMove >= OPENING_MOVES.length) return;
 
+    // Bring boardState back to currentMove to make sure parseSAN/applyMove resolves against the latest actual state
+    showMoveAt(currentMove);
+
     const color = currentMove % 2 === 0 ? "w" : "b";
     const moveStr = OPENING_MOVES[currentMove];
     const moveParsed = parseSAN(moveStr, color);
@@ -269,16 +274,19 @@ function playOpponentMove() {
     if (moveParsed) {
         applyMoveOnBoard(moveParsed.fromRow, moveParsed.fromCol, moveParsed.toRow, moveParsed.toCol);
         currentMove++;
+        viewingMoveIndex = currentMove;
         updateProgress();
         highlightLastMove(moveParsed.fromRow, moveParsed.fromCol, moveParsed.toRow, moveParsed.toCol);
 
         if (currentMove >= OPENING_MOVES.length) {
             completeOpening();
         }
+        updateNavigationButtons();
     }
 }
 
 function makeUserMove(fromRow, fromCol, toRow, toCol) {
+    if (viewingMoveIndex !== currentMove) return;
     if (currentMove >= OPENING_MOVES.length) return;
 
     const expectedMove = OPENING_MOVES[currentMove];
@@ -292,14 +300,18 @@ function makeUserMove(fromRow, fromCol, toRow, toCol) {
 
         applyMoveOnBoard(fromRow, fromCol, toRow, toCol);
         currentMove++;
+        viewingMoveIndex = currentMove;
         feedback.innerText = "✅ Correct move!";
         updateProgress();
         highlightLastMove(fromRow, fromCol, toRow, toCol);
 
         if (currentMove >= OPENING_MOVES.length) {
             completeOpening();
+            updateNavigationButtons();
             return;
         }
+
+        updateNavigationButtons();
 
         // Auto-play opponent response after 800ms
         if (opponentReplyTimeout) clearTimeout(opponentReplyTimeout);
@@ -313,6 +325,8 @@ function makeUserMove(fromRow, fromCol, toRow, toCol) {
 }
 
 function handleSquareClick(row, col) {
+    if (viewingMoveIndex !== currentMove) return;
+
     const isUserTurn = (userColor === "w" && currentMove % 2 === 0) || (userColor === "b" && currentMove % 2 === 1);
     if (!isUserTurn) return;
 
@@ -344,6 +358,11 @@ function handleSquareClick(row, col) {
 }
 
 function handleDragStart(e, row, col) {
+    if (viewingMoveIndex !== currentMove) {
+        e.preventDefault();
+        return;
+    }
+
     const isUserTurn = (userColor === "w" && currentMove % 2 === 0) || (userColor === "b" && currentMove % 2 === 1);
     if (!isUserTurn) {
         e.preventDefault();
@@ -421,28 +440,91 @@ function renderBoard() {
     }
 }
 
+function showMoveAt(index) {
+    if (index < 0 || index > currentMove) return;
+
+    boardState = STARTING_BOARD_STATE.map(row => [...row]);
+    lastMoveHighlight = null;
+
+    for (let i = 0; i < index; i++) {
+        const color = i % 2 === 0 ? "w" : "b";
+        const moveStr = OPENING_MOVES[i];
+        const moveParsed = parseSAN(moveStr, color);
+
+        if (moveParsed) {
+            const piece = boardState[moveParsed.fromRow][moveParsed.fromCol];
+            boardState[moveParsed.fromRow][moveParsed.fromCol] = "";
+            boardState[moveParsed.toRow][moveParsed.toCol] = piece;
+
+            const pieceType = piece.slice(1);
+            if (pieceType === "k" && Math.abs(moveParsed.fromCol - moveParsed.toCol) === 2) {
+                if (moveParsed.toCol === 6) {
+                    const rook = boardState[moveParsed.toRow][7];
+                    boardState[moveParsed.toRow][7] = "";
+                    boardState[moveParsed.toRow][5] = rook;
+                } else if (moveParsed.toCol === 2) {
+                    const rook = boardState[moveParsed.toRow][0];
+                    boardState[moveParsed.toRow][0] = "";
+                    boardState[moveParsed.toRow][3] = rook;
+                }
+            }
+
+            lastMoveHighlight = {
+                fromRow: moveParsed.fromRow,
+                fromCol: moveParsed.fromCol,
+                toRow: moveParsed.toRow,
+                toCol: moveParsed.toCol
+            };
+        }
+    }
+
+    viewingMoveIndex = index;
+    updateProgress();
+    renderBoard();
+    updateNavigationButtons();
+}
+
+function updateInputState() {
+    const isLatest = viewingMoveIndex === currentMove;
+    const isCompleted = currentMove >= OPENING_MOVES.length;
+
+    if (moveInput) {
+        moveInput.disabled = !isLatest || isCompleted;
+    }
+    if (checkButton) {
+        checkButton.disabled = !isLatest || isCompleted;
+    }
+}
+
+function updateNavigationButtons() {
+    const prevBtn = document.getElementById("prev-move-btn");
+    const nextBtn = document.getElementById("next-move-btn");
+
+    if (prevBtn) {
+        prevBtn.disabled = (viewingMoveIndex === 0);
+    }
+    if (nextBtn) {
+        nextBtn.disabled = (viewingMoveIndex === currentMove);
+    }
+
+    updateInputState();
+}
+
 function resetGame() {
     currentMove = 0;
+    viewingMoveIndex = 0;
     selectedSquare = null;
     lastMoveHighlight = null;
     if (opponentReplyTimeout) {
         clearTimeout(opponentReplyTimeout);
         opponentReplyTimeout = null;
     }
-    boardState = [
-        ["br", "bn", "bb", "bq", "bk", "bb", "bn", "br"],
-        ["bp", "bp", "bp", "bp", "bp", "bp", "bp", "bp"],
-        ["", "", "", "", "", "", "", ""],
-        ["", "", "", "", "", "", "", ""],
-        ["", "", "", "", "", "", "", ""],
-        ["", "", "", "", "", "", "", ""],
-        ["wp", "wp", "wp", "wp", "wp", "wp", "wp", "wp"],
-        ["wr", "wn", "wb", "wq", "wk", "wb", "wn", "wr"]
-    ];
+    boardState = STARTING_BOARD_STATE.map(row => [...row]);
     moveInput.disabled = false;
     checkButton.disabled = false;
     feedback.innerText = "Ready to begin.";
     updateProgress();
+    updateNavigationButtons();
     renderBoard();
 
     // If Black plays, the opponent makes the first White move immediately
@@ -478,6 +560,8 @@ if (playWhiteBtn && playBlackBtn) {
 
 // Support manual move text box validation in sync with the visual board
 function validateMove(move) {
+    if (viewingMoveIndex !== currentMove) return false;
+
     const isUserTurn = (userColor === "w" && currentMove % 2 === 0) || (userColor === "b" && currentMove % 2 === 1);
     if (!isUserTurn) {
         feedback.innerText = "⚠️ It is the opponent's turn. Please wait.";
@@ -492,6 +576,7 @@ function validateMove(move) {
             highlightLastMove(parsed.fromRow, parsed.fromCol, parsed.toRow, parsed.toCol);
         }
         currentMove++;
+        viewingMoveIndex = currentMove;
         feedback.innerText = "✅ Correct move!";
         updateProgress();
         moveInput.value = "";
@@ -507,6 +592,7 @@ function validateMove(move) {
                 }, 800);
             }
         }
+        updateNavigationButtons();
         return true;
     }
 
@@ -529,5 +615,49 @@ moveInput.addEventListener("keypress", (event) => {
     }
 });
 
+// Navigation Stepper Event Listeners
+const prevBtn = document.getElementById("prev-move-btn");
+const nextBtn = document.getElementById("next-move-btn");
+const resetTrainerBtn = document.getElementById("reset-trainer-btn");
+
+if (prevBtn) {
+    prevBtn.addEventListener("click", () => {
+        if (viewingMoveIndex > 0) {
+            showMoveAt(viewingMoveIndex - 1);
+        }
+    });
+}
+
+if (nextBtn) {
+    nextBtn.addEventListener("click", () => {
+        if (viewingMoveIndex < currentMove) {
+            showMoveAt(viewingMoveIndex + 1);
+        }
+    });
+}
+
+if (resetTrainerBtn) {
+    resetTrainerBtn.addEventListener("click", () => {
+        resetGame();
+    });
+}
+
+// Keyboard Arrow Navigation
+document.addEventListener("keydown", (e) => {
+    if (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA") {
+        return; // Don't intercept arrow keys if typing in input fields
+    }
+    if (e.key === "ArrowLeft") {
+        if (viewingMoveIndex > 0) {
+            showMoveAt(viewingMoveIndex - 1);
+        }
+    } else if (e.key === "ArrowRight") {
+        if (viewingMoveIndex < currentMove) {
+            showMoveAt(viewingMoveIndex + 1);
+        }
+    }
+});
+
 // Initialize game
 resetGame();
+

--- a/game/templates/game/opening_detail.html
+++ b/game/templates/game/opening_detail.html
@@ -46,6 +46,13 @@
         <div id="board" class="chess-board"></div>
     </div>
 
+    <!-- Navigation Controls -->
+    <div class="nav-controls">
+        <button type="button" id="prev-move-btn" class="nav-btn" disabled>&larr; Previous</button>
+        <button type="button" id="reset-trainer-btn" class="nav-btn">Reset</button>
+        <button type="button" id="next-move-btn" class="nav-btn" disabled>Next &rarr;</button>
+    </div>
+
     <div id="trainer-feedback" class="feedback-box">
         Ready to begin.
     </div>


### PR DESCRIPTION
# Description

Fixes #2165 

This PR implements interactive move navigation controls below the chess board in the Opening Trainer (resolving #2165). This allows users to navigate back and forth through the history of completed moves to review their progress at their own pace.

## Key Additions & Changes

### 1. UI Components (`opening_detail.html`)
- Added a new navigation control bar wrapper containing `← Previous`, `Reset`, and `Next →` buttons directly underneath the chess board.

### 2. Glassmorphic Styling (`opening_trainer.css`)
- Implemented a sleek glassmorphic card container with translucent backgrounds, high-quality backdrop filters, and subtle shadows.
- Styled custom buttons with states (hover transitions, active clicks, and clear `disabled` layouts) matching the project's warm dark gold (`#f0c040`) color palette.

### 3. Navigation & Input Locking Logic (`opening_trainer.js`)
- Introduced a `viewingMoveIndex` state to keep track of the current move index visible on the board, independently of the furthest progress index (`currentMove`).
- Added `showMoveAt(index)` to dynamically rebuild the `boardState` from any historical point in the move array and update the visual board highlights.
- Prevented piece selection, drag events, and manual text move checks whenever the user is viewing historical moves (i.e. when `viewingMoveIndex < currentMove`).
- Enabled Left Arrow (`ArrowLeft`) and Right Arrow (`ArrowRight`) keyboard listeners for quick, intuitive navigation.
- Linked the `Reset` button to trigger the existing clean game reset behavior.