### PR TITLE
fix: align navbar buttons and theme toggle spacing

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -118,7 +118,7 @@ body {
     color: #f0c040;
 }
 
-.theme-toggle {
+.header .theme-toggle {
     position: absolute;
     top: 0;
     right: 0;
@@ -133,7 +133,7 @@ body {
     transition: background 0.25s ease, color 0.25s ease, transform 0.25s ease;
 }
 
-.theme-toggle:hover {
+.header .theme-toggle:hover {
     background: rgba(255, 255, 255, 0.08);
 }
 


### PR DESCRIPTION
## Description

This PR improves the alignment and spacing of the navbar controls for a more consistent and polished appearance.

### Changes made:
- Scoped board-specific `.theme-toggle` styles to prevent them from affecting the shared navbar.
- Improved alignment of the theme toggle with the other navbar controls.
- Maintained consistent spacing and vertical alignment between the cursor selector, authentication buttons, and theme toggle.
- Preserved the existing responsive behavior across different screen sizes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #2325

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

<img width="1412" height="802" alt="Screenshot 2026-07-11 at 11 53 19 PM" src="https://github.com/user-attachments/assets/2e5af01d-c049-47bd-9c54-a976a70edb1d" />

### Before
- Theme toggle appeared misaligned and too close to the navbar edge.

### After
- Theme toggle is aligned with the cursor selector and authentication buttons, with consistent spacing across the navbar.

## Additional Notes

This change is limited to navbar layout and styling. No functional behavior has been modified.
