### PR TITLE
feat: add dyslexia-friendly font toggle

### DIFF
--- a/board.test.js
+++ b/board.test.js
@@ -27,6 +27,7 @@ document.body.innerHTML = `
   <button id="autoFlipBtn"></button>
   <div id="flipControls"></div>
   <button id="flipBtn"></button>
+  <button id="dyslexiaFontBtn"></button>
   <button id="copyFenBtn"></button>
   <div id="welcomeOverlay"></div>
   <button id="welcomeResumeBtn"></button>
@@ -352,6 +353,28 @@ describe("Coordinates visibility toggle", () => {
     checkbox.dispatchEvent(new Event("change"));
     expect(board.classList.contains("hide-coordinates")).toBe(false);
     expect(localStorage.getItem("showCoordinates")).toBe("true");
+  });
+});
+
+describe("Dyslexia-friendly font toggle", () => {
+  test("toggles body class, button state, and persisted preference", () => {
+    const button = document.getElementById("dyslexiaFontBtn");
+
+    expect(document.body.classList.contains("font-dyslexic")).toBe(false);
+    expect(button.textContent).toBe("Dyslexia-Friendly Font: OFF");
+    expect(button.getAttribute("aria-pressed")).toBe("false");
+
+    button.click();
+    expect(document.body.classList.contains("font-dyslexic")).toBe(true);
+    expect(button.textContent).toBe("Dyslexia-Friendly Font: ON");
+    expect(button.getAttribute("aria-pressed")).toBe("true");
+    expect(localStorage.getItem("dyslexiaFontEnabled")).toBe("true");
+
+    button.click();
+    expect(document.body.classList.contains("font-dyslexic")).toBe(false);
+    expect(button.textContent).toBe("Dyslexia-Friendly Font: OFF");
+    expect(button.getAttribute("aria-pressed")).toBe("false");
+    expect(localStorage.getItem("dyslexiaFontEnabled")).toBe("false");
   });
 });
 
@@ -754,4 +777,3 @@ describe("SAN Quick Move Input", () => {
     expect(body.to_col).toBe(3);
   });
 });
-

--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -53,6 +53,11 @@ body {
     max-width: 100vw;
 }
 
+body.font-dyslexic {
+    font-family: 'OpenDyslexic', 'Comic Sans MS', 'Segoe UI', system-ui, -apple-system, sans-serif;
+    letter-spacing: 0.02em;
+}
+
 /* ============================================================
    Header
    ============================================================ */
@@ -617,6 +622,12 @@ body {
     font-size: clamp(0.6rem, 1.2vw, 0.75rem);
     color: #5a5a7a;
     font-weight: 600;
+}
+
+body.font-dyslexic .ranks span,
+body.font-dyslexic .files span,
+body.font-dyslexic .square {
+    font-family: inherit;
 }
 
 .files {

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -613,6 +613,7 @@
     const copyFenBtn = document.getElementById('copyFenBtn');
     const copyPgnBtn = document.getElementById('copyPgnBtn');
     const muteBtn = document.getElementById('muteBtn');
+    const dyslexiaFontBtn = document.getElementById('dyslexiaFontBtn');
 
     const welcomeOverlay = document.getElementById('welcomeOverlay');
     const welcomeResumeBtn = document.getElementById('welcomeResumeBtn');
@@ -684,6 +685,32 @@
         if (a11yAnnouncer) {
             a11yAnnouncer.textContent = '';
             setTimeout(() => { a11yAnnouncer.textContent = msg; }, 50);
+        }
+    }
+
+    function setDyslexiaFont(enabled) {
+        document.body.classList.toggle('font-dyslexic', enabled);
+        if (dyslexiaFontBtn) {
+            dyslexiaFontBtn.textContent = `Dyslexia-Friendly Font: ${enabled ? 'ON' : 'OFF'}`;
+            dyslexiaFontBtn.setAttribute('aria-pressed', String(enabled));
+        }
+        try {
+            localStorage.setItem('dyslexiaFontEnabled', String(enabled));
+        } catch (error) {
+            // localStorage can be unavailable in private browsing; the visual toggle still works.
+        }
+    }
+
+    function initDyslexiaFontToggle() {
+        let enabled = false;
+        try {
+            enabled = localStorage.getItem('dyslexiaFontEnabled') === 'true';
+        } catch (error) {
+            enabled = false;
+        }
+        setDyslexiaFont(enabled);
+        if (dyslexiaFontBtn) {
+            dyslexiaFontBtn.onclick = () => setDyslexiaFont(!document.body.classList.contains('font-dyslexic'));
         }
     }
 
@@ -4056,6 +4083,7 @@
     if (pauseBtn) pauseBtn.onclick = () => paused ? resumeGame() : pauseGame();
     if (muteBtn) muteBtn.onclick = toggleMute;
     if (flipBtn) flipBtn.onclick = toggleBoardOrientation;
+    initDyslexiaFontToggle();
 
     const blindfoldBtn = document.getElementById('blindfoldBtn');
     if (blindfoldBtn) {

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -605,6 +605,7 @@
 
                     <button type="button" class="btn btn-gold" id="flipBtn" title="Shortcut: F">Flip Board<span class="btn-shortcut">F</span></button>
                    <button class="btn btn-gold" id="blindfoldBtn">Blindfold: OFF</button>
+                    <button class="btn btn-gold" id="dyslexiaFontBtn" type="button" aria-pressed="false">Dyslexia-Friendly Font: OFF</button>
                     <button class="btn btn-gold" id="newPvPBtn">Pass & Play (PvP)</button>
                     <button class="btn btn-gold" id="newAIBtn">Play vs AI</button>
                     <button type="button" class="btn btn-gold" id="dailyPuzzleBtn">Daily Puzzle</button>


### PR DESCRIPTION
## Summary

Closes #2224.

Adds a dyslexia-friendly font toggle to the game controls so players can switch the board UI into a more readable font style and keep that preference across reloads.

## What changed

- Added a `Dyslexia-Friendly Font` control to the game controls card.
- Applies a `font-dyslexic` body class to use a dyslexia-friendly font stack across the UI, board labels, and squares.
- Persists the preference with `localStorage`.
- Updates `aria-pressed` and button text so assistive technologies can read the toggle state.
- Added Jest coverage for the toggle class, persisted value, and button state.

## Test plan

```bash
npm ci
node --check game/static/game/js/board.js
git diff --check
npm test -- --runInBand board.test.js
```

Result: `board.test.js` passed with 45 tests.

## Notes

The change is intentionally scoped to the issue-requested board UI files plus the existing JS test mock. It does not modify chess engine behavior, Django routes, migrations, or unrelated styling.
