### PR TITLE
feat: add 3-2-1-Go countdown overlay before game start

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -600,6 +600,52 @@ body {
     flex-direction: column;
     width: calc(var(--square-size) * 8 + var(--board-border) * 2);
     box-sizing: border-box;
+    position: relative;
+}
+
+/* ================= START COUNTDOWN OVERLAY ================= */
+.chessboard.countdown-active .square {
+    pointer-events: none;
+}
+
+.countdown-overlay {
+    display: none;
+    position: absolute;
+    inset: 0;
+    z-index: 50;
+    align-items: center;
+    justify-content: center;
+    background: rgba(8, 8, 16, 0.82);
+    border-radius: 2px;
+    pointer-events: none;
+}
+
+.countdown-overlay.active {
+    display: flex;
+}
+
+.countdown-number {
+    font-family: 'Cinzel', serif;
+    font-size: clamp(3rem, 12vw, 6rem);
+    font-weight: 700;
+    color: #f0c040;
+    text-shadow: 0 0 20px rgba(240, 192, 64, 0.6);
+    animation: countdownPop 1s ease-in-out;
+}
+
+@keyframes countdownPop {
+    0% {
+        transform: scale(0.4);
+        opacity: 0;
+    }
+    30% {
+        transform: scale(1.15);
+        opacity: 1;
+    }
+    100% {
+        transform: scale(1);
+        opacity: 1;
+    }
 }
 
 .ranks {

--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -625,15 +625,15 @@ body {
 }
 
 .countdown-number {
-    font-family: 'Cinzel', serif;
+    font-family: Cinzel, serif;
     font-size: clamp(3rem, 12vw, 6rem);
     font-weight: 700;
     color: #f0c040;
     text-shadow: 0 0 20px rgba(240, 192, 64, 0.6);
-    animation: countdownPop 1s ease-in-out;
+    animation: countdown-pop 1s ease-in-out;
 }
 
-@keyframes countdownPop {
+@keyframes countdown-pop {
     0% {
         transform: scale(0.4);
         opacity: 0;
@@ -647,6 +647,7 @@ body {
         opacity: 1;
     }
 }
+
 
 .ranks {
     display: flex;

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -108,6 +108,7 @@
     let selectedIncrement = 0;
     let paused = false;
     let timerInterval = null;
+    let countdownInterval = null;
     let pendingPromo = null;
     let blindfoldMode = false;
     let illegalMoveCount = 0;
@@ -3202,30 +3203,33 @@
     }
 }
             function runStartCountdown(onComplete) {
-                if (!countdownOverlay || !countdownNumberEl) {
-                    onComplete();
-                    return;
-                }
+    if (!countdownOverlay || !countdownNumberEl) {
+        onComplete();
+        return;
+    }
 
-                const sequence = ['3', '2', '1', 'Go!'];
-                let idx = 0;
+    clearInterval(countdownInterval);
 
-                boardEl.classList.add('countdown-active');
-                countdownNumberEl.textContent = sequence[idx];
-                countdownOverlay.classList.add('active');
+    const sequence = ['3', '2', '1', 'Go!'];
+    let idx = 0;
 
-                const countdownInterval = setInterval(() => {
-                    idx++;
-                    if (idx < sequence.length) {
-                        countdownNumberEl.textContent = sequence[idx];
-                    } else {
-                        clearInterval(countdownInterval);
-                        countdownOverlay.classList.remove('active');
-                        boardEl.classList.remove('countdown-active');
-                        onComplete();
-                    }
-                }, 1000);
-            }
+    boardEl.classList.add('countdown-active');
+    countdownNumberEl.textContent = sequence[idx];
+    countdownOverlay.classList.add('active');
+
+    countdownInterval = setInterval(() => {
+        idx++;
+        if (idx < sequence.length) {
+            countdownNumberEl.textContent = sequence[idx];
+        } else {
+            clearInterval(countdownInterval);
+            countdownOverlay.classList.remove('active');
+            boardEl.classList.remove('countdown-active');
+            onComplete();
+        }
+    }, 1000);
+}
+               
             function startTimer() {
                 clearInterval(timerInterval);
                 timerInterval = setInterval(() => {

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -598,6 +598,8 @@
     const shareModal = document.getElementById('shareModal');
     const rulebookModal = document.getElementById('rulebookModal');
     const boardEl = document.getElementById('board');
+    const countdownOverlay = document.getElementById('countdownOverlay');
+    const countdownNumberEl = document.getElementById('countdownNumber');
     const turnEl = document.getElementById('turnBadge');
     const statusEl = document.getElementById('statusBar');
     const movesEl = document.getElementById('movesList');
@@ -3199,6 +3201,31 @@
         boardEl.style.pointerEvents = '';
     }
 }
+            function runStartCountdown(onComplete) {
+                if (!countdownOverlay || !countdownNumberEl) {
+                    onComplete();
+                    return;
+                }
+
+                const sequence = ['3', '2', '1', 'Go!'];
+                let idx = 0;
+
+                boardEl.classList.add('countdown-active');
+                countdownNumberEl.textContent = sequence[idx];
+                countdownOverlay.classList.add('active');
+
+                const countdownInterval = setInterval(() => {
+                    idx++;
+                    if (idx < sequence.length) {
+                        countdownNumberEl.textContent = sequence[idx];
+                    } else {
+                        clearInterval(countdownInterval);
+                        countdownOverlay.classList.remove('active');
+                        boardEl.classList.remove('countdown-active');
+                        onComplete();
+                    }
+                }, 1000);
+            }
             function startTimer() {
                 clearInterval(timerInterval);
                 timerInterval = setInterval(() => {
@@ -3546,9 +3573,16 @@
         paused = false;
         updatePauseUI();
 
-        // Auto-trigger AI if it's their turn
-        if (!isPuzzle && gameMode === 'ai' && turn !== playerColor) {
-            queueAIMoveIfNeeded();
+        if (!isPuzzle) {
+            // Hold the clocks and lock the board until the countdown finishes
+            clearInterval(timerInterval);
+            runStartCountdown(() => {
+                startTimer();
+                // Auto-trigger AI if it's their turn
+                if (gameMode === 'ai' && turn !== playerColor) {
+                    queueAIMoveIfNeeded();
+                }
+            });
         }
 
         return true;

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -401,6 +401,9 @@
                         </div>
                         <div class="board-grid-wrap">
                             <div class="chessboard" id="board" role="grid" aria-label="Chess Board"></div>
+                            <div class="countdown-overlay" id="countdownOverlay" aria-live="assertive" aria-atomic="true">
+                                <div class="countdown-number" id="countdownNumber">3</div>
+                            </div>
                         </div>
                         <div id="a11y-announcer" class="visually-hidden" aria-live="polite" aria-atomic="true"></div>
                     </div>


### PR DESCRIPTION
## Description
Adds a 3 → 2 → 1 → Go! countdown overlay that appears when a game starts, 
giving both players a moment to get ready before the board becomes active. 
Prevents one player from moving before the other is ready, especially in 
fast time controls.

fixes #2254

## Changes
- **board.html**: Added a `#countdownOverlay` element (with a `#countdownNumber` 
  display) positioned over the board.
- **board.css**: Added overlay styling — dark translucent background, gold 
  countdown numbers matching the Checkora theme, and a pop-in animation. 
  Added `.chessboard.countdown-active .square { pointer-events: none; }` to 
  disable square clicks during the countdown.
- **board.js**: Added a `runStartCountdown()` function that displays 3 → 2 → 
  1 → Go! (1 second per step), then hides itself and calls back. Hooked into 
  `startNewGame()` so the clocks and AI's first move are held until the 
  countdown completes.

## Behavior
- Countdown shows: 3 → 2 → 1 → Go! (1 second each)
- Board is visible behind the overlay but not clickable during the countdown
- Clocks start only after "Go!" disappears
- Works in both PvP and vs AI mode
- Reconnect/resume/page-refresh flows are unaffected — countdown only runs 
  when a fresh game is started
- Purely frontend — no backend, Python, models, or engine changes

## Testing
- Verified countdown plays on New PvP Game and New AI Game
- Verified squares are unclickable (pointer-events: none) during the countdown
- Verified clocks don't start ticking until the countdown finishes