### PR TITLE
fix: use deselect() in Escape key handler to reset piece selection state

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1510,8 +1510,7 @@
                 return;
             case 'Escape':
                 e.preventDefault();
-                document.querySelectorAll('.square.selected')
-                    .forEach(s => s.classList.remove('selected'));
+                deselect();
                 return;
             default:
                 return;


### PR DESCRIPTION
## Description

The Escape key handler in `handleSquareKeydown()` only removed the `.selected` CSS class from squares but did **not** reset the internal `selected` variable or clear the `hints` array. This caused the board to visually deselect the piece while the game logic still considered it selected, leading to inconsistent behavior on subsequent clicks.

**Before (broken):**
```javascript
case 'Escape':
    e.preventDefault();
    document.querySelectorAll('.square.selected')
        .forEach(s => s.classList.remove('selected'));
    return;
```

**After (fixed):**
```javascript
case 'Escape':
    e.preventDefault();
    deselect();
    return;
```

The existing `deselect()` function already handles all three steps correctly: `selected = null`, `hints = []`, and `refreshHighlights()`.

## Related Issue

Fixes #2241
