### PR TITLE
fix: prevent username disclosure in password reset

### DIFF
--- a/game/templates/game/password_reset.html
+++ b/game/templates/game/password_reset.html
@@ -45,49 +45,6 @@
             <button type="submit" class="btn btn-gold">Send Reset Link</button>
         </form>
 
-        {% if usernames %}
-
-            <div class="auth-card" style="margin-top: 20px;">
-
-                <h3>Select Your Account</h3>
-
-                {% for username in usernames %}
-
-                    <form
-                        method="POST"
-                        action="{% url 'password_reset' %}"
-                        style="margin-top: 10px;"
-                    >
-
-                        {% csrf_token %}
-
-                        <input
-                            type="hidden"
-                            name="email"
-                            value="{{ email }}"
-                        >
-
-                        <input
-                            type="hidden"
-                            name="selected_username"
-                            value="{{ username }}"
-                        >
-
-                        <button
-                            type="submit"
-                            class="btn btn-gold"
-                            style="width: 100%;"
-                        >
-                            {{ username }}
-                        </button>
-
-                    </form>
-
-                {% endfor %}
-                
-            </div>
-
-        {% endif %}
 
         <div class="auth-footer">
             Remember your password? <a href="{% url 'login' %}">Sign In</a>

--- a/game/templates/robots.txt
+++ b/game/templates/robots.txt
@@ -7,6 +7,5 @@ Disallow: /delete-account/
 Disallow: /confirm-delete/
 Disallow: /api
 Disallow: /api/
-Disallow: /password-reset-account-selection/
 
 Sitemap: https://checkora.vercel.app/sitemap.xml

--- a/game/tests.py
+++ b/game/tests.py
@@ -407,6 +407,74 @@ class PasswordResetRateLimitTest(TestCase):
         )
         self.assertEqual(view._client_ip(request), '203.0.113.195')
 
+    def test_password_reset_public_responses_are_indistinguishable(self):
+        """Verify that unknown, single-account, and multi-account submissions
+
+        produce identical public-facing responses (status, redirects, and HTML content)
+        while sending different emails privately.
+        """
+        # Case 1: Unknown email
+        cache.clear()
+        mail.outbox = []
+        response_unknown = self.client.post(
+            self.reset_url,
+            data={'email': 'unknown@example.com'},
+            follow=True,
+        )
+        self.assertEqual(len(mail.outbox), 0)
+
+        # Case 2: Single eligible account
+        cache.clear()
+        mail.outbox = []
+        response_single = self.client.post(
+            self.reset_url,
+            data={'email': 'reset@example.com'},
+            follow=True,
+        )
+        self.assertEqual(len(mail.outbox), 1)
+
+        # Case 3: Multiple eligible accounts sharing the email
+        cache.clear()
+        mail.outbox = []
+        User.objects.create_user(
+            username='resetplayer2',
+            email='reset@example.com',
+            password='StrongPass1234!',  # noqa: S106
+        )
+        response_multi = self.client.post(
+            self.reset_url,
+            data={'email': 'reset@example.com'},
+            follow=True,
+        )
+        self.assertEqual(len(mail.outbox), 2)
+
+        # 1. Compare status codes (all should be 200 after following redirects)
+        self.assertEqual(response_unknown.status_code, 200)
+        self.assertEqual(response_single.status_code, 200)
+        self.assertEqual(response_multi.status_code, 200)
+
+        # 2. Compare redirect chains
+        self.assertEqual(response_unknown.redirect_chain, response_single.redirect_chain)
+        self.assertEqual(response_single.redirect_chain, response_multi.redirect_chain)
+        self.assertEqual(response_unknown.redirect_chain, [(self.done_url, 302)])
+
+        # 3. Compare final HTML content (must be identical)
+        self.assertEqual(response_unknown.content, response_single.content)
+        self.assertEqual(response_single.content, response_multi.content)
+
+        # 4. Verify no account identifiers or selection UIs are leaked in the public HTML
+        for response in [response_unknown, response_single, response_multi]:
+            self.assertNotContains(response, 'Select Your Account')
+            self.assertNotContains(response, 'resetplayer')
+            self.assertNotContains(response, 'resetplayer2')
+            self.assertNotContains(response, 'usernames')
+
+    def test_account_selection_endpoint_is_removed(self):
+        # Verify that the account selection endpoint returns 404
+        url = '/password-reset-account-selection/'
+        response = self.client.get(url, {'email': 'reset@example.com'})
+        self.assertEqual(response.status_code, 404)
+
 
 class MoveValidationTest(TestCase):
     """Test move validation wrapper by mocking validate_move."""

--- a/game/urls.py
+++ b/game/urls.py
@@ -34,11 +34,6 @@ urlpatterns = [
     # Account Settings & Recovery
     path('delete-account/', views.delete_account, name='delete_account'),
     path('confirm-delete/<uidb64>/<token>/', views.confirm_delete_account, name='confirm_delete_account'),
-    path(
-        'password-reset-account-selection/',
-        views.password_reset_account_selection,
-        name='password_reset_account_selection'
-    ),
 
     # Avatar Management
     path('avatar/', views.upload_avatar, name='upload_avatar'),

--- a/game/views.py
+++ b/game/views.py
@@ -1518,17 +1518,6 @@ class CustomPasswordResetView(PasswordResetView):
         else:
             cache.set(ip_expires_key, time.time() + ip_timeout, timeout=ip_timeout)
 
-    def _single_user_form(self, selected_user):
-        base_form = self.get_form_class()
-
-        class SingleUserPasswordResetForm(base_form):
-            def get_users(self, email):
-                if selected_user and selected_user.has_usable_password():
-                    return [selected_user]
-                return []
-
-        return SingleUserPasswordResetForm
-
     def post(self, request, *args, **kwargs):
 
         email = request.POST.get('email', '').strip().lower()
@@ -1540,48 +1529,7 @@ class CustomPasswordResetView(PasswordResetView):
 
             return redirect('password_reset')
 
-        users = User.objects.filter(email__iexact=email)
-
-        if users.count() > 1 and not request.POST.get(
-            'selected_username'
-        ):
-
-            usernames = users.values_list(
-                'username',
-                flat=True
-            )
-
-            return render(
-                request,
-                'game/password_reset.html',
-                {
-                    'form': self.get_form(),
-                    'usernames': usernames,
-                    'email': email
-                }
-            )
-        selected_username = request.POST.get(
-            'selected_username'
-        )
-
-        form_class = self.get_form_class()
-        if selected_username:
-
-            selected_user = User.objects.filter(
-                username=selected_username,
-                email__iexact=email
-            ).first()
-
-            if not selected_user:
-                messages.error(
-                    request,
-                    'Please select a valid account for this email address.',
-                )
-                return redirect('password_reset')
-
-            form_class = self._single_user_form(selected_user)
-
-        form = form_class(**self.get_form_kwargs())
+        form = self.get_form()
         if not form.is_valid():
             return self.form_invalid(form)
 
@@ -2334,22 +2282,6 @@ def cleanup_cron(request):
             'status': 'error',
             'message': str(e)
         }, status=500)
-
-def password_reset_account_selection(request):
-
-    email = request.GET.get('email')
-
-    users = User.objects.filter(email=email)
-
-    return render(
-        request,
-        'game/password_reset_account_selection.html',
-        {
-            'users': users,
-            'email': email
-        }
-    )
-
 
 @login_required
 def delete_account(request):


### PR DESCRIPTION
## Description

Fixes an account-enumeration vulnerability in the password reset flow where usernames associated with a shared email address could be disclosed to unauthenticated users.

This PR removes the public account-selection flow and ensures unknown-email, single-account, and multi-account password reset requests use the same generic public response flow.

The standard Django password reset mechanism now handles eligible accounts privately through reset emails, while the existing cooldown and IP throttling protections remain in place.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

## Related Issue

Fixes #2097

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] I have commented my code where necessary
* [x] I have updated the documentation if needed
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix/feature works
* [x] New and existing relevant tests pass locally

## Screenshots (if applicable)

Not applicable. This is a password reset security fix with no new visual UI functionality.

## Additional Notes

Changes include:

* Removed public username disclosure from the password reset flow.
* Removed the username-based account-selection form.
* Removed the obsolete public account-selection endpoint and URL route.
* Removed the corresponding stale `robots.txt` entry.
* Added regression tests for unknown-email, single-account, and multi-account reset behavior.
* Added coverage confirming that the removed account-selection endpoint returns 404.
* Existing email cooldown and IP throttling behavior remains intact.

Verification performed:

`python manage.py test game.tests.PasswordResetRateLimitTest`

Result:

`Ran 12 tests in 8.708s — OK`

The changes are strictly scoped to Issue #2097 and its regression coverage.
