### PR TITLE
ui: Fix cursor visibility over legal modals.

### DIFF
--- a/game/static/game/css/landing.css
+++ b/game/static/game/css/landing.css
@@ -551,6 +551,23 @@ body.hide-native-cursor * {
     cursor: none !important;
 }
 
+/* Modal Cursor Overrides */
+#privacyModal, #privacyModal *,
+#termsModal, #termsModal *,
+#contactModal, #contactModal *,
+#disclaimerModal, #disclaimerModal *,
+#shortcutsModal, #shortcutsModal * {
+    cursor: auto !important;
+}
+
+#privacyModal button, #privacyModal a,
+#termsModal button, #termsModal a,
+#contactModal button, #contactModal a,
+#disclaimerModal button, #disclaimerModal a,
+#shortcutsModal button, #shortcutsModal a {
+    cursor: pointer !important;
+}
+
 .profile-dropdown.active .dropdown-content {
     opacity: 1;
     visibility: visible;


### PR DESCRIPTION
## Description

This PR fixes an accessibility and usability issue on the landing page where the native cursor becomes invisible when interacting with the footer legal modals (Privacy Policy, Terms & Conditions, Contact Us, Disclaimer) and the Keyboard Shortcuts modal.

The root cause was a global wildcard rule (`body.hide-native-cursor * { cursor: none !important; }`) that leaked into the modal dialogs, while the custom animated `.cursor` (z-index: 9990) remained hidden beneath the modal overlays (z-index: 9999/99999). 

Instead of altering the z-index stack or touching the existing JavaScript, this fix targets the specific modal IDs and their descendants, explicitly restoring the native cursor (`cursor: auto !important`) and pointer (`cursor: pointer !important`) while inside the dialogs. The custom cursor remains active and untouched everywhere else on the landing page.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #2250

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

*(Screenshots of the modal BEFORE submitting, showing no cursor over the sections.
<img width="1600" height="1200" alt="WhatsApp Image 2026-07-05 at 02 46 54 (1)" src="https://github.com/user-attachments/assets/05c145c0-3b3d-4101-a09e-79b56b6c2d71" />

*(Screenshots of the modal AFTER submitting, showing the native cursor over the sections.
<img width="1600" height="1200" alt="WhatsApp Image 2026-07-05 at 02 46 54" src="https://github.com/user-attachments/assets/3a608816-22b2-46f3-85ad-1a575635d919" />




## Additional Notes

- The override specifically relies on the CSS specificity of the modal IDs (`#privacyModal *`, etc.) to safely beat the wildcard rule. 
- No Javascript changes were required. The inconsistent modal triggers (data-modal-trigger vs inline onclick) were deliberately left out of scope as per the issue research notes.


