### PR TITLE
fix: validate bookmark redirect targets

### DIFF
--- a/game/tests.py
+++ b/game/tests.py
@@ -11,6 +11,8 @@ from game.models import (
     ActiveGame,
     OpeningProgress,
     UserProgress,
+    Discussion,
+    DiscussionBookmark,
 )
 
 from django.conf import settings
@@ -3918,3 +3920,58 @@ class OpeningStatsTests(TestCase):
 
         # XP should not increase after the second completion
         self.assertEqual(user_progress.xp, 75)
+
+
+class DiscussionBookmarkRedirectTests(TestCase):
+    """Tests for safe redirection in toggle_discussion_bookmark view."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = User.objects.create_user(
+            username='bookmark_user',
+            password='TestPass123!',
+            email='bookmark@example.com'
+        )
+        self.client.login(username='bookmark_user', password='TestPass123!')
+        self.discussion = Discussion.objects.create(
+            user=self.user,
+            title='Test Discussion',
+            content='This is a test discussion'
+        )
+        self.url = reverse('toggle_discussion_bookmark', kwargs={'discussion_id': self.discussion.id})
+
+    def test_safe_local_path_next(self):
+        response = self.client.post(self.url, {'next': '/forum/'})
+        self.assertRedirects(response, '/forum/', fetch_redirect_response=False)
+
+    def test_safe_same_host_url_next(self):
+        response = self.client.post(self.url, {'next': 'http://testserver/forum/'})
+        self.assertRedirects(response, 'http://testserver/forum/', fetch_redirect_response=False)
+
+    def test_unsafe_external_url_next_falls_back_to_forum(self):
+        response = self.client.post(self.url, {'next': 'http://evil.com/external'})
+        self.assertRedirects(response, reverse('forum'), fetch_redirect_response=False)
+
+    def test_unsafe_protocol_relative_url_next_falls_back_to_forum(self):
+        response = self.client.post(self.url, {'next': '//evil.com/external'})
+        self.assertRedirects(response, reverse('forum'), fetch_redirect_response=False)
+
+    def test_safe_referer_fallback(self):
+        response = self.client.post(self.url, HTTP_REFERER='http://testserver/forum/1/')
+        self.assertRedirects(response, 'http://testserver/forum/1/', fetch_redirect_response=False)
+
+    def test_unsafe_referer_fallback_redirects_to_forum(self):
+        response = self.client.post(self.url, HTTP_REFERER='http://evil.com/external')
+        self.assertRedirects(response, reverse('forum'), fetch_redirect_response=False)
+
+    def test_unsafe_next_and_safe_referer_falls_back_to_referer(self):
+        response = self.client.post(
+            self.url,
+            {'next': 'http://evil.com/external'},
+            HTTP_REFERER='http://testserver/forum/1/'
+        )
+        self.assertRedirects(response, 'http://testserver/forum/1/', fetch_redirect_response=False)
+
+    def test_no_next_and_no_referer_fallback(self):
+        response = self.client.post(self.url)
+        self.assertRedirects(response, reverse('forum'), fetch_redirect_response=False)

--- a/game/views.py
+++ b/game/views.py
@@ -24,7 +24,8 @@ from django.utils import timezone
 from django.shortcuts import get_object_or_404
 from django.utils.http import (
     urlsafe_base64_encode,
-    urlsafe_base64_decode
+    urlsafe_base64_decode,
+    url_has_allowed_host_and_scheme
 )
 
 from django.utils.encoding import (
@@ -4292,9 +4293,23 @@ def toggle_discussion_bookmark(request, discussion_id):
     if not created:
         bookmark.delete()
 
-    next_url = request.POST.get("next") or request.META.get("HTTP_REFERER")
-    if next_url:
+    next_url = request.POST.get("next")
+    referer_url = request.META.get("HTTP_REFERER")
+    allowed_hosts = {request.get_host()}
+    require_https = request.is_secure()
+
+    if next_url and url_has_allowed_host_and_scheme(
+        url=next_url,
+        allowed_hosts=allowed_hosts,
+        require_https=require_https,
+    ):
         return redirect(next_url)
+    elif referer_url and url_has_allowed_host_and_scheme(
+        url=referer_url,
+        allowed_hosts=allowed_hosts,
+        require_https=require_https,
+    ):
+        return redirect(referer_url)
 
     return redirect("forum")
 


### PR DESCRIPTION
## Description

Fixes an open redirect vulnerability in `toggle_discussion_bookmark()` by validating redirect targets before redirecting.

The view now:

* Validates the `next` POST parameter using Django's `url_has_allowed_host_and_scheme`.
* Validates `HTTP_REFERER` independently when `next` is missing or unsafe.
* Restricts redirect targets to the current request host.
* Uses `request.is_secure()` to enforce HTTPS requirements when applicable.
* Rejects external and protocol-relative URLs.
* Falls back to the `forum` view when no safe redirect target is available.

Added 8 focused tests covering safe local paths, same-host absolute URLs, external URLs, protocol-relative URLs, safe and unsafe referrer fallbacks, unsafe `next` with a safe referrer, and the default forum fallback.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

## Related Issue

Fixes #2096

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] I have commented my code where necessary
* [x] I have updated the documentation if needed
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix/feature works
* [x] New and existing relevant tests pass locally

## Screenshots (if applicable)

Not applicable. This is a backend security fix with no visual UI changes.

## Additional Notes

Verification performed:

`python manage.py test game.tests.DiscussionBookmarkRedirectTests`

Result: 8 tests passed.

Additional relevant test suite was also run successfully:

`game.test_new`

Result: 15 tests passed.

The changes are strictly scoped to the bookmark redirect validation vulnerability and its regression tests.
