### PR TITLE
Refactor remember me session expiry configuration

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -225,6 +225,12 @@ STATIC_ROOT = BASE_DIR / "staticfiles"
 
 SESSION_ENGINE = 'django.contrib.sessions.backends.db'
 
+# Session lifetime (2 weeks when "Remember Me" is checked)
+SESSION_COOKIE_AGE = 1209600
+
+# Expire session when browser closes unless overridden via set_expiry()
+SESSION_EXPIRE_AT_BROWSER_CLOSE = True
+
 # Session and CSRF cookie security (production only — local runserver is HTTP).
 SESSION_COOKIE_HTTPONLY = True
 SESSION_COOKIE_SECURE = IS_PRODUCTION

--- a/game/views.py
+++ b/game/views.py
@@ -1739,11 +1739,12 @@ def login_view(request):
             login(request, user)
             request.session.cycle_key()  # Prevent session fixation
 
-            remember_me = request.POST.get('remember_me')
+            remember_me = request.POST.get("remember_me")
+
             if remember_me:
-                request.session.set_expiry(1209600)  # 2 weeks
+                request.session.set_expiry(settings.SESSION_COOKIE_AGE)
             else:
-                request.session.set_expiry(0)  # Browser close
+                request.session.set_expiry(0)
 
             messages.success(
                 request,


### PR DESCRIPTION
## Description

This PR refactors the "Remember Me" session expiry configuration by replacing the hardcoded session lifetime with Django's `SESSION_COOKIE_AGE` setting and explicitly configuring session expiry behavior.

### Changes
- Replaced the hardcoded session expiry value (`1209600`) with `settings.SESSION_COOKIE_AGE` in `login_view`.
- Added `SESSION_COOKIE_AGE` to `core/settings.py` as the single source of truth for persistent session duration.
- Added `SESSION_EXPIRE_AT_BROWSER_CLOSE = True` to make browser-session behavior explicit when "Remember Me" is not selected.
- Preserved the existing login flow, including `request.session.cycle_key()` and brute-force protection logic.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Related Issue

Fixes #2296 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

## Screenshots (if applicable)

N/A

## Additional Notes

This change does not modify the existing "Remember Me" functionality. It centralizes session lifetime configuration, removes a hardcoded value, and makes session expiry behavior explicit through Django settings, improving maintainability and consistency.