### PR TITLE
fix: preserve puzzle mode UI state

### DIFF
--- a/board.test.js
+++ b/board.test.js
@@ -373,6 +373,22 @@ describe("Board UI Interactions", () => {
     expect(sq.classList.contains("custom-highlight")).toBe(false);
   });
 
+  it('keeps puzzle clock and streak visibility when starting puzzle mode', async () => {
+    const whiteClock = document.getElementById("whiteClock");
+    const blackClock = document.getElementById("blackClock");
+    const streakCounter = document.getElementById("streak-counter");
+
+    whiteClock.style.display = "none";
+    blackClock.style.display = "none";
+    streakCounter.style.display = "block";
+
+    await startNewGame('pvp', 'white', 'medium', 'startpos', 10, null, true);
+
+    expect(whiteClock.style.display).toBe("none");
+    expect(blackClock.style.display).toBe("none");
+    expect(streakCounter.style.display).toBe("block");
+  });
+
   it('showPromoModal makes overlay active', () => {
     showPromoModal('white');
     const overlay = document.getElementById("promoOverlay");
@@ -754,4 +770,3 @@ describe("SAN Quick Move Input", () => {
     expect(body.to_col).toBe(3);
   });
 });
-

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -3358,15 +3358,16 @@
         const tbody = document.getElementById('postGameAnalysisTableBody');
         if (tbody) tbody.innerHTML = '';
         replayMode = false;
-        // Show clocks for normal games
-        document.getElementById("whiteClock").style.display = "";
-        document.getElementById("blackClock").style.display = "";
+        if (!isPuzzle) {
+            document.getElementById("whiteClock").style.display = "";
+            document.getElementById("blackClock").style.display = "";
 
-        const streakCounter =
-            document.getElementById("streak-counter");
+            const streakCounter =
+                document.getElementById("streak-counter");
 
-        if (streakCounter) {
-            streakCounter.style.display = "none";
+            if (streakCounter) {
+                streakCounter.style.display = "none";
+            }
         }
 
         replayMode = false;


### PR DESCRIPTION
## Summary
- keep clock and streak visibility untouched when `startNewGame()` runs in puzzle mode
- preserve normal game behavior by only showing clocks and hiding streaks outside puzzle mode
- add a focused Jest regression test for the puzzle UI state

Closes #2170

## Validation
- npm test -- --runInBand board.test.js
- git diff --check
