### PR TITLE
feat(trainer): add board theme customization

### DIFF
--- a/game/static/game/css/opening_trainer.css
+++ b/game/static/game/css/opening_trainer.css
@@ -132,11 +132,50 @@ body{
 }
 
 .square.light {
-    background: #f0d9b5;
+    background: var(--light-square, #f0d9b5);
 }
 
 .square.dark {
-    background: #b58863;
+    background: var(--dark-square, #b58863);
+}
+
+/* Board Themes */
+.chess-board.theme-classic {
+    --light-square: #f0d9b5;
+    --dark-square: #b58863;
+}
+
+.chess-board.theme-wood {
+    --light-square: #d7b899;
+    --dark-square: #85583f;
+}
+
+.chess-board.theme-green {
+    --light-square: #eeeed2;
+    --dark-square: #769656;
+}
+
+.chess-board.theme-blue {
+    --light-square: #dee3e6;
+    --dark-square: #4b7399;
+}
+
+/* Theme Dropdown Selector */
+.theme-select {
+    padding: 8px 12px;
+    background: #1e1e1e;
+    border: 1px solid #444;
+    border-radius: 6px;
+    color: #fff;
+    cursor: pointer;
+    font-weight: 600;
+    outline: none;
+    transition: all 0.2s ease;
+}
+
+.theme-select:hover, .theme-select:focus {
+    border-color: #f0c040;
+    background: #2a2a2a;
 }
 
 .square img {

--- a/game/static/game/js/opening_trainer.js
+++ b/game/static/game/js/opening_trainer.js
@@ -529,5 +529,37 @@ moveInput.addEventListener("keypress", (event) => {
     }
 });
 
+// Theme Selection Setup
+const themeSelect = document.getElementById("board-theme-select");
+
+function applyTheme(theme) {
+    if (!boardElement) return;
+
+    // Remove any previous theme- classes
+    boardElement.className.split(" ").forEach(className => {
+        if (className.startsWith("theme-")) {
+            boardElement.classList.remove(className);
+        }
+    });
+
+    // Add selected theme class
+    boardElement.classList.add(`theme-${theme}`);
+
+    // Persist in localStorage
+    localStorage.setItem("checkora-board-theme", theme);
+}
+
+if (themeSelect) {
+    // Load persisted theme or default to classic
+    const savedTheme = localStorage.getItem("checkora-board-theme") || "classic";
+    themeSelect.value = savedTheme;
+    applyTheme(savedTheme);
+
+    // Event listener for user theme changes
+    themeSelect.addEventListener("change", (e) => {
+        applyTheme(e.target.value);
+    });
+}
+
 // Initialize game
 resetGame();

--- a/game/templates/game/opening_detail.html
+++ b/game/templates/game/opening_detail.html
@@ -39,6 +39,14 @@
         <span class="toggle-label">Play as:</span>
         <button type="button" id="play-white-btn" class="toggle-btn active" aria-pressed="true">White</button>
         <button type="button" id="play-black-btn" class="toggle-btn" aria-pressed="false">Black</button>
+
+        <span class="toggle-label" style="margin-left: 20px;">Board Theme:</span>
+        <select id="board-theme-select" class="theme-select">
+            <option value="classic">Classic</option>
+            <option value="wood">Wood</option>
+            <option value="green">Green</option>
+            <option value="blue">Blue</option>
+        </select>
     </div>
 
     <!-- Chess Board Container -->


### PR DESCRIPTION
### Description

This PR introduces board theme and style customization to the chess opening trainer page. Users can now choose from various board theme color palettes dynamically without reloading the page, and their choice is preserved across page reloads.

Fixes #2166

### Proposed Changes

#### 1. UI Template
* Modified [opening_detail.html](file:///Users/nishtha/Desktop/gssoc/checkora/Checkora/game/templates/game/opening_detail.html): Added a theme selector dropdown menu (`#board-theme-select`) inside the `.color-toggle-container` allowing the user to select from:
  * **Classic** (Default)
  * **Wood**
  * **Green**
  * **Blue**

#### 2. Stylesheets
* Modified [opening_trainer.css](file:///Users/nishtha/Desktop/gssoc/checkora/Checkora/game/static/game/css/opening_trainer.css):
  * Refactored `.square.light` and `.square.dark` elements to use CSS custom properties (`--light-square`, `--dark-square`) with standard fallbacks.
  * Added CSS variables specific to each board theme (Classic, Wood, Green, Blue) bound to the parent class on `.chess-board`.
  * Styled the dropdown element (`.theme-select`) to naturally fit the chess board controller's aesthetic.

#### 3. Frontend logic
* Modified [opening_trainer.js](file:///Users/nishtha/Desktop/gssoc/checkora/Checkora/game/static/game/js/opening_trainer.js):
  * Implemented an `applyTheme` helper that updates theme classes on `#board`.
  * Set up event handling on dropdown select change to update the theme dynamically.
  * Added `localStorage` integration under key `checkora-board-theme` so that the user's theme persists across refreshes and multiple opening sessions.
