### PR TITLE
fix: allow local Django startup without SECRET_KEY in debug

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -24,17 +24,21 @@ load_dotenv(BASE_DIR / '.env')
 # See https://docs.djangoproject.com/en/6.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-try:
-    SECRET_KEY = os.environ['SECRET_KEY']
-except KeyError:
-    raise ImproperlyConfigured('SECRET_KEY environment variable is required')
-
-# SECURITY WARNING: don't run with debug turned on in production!
+# In development, provide a safe fallback so local runs and tests work without
+# requiring a manually configured secret key.
 IS_PRODUCTION = os.environ.get('VERCEL_ENV') == 'production'
 if IS_PRODUCTION:
     DEBUG = False
 else:
     DEBUG = os.environ.get('DEBUG', 'True').lower() == 'true'
+
+try:
+    SECRET_KEY = os.environ['SECRET_KEY']
+except KeyError:
+    if DEBUG:
+        SECRET_KEY = 'dev-secret-key-for-local-testing'
+    else:
+        raise ImproperlyConfigured('SECRET_KEY environment variable is required')
 
 ALLOWED_HOSTS = ['.vercel.app']
 

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,0 +1,24 @@
+import importlib
+import os
+from unittest.mock import patch
+
+from django.core.exceptions import ImproperlyConfigured
+from django.test import SimpleTestCase
+
+
+class SettingsTests(SimpleTestCase):
+    def test_missing_secret_key_uses_dev_fallback_when_debug_enabled(self):
+        with patch.dict(os.environ, {"DEBUG": "True"}, clear=False):
+            os.environ.pop("SECRET_KEY", None)
+            settings_module = importlib.import_module("core.settings")
+            reloaded_module = importlib.reload(settings_module)
+
+            self.assertEqual(reloaded_module.SECRET_KEY, "dev-secret-key-for-local-testing")
+
+    def test_missing_secret_key_raises_when_debug_disabled(self):
+        with patch.dict(os.environ, {"DEBUG": "False"}, clear=False):
+            os.environ.pop("SECRET_KEY", None)
+            settings_module = importlib.import_module("core.settings")
+
+            with self.assertRaises(ImproperlyConfigured):
+                importlib.reload(settings_module)


### PR DESCRIPTION
## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #2321

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

## Screenshots (if applicable)

Add screenshots to demonstrate visual changes.

## Additional Notes

Any additional information reviewers should know.
