### PR TITLE
feat: add first-time visitor onboarding tour

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -589,6 +589,86 @@ body {
 }
 
 /* ============================================================
+   First-time visitor onboarding tour
+   ============================================================ */
+.tour-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.65);
+    z-index: 999998;
+}
+
+.tour-spotlight {
+    position: relative;
+    z-index: 999999;
+    box-shadow: 0 0 0 4px #f0c040, 0 0 16px 4px rgba(240, 192, 64, 0.5);
+    border-radius: 8px;
+    transition: box-shadow 0.2s ease;
+}
+
+.tour-tooltip {
+    position: fixed;
+    z-index: 999999;
+    max-width: 280px;
+    background: var(--card-bg);
+    border: 1px solid #f0c040;
+    border-radius: 10px;
+    padding: 14px 16px;
+    color: var(--text-primary);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+}
+
+.tour-step-label {
+    margin: 0 0 6px;
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: #f0c040;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.tour-step-text {
+    margin: 0 0 12px;
+    font-size: 0.85rem;
+    line-height: 1.4;
+}
+
+.tour-actions {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.tour-skip-btn {
+    background: none;
+    border: none;
+    color: var(--text-primary);
+    opacity: 0.6;
+    font-size: 0.8rem;
+    cursor: pointer;
+}
+
+.tour-skip-btn:hover { opacity: 1; }
+
+.tour-next-btn {
+    background: #f0c040;
+    color: #1a1a2e;
+    border: none;
+    border-radius: 6px;
+    padding: 6px 14px;
+    font-size: 0.8rem;
+    font-weight: 700;
+    cursor: pointer;
+}
+
+@media (max-width: 480px) {
+    .tour-tooltip {
+        max-width: calc(100vw - 32px);
+        font-size: 0.8rem;
+    }
+}
+
+/* ============================================================
    Board Area  (ranks · board grid · files)
    ============================================================ */
 .board-container {

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -83,6 +83,175 @@
     }
 
     /* ==========================================================
+    FIRST-TIME VISITOR ONBOARDING TOUR
+    Shown once per browser (persisted via localStorage), then
+    never shown again unless local storage is cleared.
+    ========================================================== */
+    const TOUR_SEEN_KEY = 'checkoraTourSeen';
+
+    const TOUR_STEPS = [
+        {
+            selector: '#manualMoveInput',
+            text: "Type your move here, like \"e2e4\" — or drag a piece on the board."
+        },
+        {
+            selector: '#gameControlsCard',
+            text: "These are your game controls — flip the board, offer a draw, or resign anytime."
+        },
+        {
+            selector: '#boardThemeCard',
+            text: "Customize your board here — pick a color theme or turn on square coordinates."
+        },
+        {
+            selector: '#sessionScoreTracker',
+            text: "This tracks your wins, losses, and draws for this session. Good luck!"
+        }
+    ];
+
+    let tourStepIndex = 0;
+    let tourActiveTarget = null;
+
+    function hasTourAlreadyBeenSeen() {
+        try {
+            return localStorage.getItem(TOUR_SEEN_KEY) === 'true';
+        } catch (e) {
+            return true; // if localStorage is unavailable, don't force the tour
+        }
+    }
+
+    function markTourAsSeen() {
+        try {
+            localStorage.setItem(TOUR_SEEN_KEY, 'true');
+        } catch (e) {
+            // ignore (e.g. private browsing)
+        }
+    }
+
+    let tourHasBeenTriggeredThisPageLoad = false;
+
+    // Call this right after the welcome/setup screen closes, from any
+    // game-start path. Safe to call multiple times — only runs once.
+    function maybeStartTourAfterWelcomeCloses() {
+        if (tourHasBeenTriggeredThisPageLoad) return;
+        if (hasTourAlreadyBeenSeen()) return;
+        tourHasBeenTriggeredThisPageLoad = true;
+        setTimeout(startTour, 400);
+    }
+
+    function positionTourTooltip(targetEl) {
+        const tooltip = document.getElementById('tourTooltip');
+        const rect = targetEl.getBoundingClientRect();
+        const tooltipHeight = tooltip.offsetHeight || 120;
+        const spacing = 12;
+
+        let top = rect.bottom + spacing;
+        // If tooltip would overflow the bottom of the screen, place it above instead
+        if (top + tooltipHeight > window.innerHeight) {
+            top = rect.top - tooltipHeight - spacing;
+        }
+        if (top < 8) top = 8;
+
+        let left = rect.left;
+        if (left + 280 > window.innerWidth) {
+            left = window.innerWidth - 296;
+        }
+        if (left < 8) left = 8;
+
+        tooltip.style.top = `${top}px`;
+        tooltip.style.left = `${left}px`;
+    }
+
+    function showTourStep(index) {
+        if (tourActiveTarget) {
+            tourActiveTarget.classList.remove('tour-spotlight');
+            tourActiveTarget = null;
+        }
+
+        if (index >= TOUR_STEPS.length) {
+            endTour();
+            return;
+        }
+
+        const step = TOUR_STEPS[index];
+        const targetEl = document.querySelector(step.selector);
+
+        // Skip a step gracefully if that element isn't on the page right now
+        if (!targetEl) {
+            showTourStep(index + 1);
+            return;
+        }
+
+        targetEl.classList.add('tour-spotlight');
+        targetEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        tourActiveTarget = targetEl;
+
+        document.getElementById('tourStepLabel').textContent =
+            `Step ${index + 1} of ${TOUR_STEPS.length}`;
+        document.getElementById('tourStepText').textContent = step.text;
+        document.getElementById('tourNextBtn').textContent =
+            (index === TOUR_STEPS.length - 1) ? 'Finish' : 'Next →';
+
+        // Give the browser a moment to scroll before positioning the tooltip
+        setTimeout(() => positionTourTooltip(targetEl), 300);
+    }
+
+    let tourClickListenerAttached = false;
+
+    function attachTourClickListener() {
+        if (tourClickListenerAttached) return;
+        const overlay = document.getElementById('tourOverlay');
+        if (!overlay) return;
+        tourClickListenerAttached = true;
+
+        // Event delegation: listen on the overlay itself (which never gets
+        // replaced), rather than binding directly to the buttons.
+        overlay.addEventListener('click', (e) => {
+            const target = e.target.closest('#tourSkipBtn, #tourNextBtn');
+            if (!target) return;
+            e.preventDefault();
+            e.stopPropagation();
+
+            if (target.id === 'tourSkipBtn') {
+                endTour();
+            } else if (target.id === 'tourNextBtn') {
+                tourStepIndex += 1;
+                showTourStep(tourStepIndex);
+            }
+        });
+    }
+
+    function startTour() {
+        const overlay = document.getElementById('tourOverlay');
+        if (!overlay) return;
+        attachTourClickListener();
+        overlay.style.display = 'block';
+        tourStepIndex = 0;
+        showTourStep(tourStepIndex);
+    }
+
+    function endTour() {
+        if (tourActiveTarget) {
+            tourActiveTarget.classList.remove('tour-spotlight');
+            tourActiveTarget = null;
+        }
+        const overlay = document.getElementById('tourOverlay');
+        if (overlay) overlay.style.display = 'none';
+        markTourAsSeen();
+    }
+
+    function initOnboardingTour() {
+        attachTourClickListener();
+
+        const welcomeOverlay = document.getElementById('welcomeOverlay');
+
+        // If there's no setup screen blocking the view at all (e.g. resuming
+        // an existing game), it's safe to start the tour right away.
+        if (!welcomeOverlay || !welcomeOverlay.classList.contains('active')) {
+            maybeStartTourAfterWelcomeCloses();
+        }
+    }
+
+    /* ==========================================================
     GAME COUNTER (Game #N badge — persists via sessionStorage,
     resets automatically when the browser session ends)
     ========================================================== */
@@ -1190,6 +1359,7 @@
                         false
                     );
                     welcomeOverlay.classList.remove('active');
+                    maybeStartTourAfterWelcomeCloses();
                     gameLayout.style.visibility = 'visible';
                     return;
                 }
@@ -3989,6 +4159,7 @@ function updateStepperUI() {
             const started = await startNewGame(mode, pColor, diff, fenValue);
             if (!started) return;
             welcomeOverlay.classList.remove('active');
+                    maybeStartTourAfterWelcomeCloses();
             gameLayout.style.visibility = 'visible';
         });
     }
@@ -3999,6 +4170,7 @@ function updateStepperUI() {
         const started = await startNewGame('pvp', 'white', 'medium', fen);
         if (!started) return;
         welcomeOverlay.classList.remove('active');
+                    maybeStartTourAfterWelcomeCloses();
         gameLayout.style.visibility = 'visible';
     };
 
@@ -4008,6 +4180,7 @@ function updateStepperUI() {
             await startDailyPuzzle();
 
             welcomeOverlay.classList.remove('active');
+                    maybeStartTourAfterWelcomeCloses();
             gameLayout.style.visibility = 'visible';
         };
     }
@@ -4104,6 +4277,7 @@ function updateStepperUI() {
         const started = await startNewGame('ai', selectedPveColor, diff, fen);
         if (!started) return;
         welcomeOverlay.classList.remove('active');
+                    maybeStartTourAfterWelcomeCloses();
         gameLayout.style.visibility = 'visible';
     };
 
@@ -4166,6 +4340,7 @@ function updateStepperUI() {
             return;
         }
         welcomeOverlay.classList.remove('active');
+                    maybeStartTourAfterWelcomeCloses();
         gameLayout.style.visibility = 'visible';
         paused = false;
         updatePauseUI();
@@ -4296,6 +4471,7 @@ function updateStepperUI() {
 
         fenOverlay.classList.remove('active');
         welcomeOverlay.classList.remove('active');
+                    maybeStartTourAfterWelcomeCloses();
         gameLayout.style.visibility = 'visible';
     };
 
@@ -5340,6 +5516,9 @@ function updateStepperUI() {
     updateSessionTracker();
     // Render the current game count already stored for this browser session
     updateGameCounterDisplay();
+    // Wire up the onboarding tour's Skip/Next buttons and, if resuming a
+    // game with no setup screen showing, start it right away
+    initOnboardingTour();
     // Resume game by clicking the paused board overlay
     boardEl.addEventListener('click', async () => {
         if (!paused) return;

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -513,7 +513,7 @@
                 </div>
             </div>
 
-            <div class="card controls-card">
+            <div class="card controls-card" id="boardThemeCard">
                 <div class="card-title">Board Theme</div>
                 <div class="theme-switcher">
                     <div class="theme-option">
@@ -543,7 +543,7 @@
                 </div>
             </div>
 
-            <div class="card controls-card">
+            <div class="card controls-card" id="gameControlsCard">
                 <div class="card-title">Game Controls</div>
                 <div style="display: flex; flex-direction: column; gap: 8px;">
                     <button type="button" class="btn btn-gold" id="flipBtn" title="Shortcut: F">Flip Board<span class="btn-shortcut">F</span></button>
@@ -940,6 +940,18 @@
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/chess.js/0.10.3/chess.min.js"></script>
     <script src="{% static 'game/js/board.js' %}"></script>
+
+<!-- First-time visitor onboarding tour -->
+<div id="tourOverlay" class="tour-overlay" style="display:none;">
+    <div id="tourTooltip" class="tour-tooltip">
+        <p id="tourStepLabel" class="tour-step-label"></p>
+        <p id="tourStepText" class="tour-step-text"></p>
+        <div class="tour-actions">
+            <button type="button" id="tourSkipBtn" class="tour-skip-btn">Skip tour</button>
+            <button type="button" id="tourNextBtn" class="tour-next-btn">Next →</button>
+        </div>
+    </div>
+</div>
 
 <script src="{% static 'game/js/theme.js' %}?v=1"></script>
 </body>


### PR DESCRIPTION
## Add a first-time visitor onboarding tour

### Description
Adds a short, automatic 4-step guided tour for brand-new visitors, highlighting the move input box, Game Controls panel, Board Theme picker, and the session score tracker. Previously, first-time users landed on a fully-featured game screen with no introduction to any of the controls.

### Changes
- **`board.html`** — Added the tour overlay/tooltip markup, plus `id` attributes on the Board Theme and Game Controls cards so they can be targeted.
- **`board.css`** — Added `.tour-overlay`, `.tour-spotlight`, `.tour-tooltip` styles (dimmed backdrop, gold spotlight ring, responsive tooltip box).
- **`board.js`** — Added tour step logic (`startTour`, `showTourStep`, `endTour`) and hooked it to trigger right after the game-mode setup screen closes, across every game-start path (PvP, AI, Daily Puzzle, resume). Click handling uses event delegation on the overlay for reliability.

### Behavior
- Tour appears automatically only on a visitor's first-ever visit to the site (tracked via `localStorage`, distinct from the session-based W/L/D tracker).
- Each step dims the background and highlights one real UI element at a time with a tooltip explaining it.
- "Skip tour" or finishing the last step marks it as seen — it won't show again on that browser.
- Fully responsive; tour UI renders above all other page elements to avoid stacking conflicts.
- No backend or database changes — pure frontend addition.
- No changes to existing gameplay or game controls logic.

### Testing done
- Verified the tour triggers correctly across PvP, AI, and Daily Puzzle game-start flows.
- Verified all 4 steps advance correctly via "Next" and that "Skip tour" and "Finish" both close it properly.
- Verified it does not reappear on repeat visits once completed/skipped.
- Verified no impact on existing gameplay, move input, or game controls functionality.

