### PR TITLE
Fix/paginate your and bookmarked forum tabs

### DIFF
--- a/game/templates/game/forum_list.html
+++ b/game/templates/game/forum_list.html
@@ -136,9 +136,9 @@
         </div>
 
         {% if user.is_authenticated %}
-        <div class="forum-tab-panel" id="tab-your">
+       <div class="forum-tab-panel" id="tab-your">
             <div class="forum-list">
-                {% for discussion in user_discussions %}
+                {% for discussion in your_page_obj %}
                     {% include "game/forum_discussion_card.html" with discussion=discussion %}
                 {% empty %}
                 <div class="forum-empty">
@@ -146,11 +146,25 @@
                 </div>
                 {% endfor %}
             </div>
+
+            {% if your_page_obj.paginator.num_pages > 1 %}
+            <div class="forum-pagination">
+                {% if your_page_obj.has_previous %}
+                    <a href="?your_page={{ your_page_obj.previous_page_number }}{% if sort_by %}&sort={{ sort_by }}{% endif %}" class="forum-page-link">← Prev</a>
+                {% endif %}
+
+                <span class="forum-page-current">Page {{ your_page_obj.number }} of {{ your_page_obj.paginator.num_pages }}</span>
+
+                {% if your_page_obj.has_next %}
+                    <a href="?your_page={{ your_page_obj.next_page_number }}{% if sort_by %}&sort={{ sort_by }}{% endif %}" class="forum-page-link">Next →</a>
+                {% endif %}
+            </div>
+            {% endif %}
         </div>
 
         <div class="forum-tab-panel" id="tab-bookmarked">
             <div class="forum-list">
-                {% for discussion in bookmarked_discussions %}
+                {% for discussion in bookmarked_page_obj %}
                     {% include "game/forum_discussion_card.html" with discussion=discussion %}
                 {% empty %}
                 <div class="forum-empty">
@@ -158,6 +172,20 @@
                 </div>
                 {% endfor %}
             </div>
+
+            {% if bookmarked_page_obj.paginator.num_pages > 1 %}
+            <div class="forum-pagination">
+                {% if bookmarked_page_obj.has_previous %}
+                    <a href="?bookmarked_page={{ bookmarked_page_obj.previous_page_number }}{% if sort_by %}&sort={{ sort_by }}{% endif %}" class="forum-page-link">← Prev</a>
+                {% endif %}
+
+                <span class="forum-page-current">Page {{ bookmarked_page_obj.number }} of {{ bookmarked_page_obj.paginator.num_pages }}</span>
+
+                {% if bookmarked_page_obj.has_next %}
+                    <a href="?bookmarked_page={{ bookmarked_page_obj.next_page_number }}{% if sort_by %}&sort={{ sort_by }}{% endif %}" class="forum-page-link">Next →</a>
+                {% endif %}
+            </div>
+            {% endif %}
         </div>
         {% endif %}
 

--- a/game/test_forum.py
+++ b/game/test_forum.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth import get_user_model
-from game.models import Discussion
+from game.models import Discussion, DiscussionBookmark
 
 User = get_user_model()
 
@@ -61,3 +61,79 @@ class ForumPaginationTests(TestCase):
         
         html = response.content.decode("utf-8")
         self.assertIn("?page=1&sort=oldest", html)
+
+
+class ForumYourDiscussionsPaginationTests(TestCase):
+    """The 'Your Discussions' tab must paginate like the 'All Discussions' tab."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="testuser2", password="password")
+        self.client.login(username="testuser2", password="password")
+
+        for i in range(22):
+            Discussion.objects.create(
+                user=self.user,
+                title=f"My Discussion {i}",
+                content=f"Content {i}"
+            )
+        self.forum_url = reverse("forum")
+
+    def test_your_discussions_first_page_is_capped_at_20(self):
+        response = self.client.get(self.forum_url)
+        self.assertEqual(response.status_code, 200)
+
+        your_page_obj = response.context["your_page_obj"]
+        self.assertEqual(your_page_obj.paginator.num_pages, 2)
+        self.assertEqual(len(your_page_obj), 20)
+        self.assertTrue(your_page_obj.has_next())
+
+    def test_your_discussions_second_page(self):
+        response = self.client.get(self.forum_url, {"your_page": 2})
+        self.assertEqual(response.status_code, 200)
+
+        your_page_obj = response.context["your_page_obj"]
+        self.assertEqual(your_page_obj.number, 2)
+        self.assertEqual(len(your_page_obj), 2)
+
+    def test_paging_your_discussions_does_not_affect_main_tab(self):
+        response = self.client.get(self.forum_url, {"your_page": 2, "page": 1})
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(response.context["your_page_obj"].number, 2)
+        self.assertEqual(response.context["page_obj"].number, 1)
+
+
+class ForumBookmarkedDiscussionsPaginationTests(TestCase):
+    """The 'Bookmarked' tab must paginate like the 'All Discussions' tab."""
+
+    def setUp(self):
+        self.owner = User.objects.create_user(username="owner", password="password")
+        self.user = User.objects.create_user(username="bookmarker", password="password")
+        self.client.login(username="bookmarker", password="password")
+
+        for i in range(22):
+            discussion = Discussion.objects.create(
+                user=self.owner,
+                title=f"Bookmarkable Discussion {i}",
+                content=f"Content {i}"
+            )
+            DiscussionBookmark.objects.create(user=self.user, discussion=discussion)
+
+        self.forum_url = reverse("forum")
+
+    def test_bookmarked_first_page_is_capped_at_20(self):
+        response = self.client.get(self.forum_url)
+        self.assertEqual(response.status_code, 200)
+
+        bookmarked_page_obj = response.context["bookmarked_page_obj"]
+        self.assertEqual(bookmarked_page_obj.paginator.num_pages, 2)
+        self.assertEqual(len(bookmarked_page_obj), 20)
+        self.assertTrue(bookmarked_page_obj.has_next())
+
+    def test_bookmarked_second_page(self):
+        response = self.client.get(self.forum_url, {"bookmarked_page": 2})
+        self.assertEqual(response.status_code, 200)
+
+        bookmarked_page_obj = response.context["bookmarked_page_obj"]
+        self.assertEqual(bookmarked_page_obj.number, 2)
+        self.assertEqual(len(bookmarked_page_obj), 2)

--- a/game/views.py
+++ b/game/views.py
@@ -1,3 +1,5 @@
+
+
 """Game views for the Checkora chess platform."""
 import logging
 import json
@@ -4163,6 +4165,8 @@ def apply_discussion_sort(queryset, sort_by):
 def forum_list(request):
     sort_by = request.GET.get("sort", "newest")
     page_number = request.GET.get("page", 1)
+    your_page_number = request.GET.get("your_page", 1)
+    bookmarked_page_number = request.GET.get("bookmarked_page", 1)
 
     discussions = Discussion.objects.select_related("user").prefetch_related("replies")
 
@@ -4174,6 +4178,11 @@ def forum_list(request):
     
     paginator = Paginator(discussions, 20)
     page_obj = paginator.get_page(page_number)
+
+    # Defaults so the template always has a page object to iterate over,
+    # even for anonymous users where these tabs are hidden.
+    your_page_obj = Paginator(Discussion.objects.none(), 20).get_page(1)
+    bookmarked_page_obj = Paginator(Discussion.objects.none(), 20).get_page(1)
 
     if request.user.is_authenticated:
         user_discussions = (
@@ -4198,6 +4207,15 @@ def forum_list(request):
         user_discussions = apply_discussion_sort(user_discussions, sort_by)
         bookmarked_discussions = apply_discussion_sort(bookmarked_discussions, sort_by)
 
+        # Same 20-per-page pagination as the "All Discussions" tab, but with
+        # their own page query params so paging one tab doesn't affect the
+        # others.
+        your_paginator = Paginator(user_discussions, 20)
+        your_page_obj = your_paginator.get_page(your_page_number)
+
+        bookmarked_paginator = Paginator(bookmarked_discussions, 20)
+        bookmarked_page_obj = bookmarked_paginator.get_page(bookmarked_page_number)
+
         bookmarked_ids = set(
             request.user.discussion_bookmarks.values_list(
                 "discussion_id",
@@ -4212,7 +4230,9 @@ def forum_list(request):
             "page_obj": page_obj,
             "discussions": discussions,
             "user_discussions": user_discussions,
+            "your_page_obj": your_page_obj,
             "bookmarked_discussions": bookmarked_discussions,
+            "bookmarked_page_obj": bookmarked_page_obj,
             "bookmarked_ids": bookmarked_ids,
             "sort_by": sort_by,
         }


### PR DESCRIPTION
Description
The "All Discussions" tab on the forum page was paginated in PR #2326, but the "Your Discussions" and "Bookmarked" tabs were missed and still render their entire, unpaginated querysets. This PR adds the same 20-per-page pagination to both tabs, using separate your_page and bookmarked_page query params so paging one tab doesn't reset the others, along with matching pagination UI controls and test coverage.
Type of Change

 Bug fix (non-breaking change that fixes an issue)
 New feature (non-breaking change that adds functionality)
 Breaking change (fix or feature that would cause existing functionality to change)
 Documentation update

Related Issue
Fixes #2351
Checklist

 My code follows the project's style guidelines
 I have performed a self-review of my code
 I have commented my code where necessary
 I have updated the documentation if needed
 My changes generate no new warnings
 I have added tests that prove my fix/feature works
 New and existing tests pass locally


Additional Notes:

game/views.py: forum_list now builds your_page_obj and bookmarked_page_obj via Paginator(..., 20), mirroring the existing page_obj pattern for "All Discussions."
game/templates/game/forum_list.html: both tabs now loop over their paginated objects and show Prev/Next controls, matching the "All Discussions" tab's markup/styling.
game/test_forum.py: added ForumYourDiscussionsPaginationTests and ForumBookmarkedDiscussionsPaginationTests, covering page counts, second-page contents, and that paging one tab doesn't affect another.
Ran python manage.py test game.test_forum --verbosity=2 locally — all 9 tests pass (4 existing + 5 new).



