### PR TITLE
security: remove OTP leak to stdout in DEBUG mode

### DIFF
--- a/game/tests.py
+++ b/game/tests.py
@@ -156,7 +156,7 @@ class RegistrationViewTest(TestCase):
         EMAIL_HOST_USER='',
         EMAIL_HOST_PASSWORD=''
     )
-    def test_missing_email_credentials_prints_otp_in_debug(self):
+    def test_missing_email_credentials_does_not_fail_registration(self):
         payload = {
             'username': 'devplayer',
             'email': 'devplayer@example.com',
@@ -164,19 +164,10 @@ class RegistrationViewTest(TestCase):
             'password2': 'StrongPass123!',
         }
 
-        with mock.patch('builtins.print') as mock_print:
-            response = self.client.post('/register/', data=payload, follow=True)
+        response = self.client.post('/register/', data=payload, follow=True)
 
         self.assertRedirects(response, '/verify-otp/')
-        self.assertNotContains(response, 'Development mode OTP')
         self.assertTrue(User.objects.filter(username='devplayer').exists())
-        printed_messages = ' '.join(
-            str(arg)
-            for call in mock_print.call_args_list
-            for arg in call.args
-        )
-        self.assertIn('Development registration OTP', printed_messages)
-        self.assertIn('devplayer@example.com', printed_messages)
 
     @override_settings(
         EMAIL_HOST_USER='sender@example.com',

--- a/game/views.py
+++ b/game/views.py
@@ -1113,10 +1113,6 @@ def register_view(request):
                 )
 
                 if settings.DEBUG and missing_email_credentials:
-                    print(
-                        f"[Checkora] Development registration OTP "
-                        f"for {user.email}: {otp}"
-                    )
                     messages.success(
                         request,
                         'If your details are valid, a verification '


### PR DESCRIPTION
Fixes #2343 by completely removing the stdout print statement that leaked the OTP. The test has been updated to reflect this.