### PR TITLE
fix(#1445): compute legal move highlights client-side to eliminate ~1…

### DIFF
--- a/board.test.js
+++ b/board.test.js
@@ -236,6 +236,9 @@ global.Chess = class MockChess {
       // Simulate a pawn about to promote
       return [
         { from: 'e7', to: 'e8', piece: 'p', captured: undefined, promotion: 'q' },
+        { from: 'e7', to: 'e8', piece: 'p', captured: undefined, promotion: 'r' },
+        { from: 'e7', to: 'e8', piece: 'p', captured: undefined, promotion: 'b' },
+        { from: 'e7', to: 'e8', piece: 'p', captured: undefined, promotion: 'n' },
       ];
     }
     return [];
@@ -833,12 +836,15 @@ describe("Client-side legal move computation (Issue #1445)", () => {
       expect(result[0].is_promotion).toBe(false);
     });
 
-    it('marks is_promotion=true when promotion field is present', () => {
+    it('marks is_promotion=true when promotion field is present and deduplicates promotion moves', () => {
       // e7 pawn promoting per MockChess stub
       const result = computeLegalMovesClient(1, 4); // e7
       expect(result).not.toBeNull();
+      // Even though MockChess returns 4 promotion moves (q, r, b, n), they are deduplicated by destination
       expect(result.length).toBe(1);
       expect(result[0].is_promotion).toBe(true);
+      expect(result[0].row).toBe(0); // e8 -> row 0
+      expect(result[0].col).toBe(4); // e8 -> col 4
     });
 
     it('returns null when window.Chess is unavailable', () => {

--- a/board.test.js
+++ b/board.test.js
@@ -77,7 +77,6 @@ document.body.innerHTML = `
 `;
 
 
-
 global.fetch = jest.fn((url, options) => {
   let boardData = [
     ['r', 'n', 'b', 'q', 'k', 'b', 'n', 'r'],
@@ -214,6 +213,33 @@ global.Chess = class MockChess {
     
     return { from: 'a1', to: 'a2' };
   }
+  /**
+   * Minimal stub used by computeLegalMovesClient (Issue #1445 tests).
+   * When called with { square: 'e2', verbose: true } it returns two
+   * representative moves for a white pawn on e2.
+   */
+  moves({ square, verbose } = {}) {
+    if (!verbose) return [];
+    if (square === 'e2') {
+      return [
+        { from: 'e2', to: 'e3', piece: 'p', captured: undefined, promotion: undefined },
+        { from: 'e2', to: 'e4', piece: 'p', captured: undefined, promotion: undefined },
+      ];
+    }
+    if (square === 'a1') {
+      // Simulate a rook that can capture on a8 (to test is_capture mapping)
+      return [
+        { from: 'a1', to: 'a8', piece: 'r', captured: 'r', promotion: undefined },
+      ];
+    }
+    if (square === 'e7') {
+      // Simulate a pawn about to promote
+      return [
+        { from: 'e7', to: 'e8', piece: 'p', captured: undefined, promotion: 'q' },
+      ];
+    }
+    return [];
+  }
 };
 
 global.SOUND_BASE_URL = '/static/game/sounds/';
@@ -233,7 +259,7 @@ window.matchMedia = window.matchMedia || function() {
   };
 };
 
-const { pColor, getSquareLabel, formatTime, getPlayerScore, validateMoveWithStockfish, clearEvaluationCache, onClick, onDragStart, onDrop, showPromoModal, hidePromoModal, onPromoChoice, toggleSquareHighlight, refreshHighlights, highlightCheck, startNewGame } = require("./game/static/game/js/board");
+const { pColor, getSquareLabel, formatTime, getPlayerScore, validateMoveWithStockfish, clearEvaluationCache, onClick, onDragStart, onDrop, showPromoModal, hidePromoModal, onPromoChoice, toggleSquareHighlight, refreshHighlights, highlightCheck, startNewGame, squareLabelToRowCol, computeLegalMovesClient } = require("./game/static/game/js/board");
 
 describe("pColor", () => {
   test("returns white for uppercase piece", () => {
@@ -755,3 +781,109 @@ describe("SAN Quick Move Input", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Issue #1445: client-side legal move computation
+// ---------------------------------------------------------------------------
+describe("Client-side legal move computation (Issue #1445)", () => {
+  describe("squareLabelToRowCol", () => {
+    it('converts a8 to row=0, col=0', () => {
+      expect(squareLabelToRowCol('a8')).toEqual({ row: 0, col: 0 });
+    });
+
+    it('converts h1 to row=7, col=7', () => {
+      expect(squareLabelToRowCol('h1')).toEqual({ row: 7, col: 7 });
+    });
+
+    it('converts e4 to row=4, col=4', () => {
+      expect(squareLabelToRowCol('e4')).toEqual({ row: 4, col: 4 });
+    });
+
+    it('converts e3 to row=5, col=4', () => {
+      expect(squareLabelToRowCol('e3')).toEqual({ row: 5, col: 4 });
+    });
+
+    it('converts e8 to row=0, col=4', () => {
+      expect(squareLabelToRowCol('e8')).toEqual({ row: 0, col: 4 });
+    });
+  });
+
+  describe("computeLegalMovesClient", () => {
+    it('returns a non-null array when chess.js is available', () => {
+      const result = computeLegalMovesClient(6, 4); // e2 pawn
+      expect(result).not.toBeNull();
+      expect(Array.isArray(result)).toBe(true);
+    });
+
+    it('maps pawn moves for e2 correctly (two forward squares)', () => {
+      const result = computeLegalMovesClient(6, 4); // e2 square
+      // MockChess.moves returns e3 and e4 for e2
+      expect(result.length).toBe(2);
+      // e3 => row 5, col 4
+      expect(result).toContainEqual({ row: 5, col: 4, is_capture: false, is_promotion: false });
+      // e4 => row 4, col 4
+      expect(result).toContainEqual({ row: 4, col: 4, is_capture: false, is_promotion: false });
+    });
+
+    it('marks is_capture=true when captured field is present', () => {
+      // a1 rook capturing a8 per MockChess stub
+      const result = computeLegalMovesClient(7, 0); // a1
+      expect(result).not.toBeNull();
+      expect(result.length).toBe(1);
+      expect(result[0].is_capture).toBe(true);
+      expect(result[0].is_promotion).toBe(false);
+    });
+
+    it('marks is_promotion=true when promotion field is present', () => {
+      // e7 pawn promoting per MockChess stub
+      const result = computeLegalMovesClient(1, 4); // e7
+      expect(result).not.toBeNull();
+      expect(result.length).toBe(1);
+      expect(result[0].is_promotion).toBe(true);
+    });
+
+    it('returns null when window.Chess is unavailable', () => {
+      const saved = global.Chess;
+      global.Chess = undefined;
+      try {
+        const result = computeLegalMovesClient(6, 4);
+        expect(result).toBeNull();
+      } finally {
+        global.Chess = saved;
+      }
+    });
+
+    it('returns an empty array for a square with no legal moves', () => {
+      // MockChess returns [] for any square not explicitly handled
+      const result = computeLegalMovesClient(3, 3); // d5, no piece stub
+      expect(result).not.toBeNull();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("onClick does not call /api/valid-moves/ when chess.js is available", () => {
+    beforeEach(async () => {
+      document.getElementById("board").innerHTML = "";
+      global.fetch.mockClear();
+      await startNewGame('pvp', 'white', 'medium', null, 10);
+    });
+
+    it('clicking a piece never calls /api/valid-moves/ (uses client computation)', async () => {
+      await onClick(6, 4); // click the e2 pawn
+      const validMovesReqs = global.fetch.mock.calls.filter(
+        c => c[0] && c[0].includes('/api/valid-moves/')
+      );
+      expect(validMovesReqs.length).toBe(0);
+    });
+
+    it('clicking a piece still shows hints without a network round-trip', async () => {
+      // computeLegalMovesClient returns moves synchronously so the board
+      // should have hint dots right after onClick resolves.
+      await onClick(6, 4);
+      const boardEl = document.getElementById('board');
+      // The highlights are added via refreshHighlights -> sq().appendChild(div.move-dot)
+      const dots = boardEl.querySelectorAll('.move-dot');
+      // MockChess returns 2 moves for e2 (e3, e4) - both are non-captures
+      expect(dots.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -760,6 +760,9 @@
     let aiRequestSeq = 0; // Sequence token to cancel stale AI responses
     let analysisRequestSeq = 0; // Sequence token to cancel stale analysis responses
     const DEFAULT_START_FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
+    // Tracks the full FEN of the current live position so legal moves can be
+    // computed on the client without a server round-trip (Issue #1445).
+    let liveFen = DEFAULT_START_FEN;
     let gameFens = [];
     let stepperIndex = 0;
     let viewingPastState = false;
@@ -1208,7 +1211,7 @@
         }
 
         board = parseBoard(data.board);
-        console.log("SERVER DATA ON AI MOVE:", data);
+        if (data.fen) liveFen = data.fen;
         turn = data.current_turn;
         whiteTime = data.white_time;
         blackTime = data.black_time;
@@ -1604,6 +1607,49 @@
     /* ==========================================================
     SELECTION & MOVES
     ========================================================== */
+
+    /**
+     * Convert a chess.js square label (e.g. "e4") to board array indices.
+     * board[0][0] == a8, board[7][7] == h1.
+     */
+    function squareLabelToRowCol(square) {
+        const file = square.charCodeAt(0) - 97; // 'a'=0 … 'h'=7
+        const rank = parseInt(square[1], 10);    // 1–8
+        const row  = 8 - rank;                   // rank 8 → row 0
+        return { row, col: file };
+    }
+
+    /**
+     * Compute legal moves for the piece at (r, c) using the chess.js library
+     * that is already loaded on the page.  Returns an array of
+     * { row, col, is_capture, is_promotion } objects — the same shape that
+     * /api/valid-moves/ returns — so the rest of the UI is unchanged.
+     *
+     * Returns null if chess.js is not available so callers can fall back.
+     */
+    function computeLegalMovesClient(r, c) {
+        if (!window.Chess) return null;
+        try {
+            const chess = new window.Chess(liveFen);
+            const fromSquare = getSquareLabel(r, c); // e.g. "e2"
+            const moves = chess.moves({ square: fromSquare, verbose: true });
+            if (!moves) return null;
+            return moves.map(m => {
+                const { row, col } = squareLabelToRowCol(m.to);
+                return {
+                    row,
+                    col,
+                    is_capture:   m.captured !== undefined,
+                    is_promotion: m.promotion !== undefined,
+                };
+            });
+        } catch (e) {
+            // Unexpected chess.js error — caller will fall back to the API.
+            console.warn('computeLegalMovesClient error:', e);
+            return null;
+        }
+    }
+
     async function selectPiece(r, c) {
         const isPremoveMode = gameMode === 'ai' && turn !== playerColor;
         const vBoard = isPremoveMode ? getVirtualBoard() : board;
@@ -1625,11 +1671,18 @@
             return;
         }
 
-        // NORMAL MOVE LOGIC
+        // NORMAL MOVE LOGIC — try client-side first (Issue #1445)
+        const clientMoves = computeLegalMovesClient(r, c);
+        if (clientMoves !== null) {
+            // Instant: no network request needed.
+            hints = clientMoves;
+            refreshHighlights();
+            return;
+        }
+
+        // Fallback: chess.js unavailable — ask the server.
         const data = await get(`/api/valid-moves/?row=${r}&col=${c}`);
-
         hints = data.valid_moves || [];
-
         refreshHighlights();
     }
     function toggleSquareHighlight(r, c) {
@@ -1814,6 +1867,7 @@
                 playSound(data);
                 if (!skipAnimation) await animateMove(fr, fc, tr, tc);
                 board = parseBoard(data.board);
+                if (data.fen) liveFen = data.fen;
                 turn = data.current_turn;
 
                 const hasThreefoldWarning = data.threefold_warning;
@@ -2100,6 +2154,7 @@
 
                 await animateMove(mv.from_row, mv.from_col, mv.to_row, mv.to_col);
                 board = parseBoard(data.board);
+                if (data.fen) liveFen = data.fen;
                 turn = data.current_turn;
                 if (data.threefold_warning) {
                     showStatus(
@@ -3758,6 +3813,7 @@ function updateStepperUI() {
 
         board = d.board;
         turn = d.current_turn;
+        if (d.fen) liveFen = d.fen;
         paused = false;
         gameOver = false;
         whiteAlertFired = false;
@@ -5259,7 +5315,8 @@ function updateStepperUI() {
     if (typeof module !== "undefined" && module.exports) {
         module.exports = { 
             pColor, getSquareLabel, formatTime, getPlayerScore, validateMoveWithStockfish, clearEvaluationCache,
-            onClick, onDragStart, onDrop, showPromoModal, hidePromoModal, onPromoChoice, toggleSquareHighlight, refreshHighlights, highlightCheck, startNewGame
+            onClick, onDragStart, onDrop, showPromoModal, hidePromoModal, onPromoChoice, toggleSquareHighlight, refreshHighlights, highlightCheck, startNewGame,
+            squareLabelToRowCol, computeLegalMovesClient
         };
     } else {
         loadGame();

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1634,15 +1634,23 @@
             const fromSquare = getSquareLabel(r, c); // e.g. "e2"
             const moves = chess.moves({ square: fromSquare, verbose: true });
             if (!moves) return null;
-            return moves.map(m => {
-                const { row, col } = squareLabelToRowCol(m.to);
-                return {
-                    row,
-                    col,
-                    is_capture:   m.captured !== undefined,
-                    is_promotion: m.promotion !== undefined,
-                };
-            });
+
+            const seen = new Set();
+            return moves
+                .filter(m => {
+                    if (seen.has(m.to)) return false;
+                    seen.add(m.to);
+                    return true;
+                })
+                .map(m => {
+                    const { row, col } = squareLabelToRowCol(m.to);
+                    return {
+                        row,
+                        col,
+                        is_capture:   m.captured !== undefined,
+                        is_promotion: m.promotion !== undefined,
+                    };
+                });
         } catch (e) {
             // Unexpected chess.js error — caller will fall back to the API.
             console.warn('computeLegalMovesClient error:', e);


### PR DESCRIPTION
## Description

This PR fixes the noticeable delay when displaying legal move highlights after selecting a chess piece.

### Changes made

* Compute legal moves on the client using the existing `chess.js` board state instead of requesting them from the server on every piece click.
* Keep the existing server-side validation for actual move submission to preserve game integrity.
* Add a fallback to the `/api/valid-moves/` endpoint if `chess.js` is unavailable.
* Track the current game FEN to ensure client-side move generation stays synchronized with the board.
* Add comprehensive unit tests covering:

  * Square-to-board coordinate conversion.
  * Client-side legal move generation.
  * Capture and promotion move mapping.
  * Fallback behavior.
  * Verification that no `/api/valid-moves/` request is made when client-side computation is available.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

## Related Issue

Fixes #1445

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] I have commented my code where necessary
* [ ] I have updated the documentation if needed
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix works
* [x] New and existing tests pass locally

## Screenshots (if applicable)

N/A – this change improves responsiveness and does not introduce visible UI changes.

## Additional Notes

Legal move highlights are now computed locally using the existing `chess.js` library, eliminating the network round-trip before rendering move indicators. The backend continues to validate submitted moves, so gameplay rules and security remain unchanged.
