### PR TITLE
security: prevent client from spoofing resigning_player in AI games

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -895,15 +895,18 @@ def resign_game(request):
     if game.game_status != 'active':
         return JsonResponse({'valid': False, 'message': 'Game is already over.'}, status=400)
 
-    import json
-    try:
-        data = json.loads(request.body)
-        resigning_player = data.get('resigning_player')
-    except (json.JSONDecodeError, AttributeError, ValueError):
-        resigning_player = None
-
-    if resigning_player not in ['white', 'black']:
-        resigning_player = game.player_color if game.mode == 'ai' else game.current_turn
+    if game.mode == 'ai':
+        resigning_player = game.player_color
+    else:
+        import json
+        try:
+            data = json.loads(request.body)
+            resigning_player = data.get('resigning_player')
+        except (json.JSONDecodeError, AttributeError, ValueError):
+            resigning_player = None
+            
+        if resigning_player not in ['white', 'black']:
+            resigning_player = game.current_turn
 
     winner = 'black' if resigning_player == 'white' else 'white'
     game_status = 'resignation'


### PR DESCRIPTION
Fixes #2341 by enforcing that the resigning player is always the human player's color when playing against the AI, ignoring the client payload.