### PR TITLE
Fix update_clock() sub-second issue and add tests

### DIFF
--- a/game/engine.py
+++ b/game/engine.py
@@ -859,7 +859,7 @@ DP cache is intentionally excluded to save cookie space."""
             else:
                 self.black_time = max(0, self.black_time - elapsed)
 
-        self.last_ts = now
+        self.last_ts += elapsed
 
     # ------------------------------------------------------------------
     #  Game status detection (check / checkmate / stalemate)

--- a/game/tests.py
+++ b/game/tests.py
@@ -2130,6 +2130,54 @@ class TimeControlIncrementTest(TestCase):
         self.assertEqual(game_dict['increment'], 3)
         self.assertEqual(game_dict['white_time'], 300)
 
+    def test_update_clock_sub_second_call_deducts_nothing(self):
+        """A single call with < 1s elapsed must deduct 0 seconds."""
+        game = ChessGame(time_limit=600)
+        game.last_ts = 1000.0
+        game.white_time = 600
+        game.current_turn = 'white'
+        game.paused = False
+
+        with mock.patch('game.engine.time.time', return_value=1000.6):
+            game.update_clock()
+
+        self.assertEqual(game.white_time, 600)
+        self.assertEqual(game.last_ts, 1000.0)
+
+    def test_update_clock_remainder_accumulates_across_calls(self):
+        """Sub-second remainders must accumulate; 0.6+0.6 = 1.2 -> deduct 1."""
+        game = ChessGame(time_limit=600)
+        game.last_ts = 1000.0
+        game.white_time = 600
+        game.current_turn = 'white'
+        game.paused = False
+
+        with mock.patch('game.engine.time.time', return_value=1000.6):
+            game.update_clock()
+        self.assertEqual(game.white_time, 600)
+        self.assertEqual(game.last_ts, 1000.0)
+
+        with mock.patch('game.engine.time.time', return_value=1001.2):
+            game.update_clock()
+        self.assertEqual(game.white_time, 599)
+        self.assertEqual(game.last_ts, 1001.0)
+
+    def test_update_clock_high_frequency_no_time_leak(self):
+        """Repeated 0.4s polls must deduct only floor(total elapsed) seconds."""
+        game = ChessGame(time_limit=600)
+        game.last_ts = 0.0
+        game.white_time = 600
+        game.current_turn = 'white'
+        game.paused = False
+
+        for i in range(1, 11):
+            with mock.patch('game.engine.time.time', return_value=i * 0.4):
+                game.update_clock()
+
+        total_elapsed = 10 * 0.4  # 4.0 s
+        self.assertEqual(game.white_time, 600 - int(total_elapsed))
+        self.assertEqual(game.last_ts, float(int(total_elapsed)))
+
 
 class GameResultMoveHistoryTest(TestCase):
     """Test suite for verifying persistent move history storage in GameResult."""


### PR DESCRIPTION
## Description

a simple one-line fix where we increment by elapsed time instead of storing time.time() which drops the decimal part. This is done inorder to consider time limits <1 sec i.e sub-second changes. Added regression tests as suggested by code rabbit.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #2256

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally


