### PR TITLE
feat(profile): add user profile page with basic player information

### DIFF
--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -346,6 +346,7 @@
                 </button>
 
                 <div class="dropdown-content">
+                    <a href="{% url 'profile' %}"> Profile </a>
                     <a href="/stats/">
                         Stats
                     </a>

--- a/game/templates/game/forum_detail.html
+++ b/game/templates/game/forum_detail.html
@@ -28,6 +28,7 @@
                 <button type="button" class="profile-btn">{{ user.username }} ⌄</button>
 
                 <div class="dropdown-content">
+                    <a href="{% url 'profile' %}"> Profile </a>
                     <a href="/play/">Dashboard</a>
                     <a href="{% url 'opening_trainer' %}">Opening Trainer</a>
                     <a href="/stats/">Stats</a>

--- a/game/templates/game/forum_list.html
+++ b/game/templates/game/forum_list.html
@@ -35,6 +35,7 @@
                 </button>
 
                 <div class="dropdown-content">
+                    <a href="{% url 'profile' %}"> Profile </a>
                     <a href="/play/">Dashboard</a>
                     <a href="/stats/">Stats</a>
                     <a href="{% url 'leaderboard' %}">Leaderboard</a>

--- a/game/templates/game/forum_new.html
+++ b/game/templates/game/forum_new.html
@@ -35,6 +35,7 @@
                 </button>
 
                 <div class="dropdown-content">
+                    <a href="{% url 'profile' %}"> Profile </a>
                     <a href="/play/">Dashboard</a>
                     <a href="/stats/">Stats</a>
                     <a href="{% url 'leaderboard' %}">Leaderboard</a>

--- a/game/templates/game/landing.html
+++ b/game/templates/game/landing.html
@@ -171,6 +171,7 @@
             <svg class="profile-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"></path></svg>
           </button>
           <div class="dropdown-content">
+            <a href="{% url 'profile' %}"> Profile </a>
             <a href="/play/"> Dashboard </a>
 
             <a href="{% url 'opening_trainer' %}">

--- a/game/templates/game/profile.html
+++ b/game/templates/game/profile.html
@@ -1,0 +1,149 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Profile — Checkora</title>
+    <link rel="icon" type="image/jpeg" href="{% static 'game/favicon.jpeg' %}">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        body {
+            background: radial-gradient(circle at top, #1e293b 0%, #0f172a 45%, #020617 100%);
+            color: #f8fafc;
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+            padding: 40px 20px;
+            min-height: 100vh;
+            margin: 0;
+            box-sizing: border-box;
+        }
+        .container {
+            max-width: 600px;
+            margin: 0 auto;
+            background: rgba(30, 41, 59, 0.5);
+            border-radius: 12px;
+            padding: 30px;
+            border: 1px solid rgba(255, 255, 255, 0.1);
+        }
+        .header-title-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 30px;
+        }
+        h1 {
+            color: #ffffff;
+            margin: 0;
+            font-size: 2rem;
+        }
+        .back-link {
+            color: #38bdf8;
+            text-decoration: none;
+            display: flex;
+            align-items: center;
+            font-weight: 500;
+        }
+        .back-link:hover {
+            text-decoration: underline;
+        }
+        .profile-header {
+            display: flex;
+            align-items: center;
+            gap: 20px;
+            margin-bottom: 30px;
+        }
+        .avatar-img {
+            width: 80px;
+            height: 80px;
+            border-radius: 50%;
+            object-fit: cover;
+            border: 2px solid #38bdf8;
+        }
+        .avatar-placeholder {
+            width: 80px;
+            height: 80px;
+            border-radius: 50%;
+            background: #334155;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            border: 2px solid #38bdf8;
+        }
+        .username {
+            font-size: 1.5rem;
+            font-weight: 700;
+            margin: 0;
+        }
+        .stats-grid {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 20px;
+        }
+        .stat-card {
+            background: rgba(15, 23, 42, 0.6);
+            padding: 20px;
+            border-radius: 8px;
+            text-align: center;
+            border: 1px solid rgba(255, 255, 255, 0.05);
+        }
+        .stat-label {
+            color: #94a3b8;
+            font-size: 0.9rem;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            margin-bottom: 8px;
+        }
+        .stat-value {
+            font-size: 1.8rem;
+            font-weight: 700;
+            color: #ffffff;
+        }
+        @media (max-width: 500px) {
+            .stats-grid {
+                grid-template-columns: 1fr;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header-title-row">
+            <h1>User Profile</h1>
+            <a href="{% url 'landing' %}" class="back-link">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="margin-right: 4px;"><line x1="19" y1="12" x2="5" y2="12"></line><polyline points="12 19 5 12 12 5"></polyline></svg>
+                Back to Home
+            </a>
+        </div>
+        
+        <div class="profile-header">
+            {% if request.user.profile.avatar %}
+                <img src="{{ request.user.profile.avatar }}" alt="{{ request.user.username }}'s Avatar" class="avatar-img">
+            {% else %}
+                <div class="avatar-placeholder">
+                    <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+                </div>
+            {% endif %}
+            <div class="username">{{ request.user.username }}</div>
+        </div>
+
+        <div class="stats-grid">
+            <div class="stat-card">
+                <div class="stat-label">Rating</div>
+                <div class="stat-value">{{ rating }}</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-label">Wins</div>
+                <div class="stat-value">{{ wins }}</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-label">Losses</div>
+                <div class="stat-value">{{ losses }}</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-label">Draws</div>
+                <div class="stat-value">{{ draws }}</div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/game/urls.py
+++ b/game/urls.py
@@ -5,6 +5,7 @@ urlpatterns = [
     path('', views.preloader, name='preloader'),
     path('home/', views.landing, name='landing'),
     path('play/', views.index, name='index'),
+    path('profile/', views.profile_view, name='profile'),
     
     # Game API Endpoints
     path('api/move/', views.make_move, name='make_move'),

--- a/game/views.py
+++ b/game/views.py
@@ -4229,3 +4229,28 @@ def get_avatar(request):
         "avatar", flat=True
     ).first() or ""
     return JsonResponse({"avatar": avatar})
+
+
+@login_required
+def profile_view(request):
+    """User profile view."""
+    try:
+        pr = request.user.player_rating
+        rating = pr.rating
+        wins = pr.wins
+        losses = pr.losses
+        draws = pr.draws
+    except PlayerRating.DoesNotExist:
+        # Fallback if PlayerRating doesn't exist
+        rating = 1200
+        wins = 0
+        losses = 0
+        draws = 0
+
+    context = {
+        'rating': rating,
+        'wins': wins,
+        'losses': losses,
+        'draws': draws,
+    }
+    return render(request, 'game/profile.html', context)


### PR DESCRIPTION
## Description

This PR adds a dedicated user profile page that allows authenticated users to view their basic player information and game statistics in a responsive interface.

### Changes

* Added a new `/profile/` route.
* Added a login-protected profile view.
* Created a responsive profile page displaying:

  * Username
  * Default avatar placeholder
  * Rating (with a fallback value when unavailable)
  * Wins
  * Losses
  * Draws
* Added a **Profile** link to the authenticated user navigation.
* Used the existing `PlayerRating` relationship when available without introducing new models or database migrations.
* Updated the fallback logic to catch only `PlayerRating.DoesNotExist` instead of a broad exception.

## Type of Change

* [ ] Bug fix (non-breaking change that fixes an issue)
* [x] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

## Related Issue

Fixes #248

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] I have commented my code where necessary
* [ ] I have updated the documentation if needed
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix/feature works
* [x] New and existing tests pass locally

## Testing

* ✅ `flake8`
* ✅ `python manage.py check`
* ✅ `python manage.py makemigrations --check --dry-run`
* ✅ `npm test`
* ✅ `python manage.py test game.tests --verbosity=2` (202/202 passed)


## Additional Notes

This implementation is limited to the scope of Issue #248. It introduces a lightweight profile page without affecting gameplay, authentication flow, or database schema.
