### PR TITLE
fix: render black lesson pieces

### DIFF
--- a/game/static/game/js/lesson_demo.js
+++ b/game/static/game/js/lesson_demo.js
@@ -26,7 +26,13 @@ document.addEventListener(
             B: "♗",
             R: "♖",
             Q: "♕",
-            K: "♔"
+            K: "♔",
+            p: "♟",
+            n: "♞",
+            b: "♝",
+            r: "♜",
+            q: "♛",
+            k: "♚"
         };
 
         function renderExample() {

--- a/game/static/game/js/lesson_practice.js
+++ b/game/static/game/js/lesson_practice.js
@@ -285,8 +285,12 @@ document.addEventListener(
             R: "♖",
             Q: "♕",
             K: "♔",
-
-            
+            p: "♟",
+            n: "♞",
+            b: "♝",
+            r: "♜",
+            q: "♛",
+            k: "♚"
         };
 
         board.innerHTML = "";


### PR DESCRIPTION
## Summary
- add lowercase black chess glyphs to the lesson practice piece map
- add the same lowercase glyphs to the lesson demo renderer
- keep the fix scoped to rendering so existing lesson move logic is unchanged

Closes #2124

## Validation
- node --check game/static/game/js/lesson_practice.js
- node --check game/static/game/js/lesson_demo.js
- git diff --check
