### PR TITLE
feat: add customizable chess pieces theme selection to settings modal

### DIFF
--- a/board.test.js
+++ b/board.test.js
@@ -262,7 +262,7 @@ window.matchMedia = window.matchMedia || function() {
   };
 };
 
-const { pColor, getSquareLabel, formatTime, getPlayerScore, validateMoveWithStockfish, clearEvaluationCache, onClick, onDragStart, onDrop, showPromoModal, hidePromoModal, onPromoChoice, toggleSquareHighlight, refreshHighlights, highlightCheck, startNewGame, squareLabelToRowCol, computeLegalMovesClient } = require("./game/static/game/js/board");
+const { pColor, getSquareLabel, formatTime, getPlayerScore, validateMoveWithStockfish, clearEvaluationCache, onClick, onDragStart, onDrop, showPromoModal, hidePromoModal, onPromoChoice, toggleSquareHighlight, refreshHighlights, highlightCheck, startNewGame, squareLabelToRowCol, computeLegalMovesClient, updatePieceStyle, PIECE_IMG, VALID_PIECE_STYLES } = require("./game/static/game/js/board");
 
 describe("pColor", () => {
   test("returns white for uppercase piece", () => {
@@ -890,6 +890,28 @@ describe("Client-side legal move computation (Issue #1445)", () => {
       const dots = boardEl.querySelectorAll('.move-dot');
       // MockChess returns 2 moves for e2 (e3, e4) - both are non-captures
       expect(dots.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("Customizable Piece Styles Theme", () => {
+    it("has a list of valid piece styles including neo, classic, alpha, cburnett", () => {
+      expect(VALID_PIECE_STYLES).toContain("neo");
+      expect(VALID_PIECE_STYLES).toContain("classic");
+      expect(VALID_PIECE_STYLES).toContain("alpha");
+      expect(VALID_PIECE_STYLES).toContain("cburnett");
+    });
+
+    it("updates PIECE_IMG correctly when updatePieceStyle is called", () => {
+      updatePieceStyle("classic");
+      expect(PIECE_IMG["wk"]).toBe("https://images.chesscomfiles.com/chess-themes/pieces/classic/150/wk.png");
+      expect(PIECE_IMG["bp"]).toBe("https://images.chesscomfiles.com/chess-themes/pieces/classic/150/bp.png");
+      
+      updatePieceStyle("alpha");
+      expect(PIECE_IMG["wk"]).toBe("https://images.chesscomfiles.com/chess-themes/pieces/alpha/150/wk.png");
+      
+      // Falls back to neo if invalid theme is given
+      updatePieceStyle("invalid_theme_name");
+      expect(PIECE_IMG["wk"]).toBe("https://images.chesscomfiles.com/chess-themes/pieces/neo/150/wk.png");
     });
   });
 });

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -5367,7 +5367,7 @@ function updateStepperUI() {
         module.exports = { 
             pColor, getSquareLabel, formatTime, getPlayerScore, validateMoveWithStockfish, clearEvaluationCache,
             onClick, onDragStart, onDrop, showPromoModal, hidePromoModal, onPromoChoice, toggleSquareHighlight, refreshHighlights, highlightCheck, startNewGame,
-            squareLabelToRowCol, computeLegalMovesClient
+            squareLabelToRowCol, computeLegalMovesClient, updatePieceStyle, PIECE_IMG, VALID_PIECE_STYLES
         };
     } else {
         loadGame();

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -13,20 +13,23 @@
         k: 0
     };
 
-    const savedPieceStyle = localStorage.getItem('pieceStyle') || 'neo';
+    const VALID_PIECE_STYLES = ['neo', 'classic', 'alpha', 'cburnett'];
     const PIECE_IMG = {};
-    for (const c of ['w', 'b']) {
-        for (const t of ['k', 'q', 'r', 'b', 'n', 'p']) {
-            PIECE_IMG[c + t] = `https://images.chesscomfiles.com/chess-themes/pieces/${savedPieceStyle}/150/${c}${t}.png`;
+
+    function buildPieceImg(style) {
+        const targetStyle = VALID_PIECE_STYLES.includes(style) ? style : 'neo';
+        for (const c of ['w', 'b']) {
+            for (const t of ['k', 'q', 'r', 'b', 'n', 'p']) {
+                PIECE_IMG[c + t] = `https://images.chesscomfiles.com/chess-themes/pieces/${targetStyle}/150/${c}${t}.png`;
+            }
         }
     }
 
+    // Initialize piece style on page load
+    buildPieceImg(localStorage.getItem('pieceStyle'));
+
     function updatePieceStyle(style) {
-        for (const c of ['w', 'b']) {
-            for (const t of ['k', 'q', 'r', 'b', 'n', 'p']) {
-                PIECE_IMG[c + t] = `https://images.chesscomfiles.com/chess-themes/pieces/${style}/150/${c}${t}.png`;
-            }
-        }
+        buildPieceImg(style);
         
         // Re-draw board pieces
         if (typeof syncPieces === 'function') {

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -13,11 +13,34 @@
         k: 0
     };
 
-
+    const savedPieceStyle = localStorage.getItem('pieceStyle') || 'neo';
     const PIECE_IMG = {};
-    for (const c of ['w', 'b'])
-        for (const t of ['k', 'q', 'r', 'b', 'n', 'p'])
-            PIECE_IMG[c + t] = `https://images.chesscomfiles.com/chess-themes/pieces/neo/150/${c}${t}.png`;
+    for (const c of ['w', 'b']) {
+        for (const t of ['k', 'q', 'r', 'b', 'n', 'p']) {
+            PIECE_IMG[c + t] = `https://images.chesscomfiles.com/chess-themes/pieces/${savedPieceStyle}/150/${c}${t}.png`;
+        }
+    }
+
+    function updatePieceStyle(style) {
+        for (const c of ['w', 'b']) {
+            for (const t of ['k', 'q', 'r', 'b', 'n', 'p']) {
+                PIECE_IMG[c + t] = `https://images.chesscomfiles.com/chess-themes/pieces/${style}/150/${c}${t}.png`;
+            }
+        }
+        
+        // Re-draw board pieces
+        if (typeof syncPieces === 'function') {
+            syncPieces();
+        }
+        
+        // Re-draw captured list pieces dynamically
+        document.querySelectorAll('.captured-img').forEach(img => {
+            const key = img.dataset.piece;
+            if (key && PIECE_IMG[key]) {
+                img.src = PIECE_IMG[key];
+            }
+        });
+    }
 
     const PIECE_NAMES = {
         'p': 'Pawn',
@@ -2601,8 +2624,10 @@ function updateStepperUI() {
         // Use createElement instead of innerHTML to prevent XSS and avoid DOM reflows
         const makeImg = (p) => {
             const img = document.createElement('img');
-            img.src = PIECE_IMG[pKey(p)];
+            const key = pKey(p);
+            img.src = PIECE_IMG[key];
             img.className = 'captured-img';
+            img.dataset.piece = key; // Save key for live piece style switching
             const name = pieceNames[p.toLowerCase()] || p;
             img.title = name;
             img.alt = name;
@@ -5093,6 +5118,11 @@ function updateStepperUI() {
             const boardThemeRadio = themeSettingsModal.querySelector(`input[name="boardThemeRadio"][value="${currentBoardTheme}"]`);
             if (boardThemeRadio) boardThemeRadio.checked = true;
 
+            // Sync Piece Style radio
+            const currentPieceStyle = localStorage.getItem('pieceStyle') || 'neo';
+            const pieceStyleRadio = themeSettingsModal.querySelector(`input[name="pieceStyleRadio"][value="${currentPieceStyle}"]`);
+            if (pieceStyleRadio) pieceStyleRadio.checked = true;
+
             // 2. Sync Sound Toggle
             const soundToggle = document.getElementById('modalSoundToggle');
             if (soundToggle) soundToggle.checked = soundEnabled;
@@ -5168,6 +5198,16 @@ function updateStepperUI() {
                         btn.setAttribute('aria-pressed', 'false');
                     }
                 });
+            });
+        });
+
+        // Handle Piece Style swatch switches
+        const pieceRadios = themeSettingsModal.querySelectorAll('input[name="pieceStyleRadio"]');
+        pieceRadios.forEach(radio => {
+            radio.addEventListener('change', () => {
+                const selectedStyle = radio.value;
+                localStorage.setItem('pieceStyle', selectedStyle);
+                updatePieceStyle(selectedStyle);
             });
         });
 

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -671,6 +671,32 @@
             </div>
 
             <div class="theme-modal-section">
+                <h3 class="section-title">Piece Style</h3>
+                <div class="theme-swatches-grid">
+                    <label class="theme-swatch-label">
+                        <input type="radio" name="pieceStyleRadio" value="neo" class="theme-radio-input">
+                        <span class="theme-swatch piece-swatch theme-btn" data-piece-style="neo" title="Neo" style="background-image: url('https://images.chesscomfiles.com/chess-themes/pieces/neo/150/wn.png'); background-size: cover; background-color: rgba(255,255,255,0.05);"></span>
+                        <span class="theme-swatch-name">Neo</span>
+                    </label>
+                    <label class="theme-swatch-label">
+                        <input type="radio" name="pieceStyleRadio" value="classic" class="theme-radio-input">
+                        <span class="theme-swatch piece-swatch theme-btn" data-piece-style="classic" title="Classic" style="background-image: url('https://images.chesscomfiles.com/chess-themes/pieces/classic/150/wn.png'); background-size: cover; background-color: rgba(255,255,255,0.05);"></span>
+                        <span class="theme-swatch-name">Classic</span>
+                    </label>
+                    <label class="theme-swatch-label">
+                        <input type="radio" name="pieceStyleRadio" value="alpha" class="theme-radio-input">
+                        <span class="theme-swatch piece-swatch theme-btn" data-piece-style="alpha" title="Alpha" style="background-image: url('https://images.chesscomfiles.com/chess-themes/pieces/alpha/150/wn.png'); background-size: cover; background-color: rgba(255,255,255,0.05);"></span>
+                        <span class="theme-swatch-name">Alpha</span>
+                    </label>
+                    <label class="theme-swatch-label">
+                        <input type="radio" name="pieceStyleRadio" value="cburnett" class="theme-radio-input">
+                        <span class="theme-swatch piece-swatch theme-btn" data-piece-style="cburnett" title="CBurnett" style="background-image: url('https://images.chesscomfiles.com/chess-themes/pieces/cburnett/150/wn.png'); background-size: cover; background-color: rgba(255,255,255,0.05);"></span>
+                        <span class="theme-swatch-name">CBurnett</span>
+                    </label>
+                </div>
+            </div>
+
+            <div class="theme-modal-section">
                 <h3 class="section-title">Preferences</h3>
                 <div class="pref-switch-row">
                     <label class="pref-label" for="modalSoundToggle">🔊 Sound Enabled</label>


### PR DESCRIPTION
### Description
Fixes #2346 
This PR implements the **Customizable Chess Pieces Theme** feature inside the theme and settings modal, resolving issue #2346. It allows users to personalize their chess board visual experience by selecting different piece styles (Neo, Classic, Alpha, and CBurnett) and having the changes reflect immediately on both the active board and the captured pieces panel without requiring a page refresh.

### Changes Made

#### 1. Frontend UI Update
* **File:** [`game/templates/game/board.html`](file:///Users/nishtha/Desktop/gssoc/checkora/Checkora/game/templates/game/board.html)
* Added a new **Piece Style** section in the Theme & Settings modal.
* Created visual swatches displaying a preview of each style's white knight (`wn.png`) to help users preview themes visually.

#### 2. Settings & LocalStorage Synchronization
* **File:** [`game/static/game/js/board.js`](file:///Users/nishtha/Desktop/gssoc/checkora/Checkora/game/static/game/js/board.js)
* Added a check for `pieceStyle` in `localStorage` on page load, defaulting to `neo`.
* Dynamically generated piece images based on the active style: `https://images.chesscomfiles.com/chess-themes/pieces/${selectedPieceTheme}/150/${c}${t}.png`.
* Synced settings modal radio states when the modal is opened.

#### 3. Smooth Rendering Updates
* Added an `updatePieceStyle` helper that mutates piece images on change.
* Integrated dynamic captured list updates by assigning data attributes (`data-piece`) to captured piece images to switch styles live without redrawing the whole layout.
