### PR TITLE
Fix forum tab hash restoration and add hash coverage tests

### DIFF
--- a/forum.test.js
+++ b/forum.test.js
@@ -1,0 +1,51 @@
+const {
+    initializeForumTabs,
+} = require("./game/static/game/js/forum");
+
+function createForumDOM() {
+    document.body.innerHTML = `
+        <button class="forum-tab active" data-tab="all">All</button>
+        <button class="forum-tab" data-tab="your">Your</button>
+        <button class="forum-tab" data-tab="bookmarked">Bookmarked</button>
+
+        <div id="tab-all" class="forum-tab-panel active"></div>
+        <div id="tab-your" class="forum-tab-panel"></div>
+        <div id="tab-bookmarked" class="forum-tab-panel"></div>
+    `;
+}
+
+beforeEach(() => {
+    createForumDOM();
+});
+
+test("restores the all tab from the URL hash", () => {
+    window.location.hash = "#tab-all";
+
+    initializeForumTabs();
+
+    expect(
+        document.querySelector('[data-tab="all"]').classList.contains("active")
+    ).toBe(true);
+});
+
+test("restores the your tab from the URL hash", () => {
+    window.location.hash = "#tab-your";
+
+    initializeForumTabs();
+
+    expect(
+        document.querySelector('[data-tab="your"]').classList.contains("active")
+    ).toBe(true);
+});
+
+test("restores the bookmarked tab from the URL hash", () => {
+    window.location.hash = "#tab-bookmarked";
+
+    initializeForumTabs();
+
+    expect(
+        document
+            .querySelector('[data-tab="bookmarked"]')
+            .classList.contains("active")
+    ).toBe(true);
+});

--- a/game/static/game/js/forum.js
+++ b/game/static/game/js/forum.js
@@ -8,8 +8,8 @@ function activateTab(tabId) {
         tab.classList.remove("active");
     });
 
-    document.querySelectorAll(".forum-tab-panel").forEach((panel) => {
-        panel.classList.remove("active");
+    document.querySelectorAll(".forum-tab-panel").forEach((tabPanel) => {
+        tabPanel.classList.remove("active");
     });
 
     tabBtn.classList.add("active");
@@ -37,6 +37,7 @@ function initializeForumTabs() {
 }
 
 window.addEventListener("DOMContentLoaded", initializeForumTabs);
+window.addEventListener("hashchange", restoreTabFromHash);
 
 if (typeof module !== "undefined") {
     module.exports = {

--- a/game/static/game/js/forum.js
+++ b/game/static/game/js/forum.js
@@ -1,0 +1,47 @@
+function activateTab(tabId) {
+    const tabBtn = document.querySelector(`.forum-tab[data-tab="${tabId}"]`);
+    const panel = document.getElementById(`tab-${tabId}`);
+
+    if (!tabBtn || !panel) return;
+
+    document.querySelectorAll(".forum-tab").forEach((tab) => {
+        tab.classList.remove("active");
+    });
+
+    document.querySelectorAll(".forum-tab-panel").forEach((panel) => {
+        panel.classList.remove("active");
+    });
+
+    tabBtn.classList.add("active");
+    panel.classList.add("active");
+}
+
+function restoreTabFromHash() {
+    const hashTab = window.location.hash.replace(/^#tab-/, "");
+
+    if (hashTab) {
+        activateTab(hashTab);
+    }
+}
+
+function initializeForumTabs() {
+    restoreTabFromHash();
+
+    document.querySelectorAll(".forum-tab").forEach((tab) => {
+        tab.addEventListener("click", () => {
+            const target = tab.dataset.tab;
+            activateTab(target);
+            window.location.hash = `tab-${target}`;
+        });
+    });
+}
+
+window.addEventListener("DOMContentLoaded", initializeForumTabs);
+
+if (typeof module !== "undefined") {
+    module.exports = {
+        activateTab,
+        restoreTabFromHash,
+        initializeForumTabs,
+    };
+}

--- a/game/templates/game/forum_list.html
+++ b/game/templates/game/forum_list.html
@@ -150,38 +150,17 @@
         <a href="{% url 'forum_new' %}" class="forum-fab-new">+ New Discussion</a>
         {% endif %}
     </div>
+    <script src="{% static 'game/js/forum.js' %}"></script>
     <script>
-        function activateTab(tabId) {
-            const tabBtn = document.querySelector(`.forum-tab[data-tab="${tabId}"]`);
-            const panel = document.getElementById(`tab-${tabId}`);
-            if (!tabBtn || !panel) return;
-            document.querySelectorAll(".forum-tab").forEach((t) => t.classList.remove("active"));
-            document.querySelectorAll(".forum-tab-panel").forEach((p) => p.classList.remove("active"));
-            tabBtn.classList.add("active");
-            panel.classList.add("active");
-        }
-
-        // restore tab from hash on load
-        const hashTab = window.location.hash.replace("`#tab-`", "");
-        if (hashTab) activateTab(hashTab);
-
-        document.querySelectorAll(".forum-tab").forEach((tab) => {
-            tab.addEventListener("click", () => {
-                const target = tab.dataset.tab;
-                activateTab(target);
-                window.location.hash = `tab-${target}`;
-            });
-        });
-
         // stamp next value with current path+hash before bookmark submit
-        document.querySelectorAll(".forum-bookmark-form").forEach((form) => {
-            form.addEventListener("submit", () => {
-                const nextInput = form.querySelector('input[name="next"]');
-                if (nextInput) {
-                    nextInput.value = window.location.pathname + window.location.hash;
-                }
-            });
+    document.querySelectorAll(".forum-bookmark-form").forEach((form) => {
+        form.addEventListener("submit", () => {
+            const nextInput = form.querySelector('input[name="next"]');
+            if (nextInput) {
+                nextInput.value = window.location.pathname + window.location.hash;
+            }
         });
+    });
     </script>
     <script src="{% static 'game/js/dropdown.js' %}"></script>
 </body>


### PR DESCRIPTION
## Description

This PR fixes the forum tab hash restoration issue by correctly parsing the URL hash when the page loads, ensuring the appropriate tab is restored after a refresh or when navigating directly to a hashed URL.

As part of this fix, the forum tab management logic has been refactored into a dedicated `forum.js` file to improve maintainability and enable unit testing. Jest tests have also been added to cover all supported forum tab hashes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #2095

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary (not applicable)
- [ ] I have updated the documentation if needed (not applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

Not applicable.

## Additional Notes

### Changes made
- Fixed forum tab restoration by correctly removing the `#tab-` prefix from the URL hash.
- Moved the forum tab handling logic into `game/static/game/js/forum.js`.
- Added Jest tests covering:
  - `#tab-all`
  - `#tab-your`
  - `#tab-bookmarked`

### Verification
- Verified that the correct tab is restored after refreshing the page with each supported tab hash.
- All Jest tests pass successfully (`30/30`).