### PR TITLE
feat: add copy PGN clipboard action

### DIFF
--- a/board.test.js
+++ b/board.test.js
@@ -28,6 +28,7 @@ document.body.innerHTML = `
   <div id="flipControls"></div>
   <button id="flipBtn"></button>
   <button id="copyFenBtn"></button>
+  <button id="copyPgnClipboardBtn"></button>
   <div id="welcomeOverlay"></div>
   <button id="welcomeResumeBtn"></button>
   <button id="welcomePvPBtn"></button>
@@ -137,6 +138,7 @@ global.fetch = jest.fn((url, options) => {
     json: () => Promise.resolve({ 
       valid: true,
       fen: 'startpos_fen',
+      pgn: mockPgn,
       board: boardData,
       current_turn: 'white',
       player_color: 'white',
@@ -150,6 +152,14 @@ global.fetch = jest.fn((url, options) => {
   });
 });
 global.SOUND_BASE_URL = '/static/game/sounds/';
+Object.assign(navigator, {
+  clipboard: {
+    writeText: jest.fn(() => Promise.resolve())
+  }
+});
+window.showToast = jest.fn();
+
+let mockPgn = '[Event "Checkora"]\n\n1. e4 e5';
 
 // Mock Worker for Jest
 global.Worker = class MockWorker {
@@ -352,6 +362,33 @@ describe("Coordinates visibility toggle", () => {
     checkbox.dispatchEvent(new Event("change"));
     expect(board.classList.contains("hide-coordinates")).toBe(false);
     expect(localStorage.getItem("showCoordinates")).toBe("true");
+  });
+});
+
+describe("Copy PGN clipboard button", () => {
+  beforeEach(() => {
+    mockPgn = '[Event "Checkora"]\n\n1. e4 e5';
+    navigator.clipboard.writeText.mockClear();
+    window.showToast.mockClear();
+    global.fetch.mockClear();
+  });
+
+  test("copies the current PGN to the clipboard", async () => {
+    document.getElementById("copyPgnClipboardBtn").click();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(mockPgn);
+    expect(window.showToast).toHaveBeenCalledWith("PGN copied to clipboard!", "success");
+  });
+
+  test("does not copy when no PGN is available", async () => {
+    mockPgn = "";
+
+    document.getElementById("copyPgnClipboardBtn").click();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+    expect(window.showToast).toHaveBeenCalledWith("No moves available to export.", "info");
   });
 });
 
@@ -754,4 +791,3 @@ describe("SAN Quick Move Input", () => {
     expect(body.to_col).toBe(3);
   });
 });
-

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -612,6 +612,7 @@
     const flipControls = document.getElementById('flipControls');
     const copyFenBtn = document.getElementById('copyFenBtn');
     const copyPgnBtn = document.getElementById('copyPgnBtn');
+    const copyPgnClipboardBtn = document.getElementById('copyPgnClipboardBtn');
     const muteBtn = document.getElementById('muteBtn');
 
     const welcomeOverlay = document.getElementById('welcomeOverlay');
@@ -3883,6 +3884,30 @@
             pgnDownloadTimeout = setTimeout(() => {
                 copyPgnBtn.textContent = 'Export as PGN';
             }, 2000);
+        }
+    };
+
+    if (copyPgnClipboardBtn) copyPgnClipboardBtn.onclick = async () => {
+        const notify = (message, type) => {
+            if (typeof window.showToast === 'function') {
+                window.showToast(message, type);
+            } else {
+                showStatus(message, type === 'error');
+            }
+        };
+
+        try {
+            const data = await get('/api/state/');
+
+            if (!data.pgn) {
+                notify('No moves available to export.', 'info');
+                return;
+            }
+
+            await navigator.clipboard.writeText(data.pgn);
+            notify('PGN copied to clipboard!', 'success');
+        } catch (_) {
+            notify('Failed to copy PGN', 'error');
         }
     };
 

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -634,7 +634,10 @@
         <!-- Right Panel: Move History -->
         <div class="panel move-history-panel">
             <div class="card" style="height: 100%;">
-                <div class="card-title">Move History</div>
+                <div class="card-title" style="display:flex;align-items:center;justify-content:space-between;gap:12px;">
+                    <span>Move History</span>
+                    <button type="button" class="btn btn-gold" id="copyPgnClipboardBtn" style="width:auto;padding:6px 12px;font-size:0.85rem;">Copy PGN</button>
+                </div>
                 <div class="moves-list" id="movesList">
                     <span class="placeholder">No moves yet</span>
                 </div>


### PR DESCRIPTION
## Summary
- add a Copy PGN action beside the move history panel
- copy the current PGN from `/api/state/` to the clipboard
- show success, empty-state, and failure feedback without changing the existing PGN download flow
- add Jest coverage for copying PGN and the no-moves path

Closes #2204

## Validation
- npm test -- --runInBand board.test.js
- git diff --check
