### PR TITLE
fix: rate limit AI move endpoint

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -182,6 +182,15 @@ ANALYZE_GAME_USER_MAX_REQUESTS = _positive_int_env('ANALYZE_GAME_USER_MAX_REQUES
 # Max requests that can originate from a single IP address in the time window
 ANALYZE_GAME_IP_MAX_REQUESTS = _positive_int_env('ANALYZE_GAME_IP_MAX_REQUESTS', 20)
 
+# AI Move Rate Limiting (Issue #1625)
+# Configures the rate limits for the ai_move endpoint (minimax engine calls).
+# Window duration for tracking AI move requests
+AI_MOVE_RATE_WINDOW_SECONDS = _positive_int_env('AI_MOVE_RATE_WINDOW_SECONDS', 60)
+# Max AI move requests a single user/session can make in the time window
+AI_MOVE_USER_MAX_REQUESTS = _positive_int_env('AI_MOVE_USER_MAX_REQUESTS', 120)
+# Max AI move requests that can originate from a single IP address in the time window
+AI_MOVE_IP_MAX_REQUESTS = _positive_int_env('AI_MOVE_IP_MAX_REQUESTS', 240)
+
 # Rate limiting for opening lookup
 OPENING_RATE_LIMIT_WINDOW_SECONDS = _positive_int_env(
     'OPENING_RATE_LIMIT_WINDOW_SECONDS', 60

--- a/game/test_analysis.py
+++ b/game/test_analysis.py
@@ -315,3 +315,159 @@ class AnalyzeGameRateLimitTest(TestCase):
             
             response = self.client.post(reverse('analyze_game'), data=json.dumps(payload), content_type='application/json')
             self.assertEqual(response.status_code, 200)
+
+
+@override_settings(SECURE_SSL_REDIRECT=False)
+class AiMoveRateLimitTest(TestCase):
+    """
+    Issue #1625: Rate limiting for the /api/ai-move/ endpoint.
+    """
+
+    def _make_ai_game_session(self):
+        """Set an AI-mode chess game in the test client's session."""
+        from game.engine import ChessGame
+        game = ChessGame()
+        game.mode = 'ai'
+        game.paused = False
+        session = self.client.session
+        session['game'] = game.to_dict()
+        session['difficulty'] = 'easy'
+        session.save()
+
+    def setUp(self):
+        from django.contrib.auth.models import User
+        from django.core.cache import cache
+        self.user1 = User.objects.create_user(username='ai_rl_user1', password='pass123')
+        self.user2 = User.objects.create_user(username='ai_rl_user2', password='pass123')
+        cache.clear()
+
+    def tearDown(self):
+        from django.core.cache import cache
+        cache.clear()
+
+    @override_settings(
+        AI_MOVE_RATE_WINDOW_SECONDS=60,
+        AI_MOVE_USER_MAX_REQUESTS=2,
+        AI_MOVE_IP_MAX_REQUESTS=1000,
+    )
+    def test_request_under_limit_not_rejected(self):
+        """A single request well below the limit must not return 429 and process normally."""
+        self.client.force_login(self.user1)
+        self._make_ai_game_session()
+
+        from unittest.mock import patch
+        with patch('game.engine.ChessGame.get_ai_move', return_value={'from_row': 6, 'from_col': 4, 'to_row': 4, 'to_col': 4}):
+            response = self.client.post(reverse('ai_move'), HTTP_ACCEPT='application/json')
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(data.get('valid'))
+        self.assertIn('game_status', data)
+
+    @override_settings(
+        AI_MOVE_RATE_WINDOW_SECONDS=60,
+        AI_MOVE_USER_MAX_REQUESTS=2,
+        AI_MOVE_IP_MAX_REQUESTS=1000,
+    )
+    def test_user_limit_enforcement(self):
+        """After exceeding AI_MOVE_USER_MAX_REQUESTS the endpoint returns 429."""
+        self.client.force_login(self.user1)
+        self._make_ai_game_session()
+
+        for _ in range(2):
+            r = self.client.post(reverse('ai_move'), HTTP_ACCEPT='application/json')
+            self.assertNotEqual(r.status_code, 429)
+
+        r = self.client.post(reverse('ai_move'), HTTP_ACCEPT='application/json')
+        self.assertEqual(r.status_code, 429)
+        self.assertIn('error', r.json())
+
+    @override_settings(
+        AI_MOVE_RATE_WINDOW_SECONDS=60,
+        AI_MOVE_USER_MAX_REQUESTS=1000,
+        AI_MOVE_IP_MAX_REQUESTS=2,
+    )
+    def test_ip_limit_enforcement(self):
+        """After exceeding AI_MOVE_IP_MAX_REQUESTS the endpoint returns 429."""
+        self.client.force_login(self.user1)
+        self._make_ai_game_session()
+
+        for _ in range(2):
+            r = self.client.post(reverse('ai_move'), REMOTE_ADDR='10.0.0.1', HTTP_ACCEPT='application/json')
+            self.assertNotEqual(r.status_code, 429)
+
+        r = self.client.post(reverse('ai_move'), REMOTE_ADDR='10.0.0.1', HTTP_ACCEPT='application/json')
+        self.assertEqual(r.status_code, 429)
+        self.assertIn('error', r.json())
+
+    @override_settings(
+        AI_MOVE_RATE_WINDOW_SECONDS=60,
+        AI_MOVE_USER_MAX_REQUESTS=2,
+        AI_MOVE_IP_MAX_REQUESTS=1000,
+    )
+    def test_separate_users_have_independent_buckets(self):
+        """Exhausting user1's quota must not affect user2's quota."""
+        self.client.force_login(self.user1)
+        self._make_ai_game_session()
+        for _ in range(2):
+            self.client.post(reverse('ai_move'), HTTP_ACCEPT='application/json')
+        r = self.client.post(reverse('ai_move'), HTTP_ACCEPT='application/json')
+        self.assertEqual(r.status_code, 429)
+
+        self.client.force_login(self.user2)
+        self._make_ai_game_session()
+        r2 = self.client.post(reverse('ai_move'), HTTP_ACCEPT='application/json')
+        self.assertNotEqual(r2.status_code, 429)
+
+    @override_settings(
+        AI_MOVE_RATE_WINDOW_SECONDS=60,
+        AI_MOVE_USER_MAX_REQUESTS=1000,
+        AI_MOVE_IP_MAX_REQUESTS=2,
+    )
+    def test_separate_ips_have_independent_buckets(self):
+        """Exhausting one IP's quota must not throttle a different IP."""
+        self.client.force_login(self.user1)
+        self._make_ai_game_session()
+
+        for _ in range(2):
+            self.client.post(reverse('ai_move'), REMOTE_ADDR='10.0.0.1', HTTP_ACCEPT='application/json')
+        r = self.client.post(reverse('ai_move'), REMOTE_ADDR='10.0.0.1', HTTP_ACCEPT='application/json')
+        self.assertEqual(r.status_code, 429)
+
+        r2 = self.client.post(reverse('ai_move'), REMOTE_ADDR='10.0.0.2', HTTP_ACCEPT='application/json')
+        self.assertNotEqual(r2.status_code, 429)
+
+    @override_settings(
+        AI_MOVE_RATE_WINDOW_SECONDS=60,
+        AI_MOVE_USER_MAX_REQUESTS=1000,
+        AI_MOVE_IP_MAX_REQUESTS=2,
+    )
+    def test_anonymous_requests_limited_by_ip(self):
+        """Unauthenticated requests fall back to IP-based limiting."""
+        self._make_ai_game_session()
+
+        for _ in range(2):
+            r = self.client.post(reverse('ai_move'), REMOTE_ADDR='192.0.2.1', HTTP_ACCEPT='application/json')
+            self.assertNotEqual(r.status_code, 429)
+
+        r = self.client.post(reverse('ai_move'), REMOTE_ADDR='192.0.2.1', HTTP_ACCEPT='application/json')
+        self.assertEqual(r.status_code, 429)
+        self.assertIn('error', r.json())
+
+    @override_settings(
+        AI_MOVE_RATE_WINDOW_SECONDS=60,
+        AI_MOVE_USER_MAX_REQUESTS=1,
+        AI_MOVE_IP_MAX_REQUESTS=1000,
+    )
+    def test_429_response_is_json_with_error_key(self):
+        """The throttled response must be JSON with an 'error' key."""
+        self.client.force_login(self.user1)
+        self._make_ai_game_session()
+
+        self.client.post(reverse('ai_move'), HTTP_ACCEPT='application/json')
+        r = self.client.post(reverse('ai_move'), HTTP_ACCEPT='application/json')
+        self.assertEqual(r.status_code, 429)
+        data = r.json()
+        self.assertIn('error', data)
+        self.assertIsInstance(data['error'], str)
+        self.assertGreater(len(data['error']), 0)

--- a/game/views.py
+++ b/game/views.py
@@ -582,6 +582,28 @@ def set_pause(request):
 @require_POST
 def ai_move(request):
     """Let the engine compute and play the best move for the current side."""
+    # Issue #1625: Rate-limit this endpoint to prevent computational DoS.
+    # Apply both a per-user limit (for authenticated sessions) and a per-IP
+    # limit (for anonymous or shared-IP scenarios), matching the pattern used
+    # in analyze_game_view.
+    window = getattr(settings, 'AI_MOVE_RATE_WINDOW_SECONDS', 60)
+    ip = get_client_ip(request)
+    ip_key = get_ai_move_rate_ip_key(ip)
+    ip_count = increment_counter(ip_key, timeout=window)
+    if ip_count > getattr(settings, 'AI_MOVE_IP_MAX_REQUESTS', 240):
+        return JsonResponse(
+            {'error': 'Too many AI move requests. Please try again shortly.'},
+            status=429,
+        )
+    if request.user.is_authenticated:
+        user_key = get_ai_move_rate_user_key(request.user.id)
+        user_count = increment_counter(user_key, timeout=window)
+        if user_count > getattr(settings, 'AI_MOVE_USER_MAX_REQUESTS', 120):
+            return JsonResponse(
+                {'error': 'Too many AI move requests. Please try again shortly.'},
+                status=429,
+            )
+
     game_data = request.session.get('game')
     if not game_data:
         err_msg = 'No active game.'
@@ -1520,6 +1542,17 @@ def _is_trusted_proxy(ip_text, trusted_entries):
             continue
     return False
 
+
+def get_ai_move_rate_user_key(user_id):
+    """Get the cache key for per-user AI move rate limiting."""
+    digest = hashlib.sha256(str(user_id).encode('utf-8')).hexdigest()
+    return f'ai_move_rate:user:{digest}'
+
+
+def get_ai_move_rate_ip_key(ip):
+    """Get the cache key for per-IP AI move rate limiting."""
+    digest = hashlib.sha256(ip.encode('utf-8')).hexdigest()
+    return f'ai_move_rate:ip:{digest}'
 
 def get_client_ip(request):
     """Get client IP address safely by parsing trusted proxies."""


### PR DESCRIPTION
## Description

Adds server-side rate limiting to the `/api/ai-move/` endpoint to prevent brute-force abuse and computational DoS attacks caused by repeated expensive chess engine requests.

The implementation:

* Applies independent per-user and per-IP rate limits.
* Uses the existing trusted-proxy-aware client IP detection and cache counter infrastructure.
* Adds configurable rate-limit settings for the AI move endpoint.
* Returns a JSON `429 Too Many Requests` response when a limit is exceeded.
* Adds tests covering user limits, IP limits, anonymous requests, independent user/IP buckets, normal requests under the limit, and JSON error responses.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

## Related Issue

Fixes #1625

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] I have commented my code where necessary
* [ ] I have updated the documentation if needed
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix works
* [x] New and existing relevant tests pass locally

## Screenshots (if applicable)

Not applicable. This PR contains backend security changes only and does not modify the UI.

## Additional Notes

Validation performed:

* `python manage.py check` — passed with 0 issues.
* `python manage.py test game.test_analysis --verbosity=2` — 27 tests passed.

The rate-limit configuration defaults to a 60-second window with independent limits for authenticated users and client IP addresses.
