### PR TITLE
feat(trainer): implement interactive move hint system

### DIFF
--- a/game/static/game/css/opening_trainer.css
+++ b/game/static/game/css/opening_trainer.css
@@ -274,3 +274,53 @@ body{
     color: #ffffff;
 }
 
+/* Get Hint Button */
+#get-hint-btn {
+    padding: 10px 15px;
+    margin-left: 8px;
+    cursor: pointer;
+    background: #f0c040;
+    color: black;
+    border: 1px solid #f0c040;
+    border-radius: 4px;
+    font-weight: bold;
+    transition: all 0.2s ease;
+}
+
+#get-hint-btn:hover:not(:disabled) {
+    background: #e0b030;
+    border-color: #e0b030;
+}
+
+#get-hint-btn:disabled {
+    background: #444;
+    color: #888;
+    border-color: #444;
+    cursor: not-allowed;
+}
+
+/* Pulse effect for the start (from) square of the hint */
+@keyframes hint-pulse {
+    0% {
+        background-color: rgba(240, 192, 64, 0.4) !important;
+        box-shadow: inset 0 0 10px rgba(240, 192, 64, 0.6);
+    }
+    50% {
+        background-color: rgba(240, 192, 64, 0.7) !important;
+        box-shadow: inset 0 0 20px rgba(240, 192, 64, 1);
+    }
+    100% {
+        background-color: rgba(240, 192, 64, 0.4) !important;
+        box-shadow: inset 0 0 10px rgba(240, 192, 64, 0.6);
+    }
+}
+
+.square.hint-from {
+    animation: hint-pulse 2s infinite ease-in-out;
+}
+
+/* Dashed border highlighting the target (to) square */
+.square.hint-to {
+    border: 3px dashed #f0c040 !important;
+    box-sizing: border-box;
+}

--- a/game/static/game/css/opening_trainer.css
+++ b/game/static/game/css/opening_trainer.css
@@ -302,15 +302,15 @@ body{
 /* Pulse effect for the start (from) square of the hint */
 @keyframes hint-pulse {
     0% {
-        background-color: rgba(240, 192, 64, 0.4) !important;
+        background-color: rgba(240, 192, 64, 0.4);
         box-shadow: inset 0 0 10px rgba(240, 192, 64, 0.6);
     }
     50% {
-        background-color: rgba(240, 192, 64, 0.7) !important;
+        background-color: rgba(240, 192, 64, 0.7);
         box-shadow: inset 0 0 20px rgba(240, 192, 64, 1);
     }
     100% {
-        background-color: rgba(240, 192, 64, 0.4) !important;
+        background-color: rgba(240, 192, 64, 0.4);
         box-shadow: inset 0 0 10px rgba(240, 192, 64, 0.6);
     }
 }

--- a/game/static/game/js/opening_trainer.js
+++ b/game/static/game/js/opening_trainer.js
@@ -46,6 +46,8 @@ let userColor = "w"; // 'w' or 'b'
 let selectedSquare = null;
 let lastMoveHighlight = null;
 let opponentReplyTimeout = null;
+let hintHighlight = null;
+const hintButton = document.getElementById("get-hint-btn");
 const files = ["a", "b", "c", "d", "e", "f", "g", "h"];
 
 const feedback = document.getElementById("trainer-feedback");
@@ -328,6 +330,11 @@ function makeUserMove(fromRow, fromCol, toRow, toCol) {
 }
 
 function handleSquareClick(row, col) {
+    if (hintHighlight) {
+        hintHighlight = null;
+        renderBoard();
+    }
+
     if (viewingMoveIndex !== currentMove) return;
 
     const isUserTurn = (userColor === "w" && currentMove % 2 === 0) || (userColor === "b" && currentMove % 2 === 1);
@@ -423,6 +430,15 @@ function renderBoard() {
             )) {
                 square.classList.add(lastMoveHighlight.toRow === actualRow && lastMoveHighlight.toCol === actualCol ? "highlight-to" : "highlight-from");
             }
+            // Apply hint styles if a hint is active
+            if (hintHighlight) {
+                if (hintHighlight.fromRow === actualRow && hintHighlight.fromCol === actualCol) {
+                    square.classList.add("hint-from");
+                }
+                if (hintHighlight.toRow === actualRow && hintHighlight.toCol === actualCol) {
+                    square.classList.add("hint-to");
+                }
+            }
 
             const piece = boardState[actualRow][actualCol];
             if (piece) {
@@ -448,6 +464,7 @@ function showMoveAt(index) {
 
     boardState = STARTING_BOARD_STATE.map(row => [...row]);
     lastMoveHighlight = null;
+    hintHighlight = null; // Clear hint highlight state
 
     for (let i = 0; i < index; i++) {
         const color = i % 2 === 0 ? "w" : "b";
@@ -482,6 +499,9 @@ function updateInputState() {
     if (checkButton) {
         checkButton.disabled = !isLatest || isCompleted;
     }
+    if (hintButton) {
+        hintButton.disabled = !isLatest || isCompleted;
+    }
 }
 
 function updateNavigationButtons() {
@@ -503,6 +523,7 @@ function resetGame() {
     viewingMoveIndex = 0;
     selectedSquare = null;
     lastMoveHighlight = null;
+    hintHighlight = null; // Clear hint highlight state
     if (opponentReplyTimeout) {
         clearTimeout(opponentReplyTimeout);
         opponentReplyTimeout = null;
@@ -548,6 +569,11 @@ if (playWhiteBtn && playBlackBtn) {
 
 // Support manual move text box validation in sync with the visual board
 function validateMove(move) {
+    if (hintHighlight) {
+        hintHighlight = null;
+        renderBoard();
+    }
+
     if (viewingMoveIndex !== currentMove) return false;
 
     const isUserTurn = (userColor === "w" && currentMove % 2 === 0) || (userColor === "b" && currentMove % 2 === 1);
@@ -675,6 +701,27 @@ if (themeSelect) {
     // Event listener for user theme changes
     themeSelect.addEventListener("change", (e) => {
         applyTheme(e.target.value);
+    });
+}
+
+    if (hintButton) {
+    hintButton.addEventListener("click", () => {
+        if (viewingMoveIndex !== currentMove) return;
+        if (currentMove >= OPENING_MOVES.length) return;
+
+        const expectedMove = OPENING_MOVES[currentMove];
+        const color = currentMove % 2 === 0 ? "w" : "b";
+        const moveParsed = parseSAN(expectedMove, color);
+
+        if (moveParsed) {
+            hintHighlight = {
+                fromRow: moveParsed.fromRow,
+                fromCol: moveParsed.fromCol,
+                toRow: moveParsed.toRow,
+                toCol: moveParsed.toCol
+            };
+            renderBoard();
+        }
     });
 }
 

--- a/game/static/game/js/opening_trainer.js
+++ b/game/static/game/js/opening_trainer.js
@@ -709,6 +709,10 @@ if (themeSelect) {
         if (viewingMoveIndex !== currentMove) return;
         if (currentMove >= OPENING_MOVES.length) return;
 
+        // Ensure it is the user's turn before showing a hint
+        const isUserTurn = (userColor === "w" && currentMove % 2 === 0) || (userColor === "b" && currentMove % 2 === 1);
+        if (!isUserTurn) return;
+
         const expectedMove = OPENING_MOVES[currentMove];
         const color = currentMove % 2 === 0 ? "w" : "b";
         const moveParsed = parseSAN(expectedMove, color);

--- a/game/templates/game/opening_detail.html
+++ b/game/templates/game/opening_detail.html
@@ -83,6 +83,12 @@
             id="check-move-btn">
             Check Move
         </button>
+        
+        <button 
+            type="button"
+            id="get-hint-btn">
+            Get Hint
+        </button>
     </div>
 
     <h3>Opening Line</h3>


### PR DESCRIPTION
# Description

Implements a **Move Hint System** that highlights the correct piece and destination square on the board when the user requests help during opening training.

Fixes #2167

- Assists users when they get stuck on complex opening theory.
- Provides a clean, aesthetic visual cue on the board without interrupting the general flow.

## Proposed Changes

### 1. Template
- **Modified:** `game/templates/game/opening_detail.html`
  - Added a "Get Hint" button next to the input and check move button.

### 2. Styling
- **Modified:** `game/static/game/css/opening_trainer.css`
  - Styled the new hint button (`#get-hint-btn`) to fit seamlessly with the board theme.
  - Added keyframes and styling for `.square.hint-from` to show a subtle yellow pulsing glow on the starting square of the correct piece.
  - Added styling for `.square.hint-to` to display a dashed yellow border highlighting the target square.

### 3. JavaScript Logic
- **Modified:** `game/static/game/js/opening_trainer.js`
  - Introduced `hintHighlight` and `hintButton` state handlers.
  - Added an event listener to the "Get Hint" button that parses the current expected move using `parseSAN` and marks the relevant coordinates.
  - Updated `renderBoard()` to apply the `hint-from` and `hint-to` styling to the board.
  - Configured state resets so that the hint highlight automatically disappears as soon as a user clicks another square, resets the board, moves historical steps, or makes a move.
  - Updated `updateInputState` to disable the hint button when the opening trainer is completed or when viewing historical steps.
