### PR TITLE
feat: add AI move prediction in analysis mode

### DIFF
--- a/game/engine.py
+++ b/game/engine.py
@@ -1031,9 +1031,32 @@ DP cache is intentionally excluded to save cookie space."""
         if len(parts) < 5 or parts[1] == "NONE":
             return None
 
-        return {
+        move_data = {
             'from_row': int(parts[1]),
             'from_col': int(parts[2]),
             'to_row':   int(parts[3]),
             'to_col':   int(parts[4]),
+            'eval': None,
+            'alts': []
         }
+        
+        idx = 5
+        while idx < len(parts):
+            if parts[idx] == "EVAL" and idx + 1 < len(parts):
+                move_data['eval'] = int(parts[idx + 1])
+                idx += 2
+            elif parts[idx] == "ALTS":
+                idx += 1
+                while idx + 4 < len(parts) and parts[idx] not in ("EVAL", "ALTS"):
+                    move_data['alts'].append({
+                        'from_row': int(parts[idx]),
+                        'from_col': int(parts[idx+1]),
+                        'to_row': int(parts[idx+2]),
+                        'to_col': int(parts[idx+3]),
+                        'eval': int(parts[idx+4])
+                    })
+                    idx += 5
+            else:
+                idx += 1
+
+        return move_data

--- a/game/engine/main.cpp
+++ b/game/engine/main.cpp
@@ -984,8 +984,8 @@ void handleBestMove(const string &turn, int depth) {
         return;
     }
 
-    Move best = legal[0];
-    int bestVal = maximizing ? INT_MIN : INT_MAX;
+    vector<pair<Move, int>> evaluated;
+    evaluated.reserve(legal.size());
 
     for (auto &m : legal) {
         char src = board[m.fr][m.fc];
@@ -1031,15 +1031,29 @@ void handleBestMove(const string &turn, int depth) {
             board[rook_tr][rook_tc] = '.';
         }
 
-        if (maximizing) {
-            if (eval > bestVal) { bestVal = eval; best = m; }
-        } else {
-            if (eval < bestVal) { bestVal = eval; best = m; }
-        }
+        evaluated.push_back({m, eval});
     }
 
+    if (maximizing) {
+        sort(evaluated.begin(), evaluated.end(), [](auto &a, auto &b) { return a.second > b.second; });
+    } else {
+        sort(evaluated.begin(), evaluated.end(), [](auto &a, auto &b) { return a.second < b.second; });
+    }
+
+    Move best = evaluated[0].first;
+    int bestVal = evaluated[0].second;
+
     cout << "BESTMOVE " << best.fr << " " << best.fc
-         << " " << best.tr << " " << best.tc << endl;
+         << " " << best.tr << " " << best.tc << " EVAL " << bestVal;
+    
+    if (evaluated.size() > 1) {
+        cout << " ALTS";
+        for (size_t i = 1; i < min((size_t)4, evaluated.size()); i++) {
+            Move am = evaluated[i].first;
+            cout << " " << am.fr << " " << am.fc << " " << am.tr << " " << am.tc << " " << evaluated[i].second;
+        }
+    }
+    cout << endl;
 }
 
 int main() {

--- a/game/engine/main.py
+++ b/game/engine/main.py
@@ -712,8 +712,7 @@ def handle_bestmove(turn, depth):
         print('BESTMOVE NONE')
         return
 
-    best_move = legal_moves[0]
-    best_value = -(10 ** 9) if maximizing else 10 ** 9
+    evaluated = []
 
     for move in legal_moves:
         src_piece = BOARD[move.fr][move.fc]
@@ -769,14 +768,22 @@ def handle_bestmove(turn, depth):
             BOARD[rook_fr][rook_fc] = BOARD[rook_tr][rook_tc]
             BOARD[rook_tr][rook_tc] = '.'
 
-        if maximizing and value > best_value:
-            best_value = value
-            best_move = move
-        if not maximizing and value < best_value:
-            best_value = value
-            best_move = move
+        evaluated.append((move, value))
 
-    print(f'BESTMOVE {best_move.fr} {best_move.fc} {best_move.tr} {best_move.tc}')
+    if maximizing:
+        evaluated.sort(key=lambda x: x[1], reverse=True)
+    else:
+        evaluated.sort(key=lambda x: x[1])
+
+    best_move, best_value = evaluated[0]
+    out = f'BESTMOVE {best_move.fr} {best_move.fc} {best_move.tr} {best_move.tc} EVAL {best_value}'
+    
+    if len(evaluated) > 1:
+        out += ' ALTS'
+        for i in range(1, min(4, len(evaluated))):
+            alt_m, alt_val = evaluated[i]
+            out += f' {alt_m.fr} {alt_m.fc} {alt_m.tr} {alt_m.tc} {alt_val}'
+    print(out)
 
 
 def handle_notation(turn, fr, fc, tr, tc, promo='\0'):

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -2048,12 +2048,19 @@
                         };
 
                         const moveText = mv.notation || getSquareLabel(mv.to_row, mv.to_col);
-                        predSuggestedMove.innerHTML = `<strong>${moveText}</strong> ${formatEval(mv.eval)}`;
-                        
-                        predResponsesList.innerHTML = '';
+                        predSuggestedMove.textContent = '';
+                        const smStrong = document.createElement('strong');
+                        smStrong.textContent = moveText;
+                        predSuggestedMove.appendChild(smStrong);
+                        predSuggestedMove.appendChild(document.createTextNode(` ${formatEval(mv.eval)}`));
+
+                        predResponsesList.textContent = '';
                         data.ai_move.predicted_responses.forEach((resp, index) => {
                             const li = document.createElement('li');
-                            li.innerHTML = `<strong>${index + 1}. ${resp.notation}</strong> ${formatEval(resp.eval)}`;
+                            const respStrong = document.createElement('strong');
+                            respStrong.textContent = `${index + 1}. ${resp.notation}`;
+                            li.appendChild(respStrong);
+                            li.appendChild(document.createTextNode(` ${formatEval(resp.eval)}`));
                             li.style.marginBottom = '5px';
                             predResponsesList.appendChild(li);
                         });

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -2033,6 +2033,38 @@
             if (data.valid) {
                 playSound(data);
                 const mv = data.ai_move;
+                
+                if (gameMode === 'analysis' && data.ai_move.predicted_responses) {
+                    // Issue #1630: Show predicted responses in Analysis Mode
+                    const predPanel = document.getElementById('aiPredictionPanel');
+                    const predSuggestedMove = document.getElementById('predSuggestedMove');
+                    const predResponsesList = document.getElementById('predResponsesList');
+                    
+                    if (predPanel && predSuggestedMove && predResponsesList) {
+                        const formatEval = (val) => {
+                            if (val === undefined || val === null) return '';
+                            const v = (val / 100).toFixed(2);
+                            return `(${v > 0 ? '+' + v : v})`;
+                        };
+
+                        const moveText = mv.notation || getSquareLabel(mv.to_row, mv.to_col);
+                        predSuggestedMove.innerHTML = `<strong>${moveText}</strong> ${formatEval(mv.eval)}`;
+                        
+                        predResponsesList.innerHTML = '';
+                        data.ai_move.predicted_responses.forEach((resp, index) => {
+                            const li = document.createElement('li');
+                            li.innerHTML = `<strong>${index + 1}. ${resp.notation}</strong> ${formatEval(resp.eval)}`;
+                            li.style.marginBottom = '5px';
+                            predResponsesList.appendChild(li);
+                        });
+                        
+                        predPanel.style.display = 'block';
+                    }
+                } else {
+                    const predPanel = document.getElementById('aiPredictionPanel');
+                    if (predPanel) predPanel.style.display = 'none';
+                }
+
                 await animateMove(mv.from_row, mv.from_col, mv.to_row, mv.to_col);
                 board = parseBoard(data.board);
                 turn = data.current_turn;

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -2055,15 +2055,21 @@
                         predSuggestedMove.appendChild(document.createTextNode(` ${formatEval(mv.eval)}`));
 
                         predResponsesList.textContent = '';
-                        data.ai_move.predicted_responses.forEach((resp, index) => {
+                        if (data.ai_move.predicted_responses.length === 0) {
                             const li = document.createElement('li');
-                            const respStrong = document.createElement('strong');
-                            respStrong.textContent = `${index + 1}. ${resp.notation}`;
-                            li.appendChild(respStrong);
-                            li.appendChild(document.createTextNode(` ${formatEval(resp.eval)}`));
-                            li.style.marginBottom = '5px';
+                            li.textContent = 'No opponent response available. The position may be terminal.';
                             predResponsesList.appendChild(li);
-                        });
+                        } else {
+                            data.ai_move.predicted_responses.forEach((resp, index) => {
+                                const li = document.createElement('li');
+                                const respStrong = document.createElement('strong');
+                                respStrong.textContent = `${index + 1}. ${resp.notation}`;
+                                li.appendChild(respStrong);
+                                li.appendChild(document.createTextNode(` ${formatEval(resp.eval)}`));
+                                li.style.marginBottom = '5px';
+                                predResponsesList.appendChild(li);
+                            });
+                        }
                         
                         predPanel.style.display = 'block';
                     }

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -825,6 +825,18 @@
                             <tbody id="postGameAnalysisTableBody"></tbody>
                         </table>
                     </div>
+
+                    <div id="aiPredictionPanel" style="display: none; background: #1a1a2e; border: 1px solid #444; border-radius: 5px; padding: 15px; margin-top: 15px; text-align: left;">
+                        <h4 style="color: #f0c040; margin: 0 0 10px 0;">AI Prediction</h4>
+                        <div style="font-size: 0.9rem; color: #ccc;">
+                            <strong>Suggested Move:</strong> <span id="predSuggestedMove"></span>
+                        </div>
+                        <div style="margin-top: 10px; font-size: 0.9rem; color: #ccc;">
+                            <strong>Predicted Responses:</strong>
+                            <ul id="predResponsesList" style="margin: 5px 0 0 20px; padding: 0;">
+                            </ul>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/game/test_issue1630.py
+++ b/game/test_issue1630.py
@@ -12,11 +12,13 @@ class Issue1630PredictionTest(TestCase):
         self.game = ChessGame()
         self.game.mode = 'analysis'
         session['game'] = self.game.to_dict()
-        session['game']['mode'] = 'analysis'
         session.save()
 
     @patch('game.engine.ChessGame.get_ai_move')
     def test_prediction_data_generated_in_analysis_mode(self, mock_get_ai_move):
+        # mock_get_ai_move is called twice:
+        # 1. By the main game instance to get the best move
+        # 2. By the temp_game instance to predict opponent responses
         mock_get_ai_move.side_effect = [
             {'from_row': 6, 'from_col': 4, 'to_row': 4, 'to_col': 4, 'eval': 40, 'alts': []},
             {'from_row': 1, 'from_col': 4, 'to_row': 3, 'to_col': 4, 'eval': -30, 'alts': [
@@ -45,19 +47,25 @@ class Issue1630PredictionTest(TestCase):
 
     @patch('game.engine.ChessGame.get_ai_move')
     def test_no_prediction_in_pvp_or_normal_ai_mode(self, mock_get_ai_move):
-        session = self.client.session
-        self.game.mode = 'ai'
-        session['game'] = self.game.to_dict()
-        session['game']['mode'] = 'ai'
-        session.save()
-        
-        mock_get_ai_move.return_value = {'from_row': 1, 'from_col': 4, 'to_row': 3, 'to_col': 4, 'eval': 40, 'alts': []}
-        
-        response = self.client.post(reverse('ai_move'), content_type='application/json')
-        data = response.json()
-        
-        self.assertNotIn('predicted_responses', data.get('ai_move', {}))
-        self.assertEqual(mock_get_ai_move.call_count, 1)
+        for mode in ['ai', 'pvp']:
+            self.game.mode = mode
+            session = self.client.session
+            session['game'] = self.game.to_dict()
+            session.save()
+
+            mock_get_ai_move.return_value = {'from_row': 1, 'from_col': 4, 'to_row': 3, 'to_col': 4, 'eval': 40, 'alts': []}
+            mock_get_ai_move.reset_mock()
+
+            response = self.client.post(reverse('ai_move'), content_type='application/json')
+
+            if mode == 'ai':
+                self.assertEqual(response.status_code, 200)
+                data = response.json()
+                self.assertNotIn('predicted_responses', data.get('ai_move', {}))
+                self.assertEqual(mock_get_ai_move.call_count, 1)
+            else:
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(mock_get_ai_move.call_count, 0)
 
 class Issue1630EngineParserTest(TestCase):
     @patch('game.engine.ChessGame._call_engine')

--- a/game/test_issue1630.py
+++ b/game/test_issue1630.py
@@ -1,0 +1,84 @@
+import json
+from django.test import TestCase, Client
+from django.urls import reverse
+from game.engine import ChessGame
+from unittest.mock import patch
+from django.contrib.sessions.middleware import SessionMiddleware
+
+class Issue1630PredictionTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        session = self.client.session
+        self.game = ChessGame()
+        self.game.mode = 'analysis'
+        session['game'] = self.game.to_dict()
+        session['game']['mode'] = 'analysis'
+        session.save()
+
+    @patch('game.engine.ChessGame.get_ai_move')
+    def test_prediction_data_generated_in_analysis_mode(self, mock_get_ai_move):
+        mock_get_ai_move.side_effect = [
+            {'from_row': 6, 'from_col': 4, 'to_row': 4, 'to_col': 4, 'eval': 40, 'alts': []},
+            {'from_row': 1, 'from_col': 4, 'to_row': 3, 'to_col': 4, 'eval': -30, 'alts': [
+                {'from_row': 1, 'from_col': 2, 'to_row': 3, 'to_col': 2, 'eval': -40},
+                {'from_row': 1, 'from_col': 3, 'to_row': 3, 'to_col': 3, 'eval': -50},
+                {'from_row': 0, 'from_col': 6, 'to_row': 2, 'to_col': 5, 'eval': -60},
+                {'from_row': 0, 'from_col': 1, 'to_row': 2, 'to_col': 2, 'eval': -70}
+            ]}
+        ]
+        
+        response = self.client.post(reverse('ai_move'), content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        
+        self.assertEqual(data['valid'], True, data)
+        ai_move = data['ai_move']
+        self.assertIn('predicted_responses', ai_move)
+        preds = ai_move['predicted_responses']
+        
+        # Verify it has at least one response and is limited to 3
+        self.assertTrue(len(preds) > 0)
+        self.assertEqual(len(preds), 3)
+        self.assertEqual(preds[0]['eval'], -30)
+        self.assertEqual(preds[1]['eval'], -40)
+        self.assertEqual(preds[2]['eval'], -50)
+
+    @patch('game.engine.ChessGame.get_ai_move')
+    def test_no_prediction_in_pvp_or_normal_ai_mode(self, mock_get_ai_move):
+        session = self.client.session
+        self.game.mode = 'ai'
+        session['game'] = self.game.to_dict()
+        session['game']['mode'] = 'ai'
+        session.save()
+        
+        mock_get_ai_move.return_value = {'from_row': 1, 'from_col': 4, 'to_row': 3, 'to_col': 4, 'eval': 40, 'alts': []}
+        
+        response = self.client.post(reverse('ai_move'), content_type='application/json')
+        data = response.json()
+        
+        self.assertNotIn('predicted_responses', data.get('ai_move', {}))
+        self.assertEqual(mock_get_ai_move.call_count, 1)
+
+class Issue1630EngineParserTest(TestCase):
+    @patch('game.engine.ChessGame._call_engine')
+    def test_bestmove_parsing_backward_compatibility(self, mock_call):
+        mock_call.return_value = "BESTMOVE 1 4 3 4\n"
+        game = ChessGame()
+        result = game.get_ai_move()
+        self.assertEqual(result['from_row'], 1)
+        self.assertEqual(result['to_row'], 3)
+        self.assertIsNone(result.get('eval'))
+        self.assertEqual(result.get('alts'), [])
+
+    @patch('game.engine.ChessGame._call_engine')
+    def test_eval_and_alts_parsing(self, mock_call):
+        mock_call.return_value = "BESTMOVE 1 4 3 4 EVAL 45 ALTS 1 3 3 3 20 6 2 4 2 -10\n"
+        game = ChessGame()
+        result = game.get_ai_move()
+        self.assertEqual(result['from_row'], 1)
+        self.assertEqual(result['eval'], 45)
+        self.assertEqual(len(result['alts']), 2)
+        self.assertEqual(result['alts'][0]['from_row'], 1)
+        self.assertEqual(result['alts'][0]['eval'], 20)
+        self.assertEqual(result['alts'][1]['from_row'], 6)
+        self.assertEqual(result['alts'][1]['eval'], -10)

--- a/game/views.py
+++ b/game/views.py
@@ -675,7 +675,8 @@ def ai_move(request):
                     ),
                     'eval': opp_resp.get('eval')
                 })
-                for alt in opp_resp.get('alts', []):
+                # Cap the alts before running the notation loop
+                for alt in opp_resp.get('alts', [])[:2]:
                     predicted_responses.append({
                         'notation': temp_game._notation(
                             alt['from_row'], alt['from_col'], 
@@ -687,9 +688,9 @@ def ai_move(request):
                         'eval': alt.get('eval')
                     })
             
-            best['predicted_responses'] = predicted_responses[:3]
-        except Exception as e:
-            logger.error(f"Failed to predict opponent responses: {e}")
+            best['predicted_responses'] = predicted_responses
+        except Exception:
+            logger.exception("Failed to predict opponent responses")
 
     if not best:
         if game.game_status == 'checkmate':

--- a/game/views.py
+++ b/game/views.py
@@ -591,7 +591,7 @@ def ai_move(request):
 
     game = ChessGame.from_dict(game_data)
 
-    if game.mode != 'ai':
+    if game.mode not in ('ai', 'analysis'):
         err_msg = 'Not in AI mode.'
         return JsonResponse(
             {'valid': False, 'message': err_msg}, status=400
@@ -637,6 +637,59 @@ def ai_move(request):
         request.session['opening'] = ''
         request.session.modified = True
         best = game.get_ai_move(depth=depth)
+
+    # Issue #1630: Predict opponent responses in Analysis Mode
+    if best and game.mode == 'analysis':
+        try:
+            # Generate notation for the best move
+            best['notation'] = game._notation(
+                best['from_row'], best['from_col'],
+                best['to_row'], best['to_col'],
+                game.board[best['from_row']][best['from_col']],
+                game.board[best['to_row']][best['to_col']],
+                game.serialize_board(), game.serialize_castling_rights(), game._serialize_ep()
+            )
+
+            # Create a temporary copy
+            temp_game = ChessGame()
+            temp_game.board = temp_game._parse_board64(game.serialize_board())
+            temp_game.castling_rights = dict(game.castling_rights)
+            temp_game.current_turn = game.current_turn
+            temp_game.en_passant_target = game.en_passant_target
+            
+            # Apply the suggested move
+            temp_game.make_move(best['from_row'], best['from_col'], best['to_row'], best['to_col'])
+            
+            # Request opponent's responses
+            opp_resp = temp_game.get_ai_move(depth=depth)
+            
+            predicted_responses = []
+            if opp_resp and 'alts' in opp_resp:
+                predicted_responses.append({
+                    'notation': temp_game._notation(
+                        opp_resp['from_row'], opp_resp['from_col'], 
+                        opp_resp['to_row'], opp_resp['to_col'], 
+                        temp_game.board[opp_resp['from_row']][opp_resp['from_col']], 
+                        temp_game.board[opp_resp['to_row']][opp_resp['to_col']], 
+                        temp_game.serialize_board(), temp_game.serialize_castling_rights(), temp_game._serialize_ep()
+                    ),
+                    'eval': opp_resp.get('eval')
+                })
+                for alt in opp_resp.get('alts', []):
+                    predicted_responses.append({
+                        'notation': temp_game._notation(
+                            alt['from_row'], alt['from_col'], 
+                            alt['to_row'], alt['to_col'], 
+                            temp_game.board[alt['from_row']][alt['from_col']], 
+                            temp_game.board[alt['to_row']][alt['to_col']], 
+                            temp_game.serialize_board(), temp_game.serialize_castling_rights(), temp_game._serialize_ep()
+                        ),
+                        'eval': alt.get('eval')
+                    })
+            
+            best['predicted_responses'] = predicted_responses[:3]
+        except Exception as e:
+            logger.error(f"Failed to predict opponent responses: {e}")
 
     if not best:
         if game.game_status == 'checkmate':


### PR DESCRIPTION
## Description

This PR implements AI Move Prediction and Suggested Response Analysis for Analysis Mode.

The feature extends the existing chess engine analysis flow to:

* expose evaluation scores and alternative candidate moves from the existing engine search;
* predict likely opponent responses after the suggested move;
* display up to 3 predicted responses with evaluation scores;
* show the suggested move and predicted continuation in the Analysis Mode UI;
* keep normal AI and PvP behavior unchanged;
* maintain backward compatibility with the existing `BESTMOVE` engine output format.

Dedicated tests were added for Issue #1630, covering prediction generation, response limits, Analysis Mode isolation, backward-compatible engine parsing, and `EVAL`/`ALTS` parsing.

## Type of Change

* [ ] Bug fix (non-breaking change that fixes an issue)
* [x] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

## Related Issue

Fixes #1630

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] I have commented my code where necessary
* [ ] I have updated the documentation if needed
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix/feature works
* [x] New and relevant existing tests pass locally

## Screenshots (if applicable)

Not included.

## Additional Notes

The implementation is limited to Analysis Mode and reuses the existing engine and AI move API flow.

Validation performed:

`python manage.py test game.test_issue1630 game.test_analysis`

Result: 24 tests passed successfully with 0 failures and 0 errors.

A local warning about the missing `staticfiles` directory was emitted during testing, but it did not affect test execution or results.
