### PR TITLE
feat: add SAN quick move input

### DIFF
--- a/board.test.js
+++ b/board.test.js
@@ -11,6 +11,9 @@ document.body.innerHTML = `
   <div id="status-text"></div>
   <div id="manualMoveInput"></div>
   <div id="manualMoveError"></div>
+  <input id="sanMoveInput" type="text" />
+  <button id="sanMoveBtn"></button>
+  <div id="sanMoveError" style="display: none;"></div>
 
   <div id="turnBadge"></div>
   <div id="statusBar"></div>
@@ -23,6 +26,7 @@ document.body.innerHTML = `
   <div id="modeBadge"></div>
   <button id="autoFlipBtn"></button>
   <div id="flipControls"></div>
+  <button id="flipBtn"></button>
   <button id="copyFenBtn"></button>
   <div id="welcomeOverlay"></div>
   <button id="welcomeResumeBtn"></button>
@@ -132,6 +136,7 @@ global.fetch = jest.fn((url, options) => {
   return Promise.resolve({
     json: () => Promise.resolve({ 
       valid: true,
+      fen: 'startpos_fen',
       board: boardData,
       current_turn: 'white',
       player_color: 'white',
@@ -191,8 +196,20 @@ global.Chess = class MockChess {
   }
   move(moveObj) {
     const moveStr = typeof moveObj === 'string' ? moveObj : `${moveObj.from}${moveObj.to}`;
+    
+    if (moveStr === 'invalid' || moveStr === 'illegal') return null;
+    
     this._fen = `${this._fen}_then_${moveStr}`;
-    return {};
+    
+    if (moveStr === 'e4' || moveStr === 'e2e4') return { from: 'e2', to: 'e4', promotion: undefined };
+    if (moveStr === 'Nf3') return { from: 'g1', to: 'f3', promotion: undefined };
+    if (moveStr === 'O-O') return { from: 'e1', to: 'g1', promotion: undefined };
+    if (moveStr === 'e8=Q' || moveStr === 'e8=q' || moveStr === 'e7e8q') return { from: 'e7', to: 'e8', promotion: 'q' };
+    if (moveStr === 'Bxc6+') return { from: 'b5', to: 'c6', promotion: undefined };
+    if (moveStr === 'Nbd7') return { from: 'b8', to: 'd7', promotion: undefined };
+    if (moveStr === 'Qh5+') return { from: 'd1', to: 'h5', promotion: undefined };
+    
+    return { from: 'a1', to: 'a2' };
   }
 };
 
@@ -204,6 +221,13 @@ global.Audio = class MockAudio {
   play() {
     return Promise.resolve();
   }
+};
+window.matchMedia = window.matchMedia || function() {
+  return {
+    matches: true,
+    addListener: function() {},
+    removeListener: function() {}
+  };
 };
 
 const { pColor, getSquareLabel, formatTime, getPlayerScore, validateMoveWithStockfish, clearEvaluationCache, onClick, onDragStart, onDrop, showPromoModal, hidePromoModal, onPromoChoice, toggleSquareHighlight, refreshHighlights, highlightCheck, startNewGame } = require("./game/static/game/js/board");
@@ -409,3 +433,229 @@ describe("Board UI Interactions", () => {
      expect(typeof onDragStart).toBe('function');
   });
 });
+
+describe("SAN Quick Move Input", () => {
+  beforeEach(async () => {
+    document.getElementById("board").innerHTML = "";
+    document.getElementById("sanMoveInput").value = "";
+    document.getElementById("sanMoveError").style.display = "none";
+    document.getElementById("sanMoveBtn").disabled = false;
+    global.fetch.mockClear();
+    
+    // Call startNewGame to initialize board variable and DOM
+    const { startNewGame } = require("./game/static/game/js/board");
+    await startNewGame('pvp', 'white', 'medium', 'startpos', 10);
+  });
+
+  async function flushPromises() {
+    return new Promise(resolve => setTimeout(resolve, 0));
+  }
+
+  it('valid pawn move (e4) using Enter key clears input and calls /api/move/', async () => {
+    const input = document.getElementById("sanMoveInput");
+    input.value = "e4";
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    
+    await flushPromises();
+    
+    expect(input.value).toBe('');
+    
+    const moveReqs = global.fetch.mock.calls.filter(c => c[0].includes('/api/move/'));
+    expect(moveReqs.length).toBe(1);
+    
+    const body = JSON.parse(moveReqs[0][1].body);
+    // e2 is (1, 4), e4 is (3, 4) -> indices: fr=6, fc=4, tr=4, tc=4
+    expect(body.from_row).toBe(6);
+    expect(body.from_col).toBe(4);
+    expect(body.to_row).toBe(4);
+    expect(body.to_col).toBe(4);
+  });
+
+  it('valid piece move (Nf3) using Move button', async () => {
+    const input = document.getElementById("sanMoveInput");
+    const btn = document.getElementById("sanMoveBtn");
+    input.value = "Nf3";
+    btn.click();
+    
+    await flushPromises();
+    
+    expect(input.value).toBe('');
+    
+    const moveReqs = global.fetch.mock.calls.filter(c => c[0].includes('/api/move/'));
+    expect(moveReqs.length).toBe(1);
+    const body = JSON.parse(moveReqs[0][1].body);
+    // g1 is (0, 6), f3 is (2, 5) -> indices: fr=7, fc=6, tr=5, tc=5
+    expect(body.from_row).toBe(7);
+    expect(body.from_col).toBe(6);
+    expect(body.to_row).toBe(5);
+    expect(body.to_col).toBe(5);
+  });
+
+  it('castling (O-O) move mapping', async () => {
+    const input = document.getElementById("sanMoveInput");
+    input.value = "O-O";
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    
+    await flushPromises();
+    expect(input.value).toBe('');
+    
+    const moveReqs = global.fetch.mock.calls.filter(c => c[0].includes('/api/move/'));
+    expect(moveReqs.length).toBe(1);
+    const body = JSON.parse(moveReqs[0][1].body);
+    // e1 to g1 -> fr=7, fc=4, tr=7, tc=6
+    expect(body.from_row).toBe(7);
+    expect(body.from_col).toBe(4);
+    expect(body.to_row).toBe(7);
+    expect(body.to_col).toBe(6);
+  });
+
+  it('invalid notation retains input and shows error', async () => {
+    const input = document.getElementById("sanMoveInput");
+    const err = document.getElementById("sanMoveError");
+    input.value = "invalid";
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    
+    await flushPromises();
+    
+    expect(input.value).toBe('invalid'); // input retained
+    expect(err.style.display).toBe('block');
+    expect(err.textContent).toContain('Invalid or illegal move notation');
+    
+    const moveReqs = global.fetch.mock.calls.filter(c => c[0].includes('/api/move/'));
+    expect(moveReqs.length).toBe(0);
+  });
+  
+  it('illegal move retains input and shows error', async () => {
+    const input = document.getElementById("sanMoveInput");
+    const err = document.getElementById("sanMoveError");
+    input.value = "illegal";
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    
+    await flushPromises();
+    
+    expect(input.value).toBe('illegal');
+    expect(err.style.display).toBe('block');
+  });
+
+  it('Escape clears and blurs the input', () => {
+    const input = document.getElementById("sanMoveInput");
+    const err = document.getElementById("sanMoveError");
+    input.value = "partial";
+    err.style.display = "block";
+    
+    input.focus();
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    
+    expect(input.value).toBe('');
+    expect(err.style.display).toBe('none');
+    // document.activeElement might not accurately reflect blur in jsdom without attached body, but value clearing is tested.
+  });
+
+  it('typing shortcut characters (f) while focused does not trigger global shortcuts', () => {
+    const input = document.getElementById("sanMoveInput");
+    const flipBtn = document.getElementById("flipBtn");
+    // Mock the click on flipBtn
+    flipBtn.click = jest.fn();
+    
+    input.focus();
+    // Simulate global keydown listener which uses document.activeElement check
+    // Wait, the test environment doesn't perfectly simulate activeElement in all cases unless attached.
+    // Instead we can dispatch the event on document, but mock activeElement.
+    Object.defineProperty(document, 'activeElement', { value: input, writable: true });
+    
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'f' }));
+    
+    expect(flipBtn.click).not.toHaveBeenCalled();
+  });
+
+  it('backend move rejection retains input and shows error', async () => {
+    const input = document.getElementById("sanMoveInput");
+    const err = document.getElementById("sanMoveError");
+    
+    // Override fetch temporarily for this test
+    const originalFetch = global.fetch;
+    try {
+      global.fetch = jest.fn(async (url, options) => {
+        if (url && url.includes('/api/state/')) return { json: async () => ({ fen: 'startpos' }) };
+        if (url && url.includes('/api/move/')) return { json: async () => ({ valid: false, message: 'Backend rejected' }) };
+        return originalFetch(url, options);
+      });
+
+      input.value = "e4";
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await flushPromises();
+      
+      expect(input.value).toBe('e4');
+      expect(err.style.display).toBe('block');
+      expect(err.textContent).toContain('Backend rejected');
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
+  it('SAN with capture and check (Bxc6+)', async () => {
+    const input = document.getElementById("sanMoveInput");
+    input.value = "Bxc6+";
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await flushPromises();
+    
+    expect(input.value).toBe('');
+    const moveReqs = global.fetch.mock.calls.filter(c => c[0] && c[0].includes('/api/move/'));
+    const body = JSON.parse(moveReqs[moveReqs.length - 1][1].body);
+    // b5 -> c6: fr=3, fc=1, tr=2, tc=2
+    expect(body.from_row).toBe(3);
+    expect(body.from_col).toBe(1);
+    expect(body.to_row).toBe(2);
+    expect(body.to_col).toBe(2);
+  });
+
+  it('SAN with disambiguation (Nbd7)', async () => {
+    const input = document.getElementById("sanMoveInput");
+    input.value = "Nbd7";
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await flushPromises();
+    
+    expect(input.value).toBe('');
+    const moveReqs = global.fetch.mock.calls.filter(c => c[0] && c[0].includes('/api/move/'));
+    const body = JSON.parse(moveReqs[moveReqs.length - 1][1].body);
+    // b8 -> d7: fr=0, fc=1, tr=1, tc=3
+    expect(body.from_row).toBe(0);
+    expect(body.from_col).toBe(1);
+    expect(body.to_row).toBe(1);
+    expect(body.to_col).toBe(3);
+  });
+
+  it('SAN with check suffix (Qh5+)', async () => {
+    const input = document.getElementById("sanMoveInput");
+    input.value = "Qh5+";
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await flushPromises();
+    
+    expect(input.value).toBe('');
+    const moveReqs = global.fetch.mock.calls.filter(c => c[0] && c[0].includes('/api/move/'));
+    const body = JSON.parse(moveReqs[moveReqs.length - 1][1].body);
+    // d1 -> h5: fr=7, fc=3, tr=3, tc=7
+    expect(body.from_row).toBe(7);
+    expect(body.from_col).toBe(3);
+    expect(body.to_row).toBe(3);
+    expect(body.to_col).toBe(7);
+  });
+
+  it('SAN with promotion (e8=Q)', async () => {
+    const input = document.getElementById("sanMoveInput");
+    input.value = "e8=Q";
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await flushPromises();
+    
+    expect(input.value).toBe('');
+    const moveReqs = global.fetch.mock.calls.filter(c => c[0] && c[0].includes('/api/move/'));
+    const body = JSON.parse(moveReqs[moveReqs.length - 1][1].body);
+    // e7 -> e8: fr=1, fc=4, tr=0, tc=4
+    expect(body.from_row).toBe(1);
+    expect(body.from_col).toBe(4);
+    expect(body.to_row).toBe(0);
+    expect(body.to_col).toBe(4);
+    expect(body.promotion_piece).toBe('q');
+  });
+});
+

--- a/board.test.js
+++ b/board.test.js
@@ -556,16 +556,22 @@ describe("SAN Quick Move Input", () => {
     const flipBtn = document.getElementById("flipBtn");
     // Mock the click on flipBtn
     flipBtn.click = jest.fn();
-    
-    input.focus();
-    // Simulate global keydown listener which uses document.activeElement check
-    // Wait, the test environment doesn't perfectly simulate activeElement in all cases unless attached.
-    // Instead we can dispatch the event on document, but mock activeElement.
-    Object.defineProperty(document, 'activeElement', { value: input, writable: true });
-    
-    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'f' }));
-    
-    expect(flipBtn.click).not.toHaveBeenCalled();
+
+    // Save the original activeElement descriptor and restore it after the test
+    const originalDescriptor = Object.getOwnPropertyDescriptor(document, 'activeElement');
+    try {
+      Object.defineProperty(document, 'activeElement', { value: input, configurable: true, writable: true });
+      
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'f' }));
+      
+      expect(flipBtn.click).not.toHaveBeenCalled();
+    } finally {
+      if (originalDescriptor) {
+        Object.defineProperty(document, 'activeElement', originalDescriptor);
+      } else {
+        delete document.activeElement;
+      }
+    }
   });
 
   it('backend move rejection retains input and shows error', async () => {
@@ -656,6 +662,40 @@ describe("SAN Quick Move Input", () => {
     expect(body.to_row).toBe(0);
     expect(body.to_col).toBe(4);
     expect(body.promotion_piece).toBe('q');
+  });
+
+  it('fully-uppercase piece SAN (NF3) is normalized and executed', async () => {
+    const input = document.getElementById("sanMoveInput");
+    input.value = "NF3";
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await flushPromises();
+    
+    // Should normalize to Nf3 and succeed
+    expect(input.value).toBe('');
+    const moveReqs = global.fetch.mock.calls.filter(c => c[0] && c[0].includes('/api/move/'));
+    const body = JSON.parse(moveReqs[moveReqs.length - 1][1].body);
+    // g1 -> f3: fr=7, fc=6, tr=5, tc=5
+    expect(body.from_row).toBe(7);
+    expect(body.from_col).toBe(6);
+    expect(body.to_row).toBe(5);
+    expect(body.to_col).toBe(5);
+  });
+
+  it('fully-uppercase pawn SAN (E4) is normalized and executed', async () => {
+    const input = document.getElementById("sanMoveInput");
+    input.value = "E4";
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await flushPromises();
+    
+    // Should normalize to e4 and succeed
+    expect(input.value).toBe('');
+    const moveReqs = global.fetch.mock.calls.filter(c => c[0] && c[0].includes('/api/move/'));
+    const body = JSON.parse(moveReqs[moveReqs.length - 1][1].body);
+    // e2 -> e4: fr=6, fc=4, tr=4, tc=4
+    expect(body.from_row).toBe(6);
+    expect(body.from_col).toBe(4);
+    expect(body.to_row).toBe(4);
+    expect(body.to_col).toBe(4);
   });
 });
 

--- a/board.test.js
+++ b/board.test.js
@@ -208,6 +208,9 @@ global.Chess = class MockChess {
     if (moveStr === 'Bxc6+') return { from: 'b5', to: 'c6', promotion: undefined };
     if (moveStr === 'Nbd7') return { from: 'b8', to: 'd7', promotion: undefined };
     if (moveStr === 'Qh5+') return { from: 'd1', to: 'h5', promotion: undefined };
+    if (moveStr === 'b4') return { from: 'b2', to: 'b4', promotion: undefined };
+    if (moveStr === 'bxc5') return { from: 'b4', to: 'c5', promotion: undefined };
+    if (moveStr === 'exd5') return { from: 'e4', to: 'd5', promotion: undefined };
     
     return { from: 'a1', to: 'a2' };
   }
@@ -673,6 +676,7 @@ describe("SAN Quick Move Input", () => {
     // Should normalize to Nf3 and succeed
     expect(input.value).toBe('');
     const moveReqs = global.fetch.mock.calls.filter(c => c[0] && c[0].includes('/api/move/'));
+    expect(moveReqs.length).toBe(1);
     const body = JSON.parse(moveReqs[moveReqs.length - 1][1].body);
     // g1 -> f3: fr=7, fc=6, tr=5, tc=5
     expect(body.from_row).toBe(7);
@@ -690,12 +694,64 @@ describe("SAN Quick Move Input", () => {
     // Should normalize to e4 and succeed
     expect(input.value).toBe('');
     const moveReqs = global.fetch.mock.calls.filter(c => c[0] && c[0].includes('/api/move/'));
+    expect(moveReqs.length).toBe(1);
     const body = JSON.parse(moveReqs[moveReqs.length - 1][1].body);
     // e2 -> e4: fr=6, fc=4, tr=4, tc=4
     expect(body.from_row).toBe(6);
     expect(body.from_col).toBe(4);
     expect(body.to_row).toBe(4);
     expect(body.to_col).toBe(4);
+  });
+
+  it('b-file pawn move (b4) is not treated as Bishop move', async () => {
+    const input = document.getElementById("sanMoveInput");
+    input.value = "b4";
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await flushPromises();
+
+    expect(input.value).toBe('');
+    const moveReqs = global.fetch.mock.calls.filter(c => c[0] && c[0].includes('/api/move/'));
+    expect(moveReqs.length).toBe(1);
+    const body = JSON.parse(moveReqs[moveReqs.length - 1][1].body);
+    // b2 -> b4: fr=6, fc=1, tr=4, tc=1
+    expect(body.from_row).toBe(6);
+    expect(body.from_col).toBe(1);
+    expect(body.to_row).toBe(4);
+    expect(body.to_col).toBe(1);
+  });
+
+  it('b-file pawn capture (bxc5) is not treated as Bishop capture', async () => {
+    const input = document.getElementById("sanMoveInput");
+    input.value = "bxc5";
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await flushPromises();
+
+    expect(input.value).toBe('');
+    const moveReqs = global.fetch.mock.calls.filter(c => c[0] && c[0].includes('/api/move/'));
+    expect(moveReqs.length).toBe(1);
+    const body = JSON.parse(moveReqs[moveReqs.length - 1][1].body);
+    // b4 -> c5: fr=4, fc=1, tr=3, tc=2
+    expect(body.from_row).toBe(4);
+    expect(body.from_col).toBe(1);
+    expect(body.to_row).toBe(3);
+    expect(body.to_col).toBe(2);
+  });
+
+  it('fully-uppercase pawn capture (EXD5) is normalized to exd5', async () => {
+    const input = document.getElementById("sanMoveInput");
+    input.value = "EXD5";
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await flushPromises();
+
+    expect(input.value).toBe('');
+    const moveReqs = global.fetch.mock.calls.filter(c => c[0] && c[0].includes('/api/move/'));
+    expect(moveReqs.length).toBe(1);
+    const body = JSON.parse(moveReqs[moveReqs.length - 1][1].body);
+    // e4 -> d5: fr=4, fc=4, tr=3, tc=3
+    expect(body.from_row).toBe(4);
+    expect(body.from_col).toBe(4);
+    expect(body.to_row).toBe(3);
+    expect(body.to_col).toBe(3);
   });
 });
 

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1850,6 +1850,7 @@
                 if (gameMode === 'ai' && turn !== playerColor && !gameOver) {
                     requestAIMove();
                 }
+                return { success: true };
             } else {
                 showStatus(data.message, true);
                 flashBoard();
@@ -1858,9 +1859,11 @@
                     premoveQueue = [];
                     refreshPremoveHighlight();
                 }
+                return { success: false, message: data.message };
             }
         } catch (e) {
             await handleReconnect();
+            return { success: false, message: 'Connection lost' };
         }
     }
 
@@ -4150,6 +4153,120 @@
             await handleReconnect();
         }
     });
+    // --- SAN Quick Move Input ---
+    const sanMoveInput = document.getElementById('sanMoveInput');
+    const sanMoveBtn = document.getElementById('sanMoveBtn');
+    const sanMoveError = document.getElementById('sanMoveError');
+
+    async function handleSanMove() {
+        if (!sanMoveInput) return;
+        let san = sanMoveInput.value.trim();
+        if (!san) return;
+        
+        if (sanMoveError) sanMoveError.style.display = 'none';
+
+        if (paused || gameOver) {
+            if (sanMoveError) {
+                sanMoveError.textContent = 'Game is not active';
+                sanMoveError.style.display = 'block';
+            }
+            flashBoard();
+            return;
+        }
+
+        if (gameMode === 'ai' && turn !== playerColor) {
+            if (sanMoveError) {
+                sanMoveError.textContent = 'Not your turn';
+                sanMoveError.style.display = 'block';
+            }
+            flashBoard();
+            return;
+        }
+
+        if (sanMoveBtn) sanMoveBtn.disabled = true;
+
+        try {
+            const data = await get('/api/state/');
+            if (!data.fen) throw new Error("No FEN");
+            
+            if (!window.Chess) throw new Error("Chess engine not loaded");
+            const chess = new window.Chess(data.fen);
+            
+            // Minimal normalization
+            if (/^[0oO]-[0oO]-[0oO]$/i.test(san)) {
+                san = 'O-O-O';
+            } else if (/^[0oO]-[0oO]$/i.test(san)) {
+                san = 'O-O';
+            } else if (/^[nbrqk]/i.test(san)) {
+                san = san.charAt(0).toUpperCase() + san.slice(1);
+            } else if (/^[a-h]/i.test(san)) {
+                san = san.charAt(0).toLowerCase() + san.slice(1);
+            }
+            
+            const moveObj = chess.move(san);
+            if (!moveObj) {
+                if (sanMoveError) {
+                    sanMoveError.textContent = 'Invalid or illegal move notation';
+                    sanMoveError.style.display = 'block';
+                }
+                flashBoard();
+                if (sanMoveBtn) sanMoveBtn.disabled = false;
+                return;
+            }
+            
+            const files = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+            const ranks = ['8', '7', '6', '5', '4', '3', '2', '1'];
+            
+            const fc = files.indexOf(moveObj.from[0]);
+            const fr = ranks.indexOf(moveObj.from[1]);
+            const tc = files.indexOf(moveObj.to[0]);
+            const tr = ranks.indexOf(moveObj.to[1]);
+            const promo = moveObj.promotion || null;
+            
+            const result = await executeMove(fr, fc, tr, tc, promo);
+            if (result && result.success) {
+                sanMoveInput.value = '';
+                sanMoveInput.blur();
+            } else {
+                if (sanMoveError) {
+                    sanMoveError.textContent = (result && result.message) ? result.message : 'Move rejected';
+                    sanMoveError.style.display = 'block';
+                }
+                flashBoard();
+            }
+        } catch (err) {
+            console.error('SAN Move Error:', err);
+            if (sanMoveError) {
+                sanMoveError.textContent = 'Error processing move';
+                sanMoveError.style.display = 'block';
+            }
+        } finally {
+            if (sanMoveBtn) sanMoveBtn.disabled = false;
+        }
+    }
+
+    if (sanMoveInput) {
+        sanMoveInput.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') {
+                e.preventDefault();
+                sanMoveInput.value = '';
+                sanMoveInput.blur();
+                if (sanMoveError) sanMoveError.style.display = 'none';
+            } else if (e.key === 'Enter') {
+                e.preventDefault();
+                handleSanMove();
+            }
+        });
+        sanMoveInput.addEventListener('input', () => {
+            if (sanMoveError) sanMoveError.style.display = 'none';
+        });
+    }
+
+    if (sanMoveBtn) {
+        sanMoveBtn.addEventListener('click', handleSanMove);
+    }
+    // ----------------------------
+
     const manualMoveInput = document.getElementById('manualMoveInput');
     const manualMoveError = document.getElementById('manualMoveError');
 

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -4193,23 +4193,33 @@
             const chess = new window.Chess(data.fen);
             
             // Minimal normalization: fix casing so chess.js can parse user input
-            // without corrupting check/checkmate suffixes (+/#) or promotion (=Q)
+            // Rules:
+            //   - Castling variants: map to standard O-O / O-O-O
+            //   - Uppercase [NBRQK]: definite piece move — uppercase first char, lowercase body, preserve suffix
+            //   - Lowercase [nrqk]: definite piece move (n,r,q,k are not valid pawn files) — same as above
+            //   - Lowercase 'b' and all [a-h]/[A-H]: pawn move — lowercase entire body, preserve suffix
+            // Promotion suffix (=Q/=R etc) is always uppercased; check/checkmate (+/#) is preserved as-is.
             if (/^[0oO]-[0oO]-[0oO]$/i.test(san)) {
                 san = 'O-O-O';
             } else if (/^[0oO]-[0oO]$/i.test(san)) {
                 san = 'O-O';
-            } else if (/^[nbrqk]/i.test(san)) {
-                // Piece moves: uppercase first letter, lowercase body, preserve =Q/=R/=B/=N suffix and +/#
+            } else {
+                // Strip trailing check/checkmate and promotion to preserve them exactly
                 const promoMatch = san.match(/=([qrbnQRBN])([+#]?)$/);
-                const suffix = promoMatch ? `=${promoMatch[1].toUpperCase()}${promoMatch[2]}` : san.match(/[+#]$/) ? san.slice(-1) : '';
-                const body = san.replace(/[+#]$/, '').replace(/=([qrbnQRBN])$/, '');
-                san = body.charAt(0).toUpperCase() + body.slice(1).toLowerCase() + suffix;
-            } else if (/^[a-h]/i.test(san)) {
-                // Pawn moves: lowercase file letter, preserve promotion suffix and +/#
-                const promoMatch = san.match(/=([qrbnQRBN])([+#]?)$/);
-                const suffix = promoMatch ? `=${promoMatch[1].toUpperCase()}${promoMatch[2]}` : san.match(/[+#]$/) ? san.slice(-1) : '';
-                const body = san.replace(/[+#]$/, '').replace(/=([qrbnQRBN])$/, '');
-                san = body.charAt(0).toLowerCase() + body.slice(1) + suffix;
+                const suffix = promoMatch
+                    ? `=${promoMatch[1].toUpperCase()}${promoMatch[2]}`
+                    : san.match(/[+#]$/) ? san.slice(-1) : '';
+                const body = promoMatch
+                    ? san.slice(0, san.lastIndexOf('='))
+                    : suffix ? san.slice(0, -1) : san;
+
+                if (/^[NBRQK]/.test(san) || /^[nrqk]/.test(san)) {
+                    // Piece move: uppercase first char, lowercase rest of body
+                    san = body.charAt(0).toUpperCase() + body.slice(1).toLowerCase() + suffix;
+                } else if (/^[a-h]/i.test(san)) {
+                    // Pawn move (files a-h, including lowercase 'b'): fully lowercase body
+                    san = body.toLowerCase() + suffix;
+                }
             }
             
             const moveObj = chess.move(san);

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -4192,15 +4192,24 @@
             if (!window.Chess) throw new Error("Chess engine not loaded");
             const chess = new window.Chess(data.fen);
             
-            // Minimal normalization
+            // Minimal normalization: fix casing so chess.js can parse user input
+            // without corrupting check/checkmate suffixes (+/#) or promotion (=Q)
             if (/^[0oO]-[0oO]-[0oO]$/i.test(san)) {
                 san = 'O-O-O';
             } else if (/^[0oO]-[0oO]$/i.test(san)) {
                 san = 'O-O';
             } else if (/^[nbrqk]/i.test(san)) {
-                san = san.charAt(0).toUpperCase() + san.slice(1);
+                // Piece moves: uppercase first letter, lowercase body, preserve =Q/=R/=B/=N suffix and +/#
+                const promoMatch = san.match(/=([qrbnQRBN])([+#]?)$/);
+                const suffix = promoMatch ? `=${promoMatch[1].toUpperCase()}${promoMatch[2]}` : san.match(/[+#]$/) ? san.slice(-1) : '';
+                const body = san.replace(/[+#]$/, '').replace(/=([qrbnQRBN])$/, '');
+                san = body.charAt(0).toUpperCase() + body.slice(1).toLowerCase() + suffix;
             } else if (/^[a-h]/i.test(san)) {
-                san = san.charAt(0).toLowerCase() + san.slice(1);
+                // Pawn moves: lowercase file letter, preserve promotion suffix and +/#
+                const promoMatch = san.match(/=([qrbnQRBN])([+#]?)$/);
+                const suffix = promoMatch ? `=${promoMatch[1].toUpperCase()}${promoMatch[2]}` : san.match(/[+#]$/) ? san.slice(-1) : '';
+                const body = san.replace(/[+#]$/, '').replace(/=([qrbnQRBN])$/, '');
+                san = body.charAt(0).toLowerCase() + body.slice(1) + suffix;
             }
             
             const moveObj = chess.move(san);

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -511,6 +511,12 @@
                    </div>
                </div>
                 
+                <!-- Quick Move Input (SAN) -->
+                <div class="san-input-container" style="margin-top: 15px; display: flex; gap: 8px;">
+                    <input type="text" id="sanMoveInput" placeholder="Move (e.g. e4, Nf3, O-O)" aria-label="Enter move notation" style="flex: 1; padding: 10px; border-radius: 5px; border: 1px solid #444; background: #1a1a2e; color: #fff; font-size: 0.9rem;" autocomplete="off">
+                    <button type="button" id="sanMoveBtn" class="btn btn-gold" style="padding: 10px 15px;">Move</button>
+                </div>
+                <div id="sanMoveError" role="alert" style="color: #ff6b6b; font-size: 0.8rem; display: none; margin-top: 5px; padding: 5px; background: rgba(255, 107, 107, 0.1); border-radius: 4px; border: 1px solid rgba(255, 107, 107, 0.3);">Invalid notation</div>
             </div>
         </div>
         

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -46,6 +46,34 @@
             color: #94a3b8;
             vertical-align: middle;
         }
+        /* ── SAN Quick Move Input styles ── */
+        .san-input-container {
+            margin-top: 15px;
+            display: flex;
+            gap: 8px;
+        }
+        .san-move-input {
+            flex: 1;
+            padding: 10px;
+            border-radius: 5px;
+            border: 1px solid #444;
+            background: #1a1a2e;
+            color: #fff;
+            font-size: 0.9rem;
+        }
+        .san-move-btn {
+            padding: 10px 15px;
+        }
+        .san-move-error {
+            color: #ff6b6b;
+            font-size: 0.8rem;
+            display: none;
+            margin-top: 5px;
+            padding: 5px;
+            background: rgba(255, 107, 107, 0.1);
+            border-radius: 4px;
+            border: 1px solid rgba(255, 107, 107, 0.3);
+        }
     </style>
 
     <!-- Vercel Web Analytics -->
@@ -512,11 +540,11 @@
                </div>
                 
                 <!-- Quick Move Input (SAN) -->
-                <div class="san-input-container" style="margin-top: 15px; display: flex; gap: 8px;">
-                    <input type="text" id="sanMoveInput" placeholder="Move (e.g. e4, Nf3, O-O)" aria-label="Enter move notation" style="flex: 1; padding: 10px; border-radius: 5px; border: 1px solid #444; background: #1a1a2e; color: #fff; font-size: 0.9rem;" autocomplete="off">
-                    <button type="button" id="sanMoveBtn" class="btn btn-gold" style="padding: 10px 15px;">Move</button>
+                <div class="san-input-container">
+                    <input type="text" id="sanMoveInput" class="san-move-input" placeholder="Move (e.g. e4, Nf3, O-O)" aria-label="Enter move notation" autocomplete="off">
+                    <button type="button" id="sanMoveBtn" class="btn btn-gold san-move-btn">Move</button>
                 </div>
-                <div id="sanMoveError" role="alert" style="color: #ff6b6b; font-size: 0.8rem; display: none; margin-top: 5px; padding: 5px; background: rgba(255, 107, 107, 0.1); border-radius: 4px; border: 1px solid rgba(255, 107, 107, 0.3);">Invalid notation</div>
+                <div id="sanMoveError" class="san-move-error" role="alert">Invalid notation</div>
             </div>
         </div>
         


### PR DESCRIPTION
## Description

Adds a Quick Move Input feature that allows players to enter moves using Standard Algebraic Notation (SAN), such as `e4`, `Nf3`, `Bxc6+`, `Nbd7`, `O-O`, and `e8=Q`.

The implementation:

* Adds an accessible SAN move input and Move button below the board controls.
* Supports move submission with both the Enter key and Move button.
* Uses the authoritative game FEN from the existing state endpoint and the existing chess.js integration to parse and validate SAN moves.
* Reuses the existing `executeMove` flow so typed moves follow the same backend validation and game update process as existing move methods.
* Supports castling, captures, disambiguation, promotions, and check notation.
* Preserves the entered move when validation or backend execution fails and displays an accessible error message.
* Clears and blurs the input only after successful move execution.
* Supports Escape to clear and leave the input.
* Prevents existing board keyboard shortcuts from triggering while the move input is focused.
* Works with the existing PvP and AI turn restrictions.

## Type of Change

* [ ] Bug fix (non-breaking change that fixes an issue)
* [x] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

## Related Issue

Fixes #287

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] I have commented my code where necessary
* [ ] I have updated the documentation if needed
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix/feature works
* [x] New and existing tests pass locally

## Screenshots (if applicable)

UI screenshot can be added to demonstrate the SAN input field, Move button, and validation error state.

## Additional Notes

Added test coverage for:

* Pawn moves using Enter submission
* Piece moves using the Move button
* Castling
* Invalid and illegal notation handling
* Backend move rejection and input retention
* Capture and check notation
* Disambiguated SAN moves
* Check suffix notation
* Promotion notation
* Escape key behavior
* Keyboard shortcut isolation while the SAN input is focused

### Test Results

`npm test`

* Test Suites: 1 passed, 1 total
* Tests: 39 passed, 39 total
* Snapshots: 0 total
