### PR TITLE
feat/shared-navbar-footer-replaced-emojis

### DIFF
--- a/game/static/game/css/landing.css
+++ b/game/static/game/css/landing.css
@@ -1946,9 +1946,24 @@ body.hide-native-cursor * {
 }
 
 .stat-icon {
-    font-size: 1.75rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     margin-bottom: 0.75rem;
-    filter: drop-shadow(0 2px 8px rgba(0, 0, 0, 0.2));
+}
+
+.stat-icon svg {
+    color: var(--accent-gold);
+    filter: drop-shadow(0 0 4px rgba(240, 192, 64, 0.7))
+            drop-shadow(0 0 10px rgba(240, 192, 64, 0.35));
+    transition: filter 0.4s cubic-bezier(0.16, 1, 0.3, 1),
+                transform 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.stat-box:hover .stat-icon svg {
+    filter: drop-shadow(0 0 6px rgba(240, 192, 64, 0.9))
+            drop-shadow(0 0 16px rgba(240, 192, 64, 0.5));
+    transform: scale(1.08);
 }
 
 .stat-number-wrapper {

--- a/game/static/game/css/lesson.css
+++ b/game/static/game/css/lesson.css
@@ -1,6 +1,6 @@
 body {
-    background: #121212;
-    color: white;
+    background: var(--bg-primary);
+    color: var(--text-primary);
     font-family: Arial, sans-serif;
     margin: 0;
     padding: 40px;
@@ -11,28 +11,20 @@ body {
     margin: auto;
 }
 
-.back-btn {
-    display: inline-block;
-    margin-bottom: 20px;
-    color: #f0c040;
-    text-decoration: none;
-    font-weight: bold;
-}
-
 .lesson-box {
-    background: #1e1e1e;
+    background: var(--card-bg);
     padding: 25px;
     border-radius: 12px;
-    border: 1px solid #333;
+    border: 1px solid var(--card-border);
 }
 
 h1 {
-    color: #f0c040;
+    color: var(--accent-gold);
     margin-bottom: 15px;
 }
 
 .description {
-    color: #d0d0d0;
+    color: var(--text-primary);
     line-height: 1.6;
     margin-bottom: 30px;
 }
@@ -46,7 +38,7 @@ h1 {
 .lesson-content li {
     margin-bottom: 12px;
     line-height: 1.7;
-    color: #e0e0e0;
+    color: var(--text-primary);
 }
 
 .board-placeholder {
@@ -56,12 +48,12 @@ h1 {
     display: flex;
     justify-content: center;
     align-items: center;
-    color: #aaa;
+    color: var(--text-secondary);
     font-size: 18px;
 }
 
 .complete-btn {
-    background: #f0c040;
+    background: var(--accent-gold);
     color: #121212;
     border: none;
     padding: 12px 20px;
@@ -72,8 +64,8 @@ h1 {
 }
 
 .quiz-btn {
-    background: #333;
-    color: white;
+    background: var(--card-border);
+    color: var(--text-primary);
     border: none;
     padding: 10px 16px;
     border-radius: 8px;
@@ -89,14 +81,14 @@ h1 {
 
 .quiz-btn.correct {
     background-color: #4caf50 !important;
-    color: white;
+    color: var(--text-primary);
     animation: pop 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
     box-shadow: 0 0 15px rgba(76, 175, 80, 0.4);
 }
 
 .quiz-btn.incorrect {
     background-color: #ff5252 !important;
-    color: white;
+    color: var(--text-primary);
     animation: shake 0.4s cubic-bezier(.36,.07,.19,.97) both;
     box-shadow: 0 0 15px rgba(255, 82, 82, 0.4);
 }
@@ -130,7 +122,7 @@ h1 {
     position: absolute;
     width: 12px;
     height: 12px;
-    background: #f0c040;
+    background: var(--accent-gold);
     top: -20px;
     opacity: 0;
     animation: confetti-fall 3.5s ease-in-out forwards;
@@ -158,7 +150,7 @@ h1 {
 }
 
 .lesson-navigation a {
-    color: #f0c040;
+    color: var(--accent-gold);
     text-decoration: none;
     font-weight: bold;
 }
@@ -171,51 +163,30 @@ h1 {
     margin-top: 25px;
     padding: 15px;
     background: rgba(240,192,64,0.1);
-    border-left: 4px solid #f0c040;
+    border-left: 4px solid var(--accent-gold);
     border-radius: 8px;
 }
 
-.lesson-square {
-    width: 60px;
-    height: 60px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    font-size: 38px;
-    cursor: pointer;
-}
-
-.light {
-    background: #f0d9b5;
-}
-
-.dark {
-    background: #b58863;
-}
-
-.lesson-board-wrapper{
+.lesson-square{
+    aspect-ratio:1;
     display:flex;
     justify-content:center;
-    margin:20px 0;
+    align-items:center;
+    cursor:pointer;
+    user-select:none;
+    font-size:clamp(22px,4vw,42px);
 }
 
 .lesson-board{
-    width:480px;
-    height:480px;
+    width:min(480px,90vw);
+    aspect-ratio:1;
+    height:auto;
 
     display:grid;
     grid-template-columns:repeat(8,1fr);
 
-    border:2px solid #f0c040;
-}
-
-.lesson-square{
-    display:flex;
-    justify-content:center;
-    align-items:center;
-    font-size:42px;
-    user-select:none;
-}       
+    border:2px solid var(--accent-gold);
+}     
 
 .lesson-square.light{
     background:#f0d9b5;
@@ -238,7 +209,7 @@ h1 {
     grid-template-columns:repeat(8,1fr);
     grid-template-rows:repeat(8,1fr);
 
-    border:2px solid #f0c040;
+    border:2px solid var(--accent-gold);
     margin:20px auto;
 }
 
@@ -272,7 +243,7 @@ h1 {
     text-align:center;
     font-size:18px;
     margin-bottom:15px;
-    color:#f0c040;
+    color:var(--accent-gold);
 }
 
 #lesson-result{
@@ -296,14 +267,14 @@ h1 {
     align-items: center;
     gap: 10px;
     margin-bottom: 20px;
-    background: #1e1e1e;
+    background: var(--card-bg);
     padding: 12px 20px;
     border-radius: 8px;
-    border: 1px solid #333;
+    border: 1px solid var(--card-border);
     width: fit-content;
 }
 .coord-toggle-label {
-    color: #d0d0d0;
+    color: var(--text-primary);
     font-size: 16px;
     cursor: pointer;
     user-select: none;
@@ -312,7 +283,7 @@ h1 {
     cursor: pointer;
     width: 18px;
     height: 18px;
-    accent-color: #f0c040;
+    accent-color: var(--accent-gold);
 }
 
 /* Board Wrappers */
@@ -340,7 +311,7 @@ h1 {
     align-items: center;
     justify-content: center;
     font-size: 13px;
-    color: #8b92a5;
+    color: var(--text-secondary);
     font-weight: 600;
     flex: 1; /* Divides height perfectly into 8 */
 }
@@ -354,13 +325,17 @@ h1 {
     flex: 1;
     text-align: center;
     font-size: 13px;
-    color: #8b92a5;
+    color: var(--text-secondary);
     font-weight: 600;
 }
 
 /* Override old margins so boards align perfectly with coordinates */
-#demo-board, .lesson-board-wrapper {
-    margin: 0 !important; 
+#demo-board{
+    margin:0 auto;
+}
+
+.lesson-board-wrapper{
+    margin:20px 0;
 }
 
 /* Hide functionality */
@@ -387,58 +362,9 @@ h1 {
         transition: none !important;
     }
 }
-/* ============================================================
-   LIGHT THEME OVERRIDES
-   ============================================================ */
-   [data-theme="light"] body {
-    background: #f5f7fb;
-    color: #111827;
-}
 
-[data-theme="light"] .lesson-box {
-    background: #ffffff;
-    border-color: #d1d5db;
-}
-
-[data-theme="light"] h2,
-[data-theme="light"] h3 {
-    color: #111827;
-}
-
-/* Accent colors remain unchanged */
-[data-theme="light"] h1,
-[data-theme="light"] .back-btn,
-[data-theme="light"] .lesson-navigation a {
-    color: #f0c040;
-}
-
-[data-theme="light"] .description,
-[data-theme="light"] .lesson-content li {
-    color: #4b5563;
-}
-
-[data-theme="light"] .quiz-btn {
-    background: #e5e7eb;
-    color: #111827;
-}
-
-[data-theme="light"] .quiz-btn:hover {
-    background: #d1d5db;
-}
-
-[data-theme="light"] .coord-toggle-container {
-    background: #ffffff;
-    border-color: #d1d5db;
-}
-
-[data-theme="light"] .coord-toggle-label,
-[data-theme="light"] .lesson-ranks span,
-[data-theme="light"] .lesson-files span {
-    color: #6b7280;
-}
-
-[data-theme="light"] .coming-soon {
-    background: rgba(240, 192, 64, 0.1);
-    border-left-color: #f0c040;
-    color: #111827;
+.quiz-btn,
+.confetti,
+.lesson-square {
+    will-change: transform;
 }

--- a/game/static/game/css/lessons-shared.css
+++ b/game/static/game/css/lessons-shared.css
@@ -1,0 +1,534 @@
+/* lessons-shared.css
+   Shared styles for lessons.html, lessons_roadmap.html (and lesson_detail.html
+   where noted). Built on theme.css variables so light/dark theming is
+   automatic instead of hand-duplicated [data-theme="light"] blocks per page.
+
+   NOTE on renames (avoiding collisions now these pages share landing.css):
+     .hero        -> .lessons-hero        (landing.css already owns `.hero`)
+     .header      -> .roadmap-header      (kept distinct in case of future use)
+     .lesson-card -> .roadmap-lesson-card (lessons.html's `.lesson-card` means
+                                            something different from the
+                                            roadmap's lesson-card)
+                                            */
+
+/* ── Lessons hub hero ── */
+.lessons-hero {
+    text-align: center;
+    margin-bottom: 40px;
+}
+
+.lessons-hero h1 {
+    font-size: 3rem;
+    color: var(--accent-gold);
+    margin-bottom: 10px;
+    font-family: 'Cinzel', serif;
+}
+
+.lessons-hero p {
+    color: var(--text-secondary);
+    font-size: 1rem;
+}
+
+/* ── Guest alert banner (lessons.html + lessons_roadmap.html) ── */
+.alert-banner {
+    background: linear-gradient(135deg, var(--card-hover), var(--bg-dark));
+    border: 1px solid var(--accent-gold);
+    border-radius: 12px;
+    padding: 16px 20px;
+    margin-bottom: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    box-shadow: 0 4px 20px rgba(240, 192, 64, 0.15);
+    animation: alertFadeIn 0.5s ease;
+}
+
+.alert-content {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.alert-icon {
+    color: var(--accent-gold);
+    flex-shrink: 0;
+    display: flex;
+}
+
+.alert-text {
+    font-size: 1rem;
+    color: var(--text-primary);
+    line-height: 1.5;
+}
+
+.alert-banner a.alert-link {
+    color: var(--accent-gold);
+    text-decoration: underline;
+    font-weight: 600;
+    transition: color 0.2s ease;
+}
+
+.alert-banner a.alert-link:hover {
+    color: #ffdf70;
+}
+
+.alert-close {
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    font-size: 1.5rem;
+    cursor: pointer;
+    padding: 0 4px;
+    line-height: 1;
+    transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.alert-close:hover {
+    color: var(--text-title);
+    transform: scale(1.1);
+}
+
+@keyframes alertFadeIn {
+    from { opacity: 0; transform: translateY(-10px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Progress box (lessons hub) ── */
+.progress-box {
+    background: linear-gradient(145deg, var(--card-bg), var(--card-hover));
+    border: 1px solid var(--card-border);
+    border-radius: 18px;
+    padding: 25px;
+    margin-bottom: 35px;
+}
+
+.progress-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 15px;
+}
+
+.progress-header h2 {
+    margin: 0;
+    color: var(--accent-gold);
+}
+
+.progress-header span {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.progress-bar {
+    width: 100%;
+    height: 12px;
+    background: var(--card-border);
+    border-radius: 20px;
+    overflow: hidden;
+}
+
+.progress-fill {
+    height: 100%;
+    background: linear-gradient(90deg, var(--accent-gold), #ffdf70);
+    border-radius: 20px;
+}
+
+.progress-text {
+    margin-top: 12px;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+}
+
+.continue-learning {
+    background: linear-gradient(145deg, var(--card-bg), var(--card-hover));
+    border: 1px solid var(--card-border);
+    border-radius: 18px;
+    padding: 25px;
+    margin-bottom: 40px;
+}
+
+.continue-learning h2 {
+    color: var(--accent-gold);
+    margin-top: 0;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.continue-learning p {
+    color: var(--text-secondary);
+    margin-bottom: 0;
+}
+
+.learning-stats {
+    margin-top: 15px;
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.learning-stats span {
+    background: rgba(240, 192, 64, 0.15);
+    color: var(--accent-gold);
+    padding: 8px 14px;
+    border-radius: 20px;
+    font-weight: 600;
+}
+
+/* ── Lesson category groups ── */
+.category {
+    margin-bottom: 45px;
+}
+
+.category-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 20px;
+}
+
+.category-header h2 {
+    margin: 0;
+    color: var(--accent-gold);
+    font-size: 1.8rem;
+}
+
+.category-badge {
+    display: inline-block;
+    padding: 8px 16px;
+    border-radius: 20px;
+    font-weight: 600;
+    color: #ffffff;
+    margin-bottom: 15px;
+}
+
+.category-badge.beginner     { background: #16a34a; }
+.category-badge.intermediate { background: #f59e0b; }
+.category-badge.advanced     { background: #dc2626; }
+
+.lesson-count {
+    background: var(--card-hover);
+    color: var(--accent-gold);
+    padding: 6px 12px;
+    border-radius: 20px;
+    font-size: 13px;
+    font-weight: 600;
+}
+
+/* ── Lesson cards grid (lessons hub) ── */
+.lesson-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 22px;
+}
+
+.lesson-card {
+    background: linear-gradient(145deg, var(--card-bg), var(--card-hover));
+    border: 1px solid var(--card-border);
+    border-radius: 18px;
+    padding: 20px;
+    min-height: 180px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    transition: all 0.3s ease;
+}
+
+.lesson-card:hover {
+    transform: translateY(-8px) scale(1.02);
+    border-color: var(--accent-gold);
+    box-shadow: 0 14px 30px rgba(240, 192, 64, 0.3);
+}
+
+.lesson-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.lesson-icon {
+    font-size: 28px;
+    color: var(--accent-gold);
+}
+
+.lesson-card h3 {
+    color: var(--text-title);
+    font-size: 1.2rem;
+    margin: 18px 0;
+    line-height: 1.4;
+}
+
+.lesson-meta {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+}
+
+.status {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 6px 12px;
+    border-radius: 30px;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.status.pending {
+    background: var(--accent-gold);
+    color: var(--bg-primary);
+}
+
+.status.completed {
+    background: #22c55e;
+    color: #ffffff;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   Learning Journey roadmap page
+   ══════════════════════════════════════════════════════════════ */
+
+body.roadmap-checkerboard-bg {
+    background:
+        linear-gradient(45deg,
+            var(--bg-dark) 25%, var(--bg-primary) 25%, var(--bg-primary) 50%,
+            var(--bg-dark) 50%, var(--bg-dark) 75%, var(--bg-primary) 75%);
+    background-size: 60px 60px;
+}
+
+.roadmap-header {
+    text-align: center;
+    padding: 30px;
+}
+
+.roadmap-header h1 {
+    color: var(--accent-gold);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6rem;
+}
+
+.roadmap-header p {
+    color: var(--text-secondary);
+}
+
+.map-container {
+    max-width: 900px;
+    margin: auto;
+    padding: 20px;
+    position: relative;
+}
+
+.level-title {
+    text-align: center;
+    margin: 80px 0 30px;
+    font-size: 34px;
+    color: var(--accent-gold);
+    font-weight: 700;
+    text-shadow: 0 0 15px rgba(240, 192, 64, 0.5);
+}
+
+.lesson-path {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.lesson-row {
+    width: 100%;
+    display: flex;
+    margin: 10px 0;
+}
+
+.lesson-row.left  { justify-content: flex-start; padding-left: 120px; }
+.lesson-row.right { justify-content: flex-end;   padding-right: 120px; }
+
+.lesson-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    position: relative;
+    z-index: 2;
+}
+
+.node {
+    width: 60px;
+    height: 60px;
+    background: var(--card-hover);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 24px;
+    border: 2px solid var(--card-border);
+    transition: transform 0.3s, box-shadow 0.3s;
+    text-decoration: none;
+    color: var(--text-primary);
+    position: relative;
+    z-index: 1;
+}
+
+.node span { font-size: 42px; }
+
+.node:hover { transform: scale(1.08); }
+
+.node.completed {
+    background: #22c55e;
+    box-shadow: 0 0 25px #22c55e;
+}
+
+.node.current {
+    background: #3b82f6;
+    box-shadow: 0 0 25px #3b82f6;
+    border: 4px solid #ffffff;
+    transform: scale(1.12);
+}
+
+.node.current::before {
+    content: "NEXT";
+    position: absolute;
+    top: -12px;
+    background: #ffffff;
+    color: #000000;
+    font-size: 10px;
+    font-weight: 700;
+    padding: 4px 8px;
+    border-radius: 12px;
+}
+
+.node.locked {
+    background: var(--card-border);
+    cursor: not-allowed;
+    color: var(--text-secondary);
+}
+
+.lesson-name {
+    margin-top: 12px;
+    text-align: center;
+    width: 180px;
+    color: var(--text-primary);
+}
+
+.roadmap-lesson-card {
+    margin-top: 12px;
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 16px;
+    padding: 12px;
+    width: 180px;
+    text-align: center;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.roadmap-lesson-card:hover {
+    border-color: var(--accent-gold);
+    transform: translateY(-3px);
+}
+
+.roadmap-lesson-card h3 {
+    margin: 0 0 12px;
+    color: var(--text-title);
+    font-size: 18px;
+}
+
+.badge {
+    display: inline-block;
+    padding: 6px 12px;
+    border-radius: 20px;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.badge.done          { background: #22c55e; color: #ffffff; }
+.badge.active        { background: #3b82f6; color: #ffffff; }
+.badge.locked-badge   { background: var(--card-border); color: var(--text-secondary); }
+
+.roadmap-progress-box {
+    max-width: 700px;
+    margin: 0 auto 60px;
+    background: linear-gradient(135deg, var(--card-bg), var(--card-hover));
+    padding: 25px;
+    border-radius: 24px;
+    border: 1px solid var(--card-border);
+}
+
+.roadmap-progress-box h3 {
+    color: var(--text-title);
+    margin-top: 0;
+}
+
+.roadmap-progress-box p {
+    color: var(--text-secondary);
+}
+
+.progress-track {
+    height: 12px;
+    background: var(--card-border);
+    border-radius: 20px;
+    overflow: hidden;
+}
+
+.progress-track .progress-fill {
+    background: linear-gradient(90deg, #22c55e, #36e6c5);
+}
+
+@media (max-width: 480px) {
+    #backToTopWrapper {
+        bottom: 1rem;
+        right: 1rem;
+    }
+
+    #backToTopBtn {
+        width: 44px;
+        height: 44px;
+        font-size: 1.1rem;
+    }
+
+    #backToTopTooltip {
+        font-size: 0.7rem;
+    }
+}
+
+/* ── Back button, in-flow variant ──
+   landing.css's .back-btn is `position: absolute` (meant for hero-style
+   containers with position:relative). lessons_roadmap.html and
+   lesson_detail.html have no such ancestor, so pair .back-btn with this
+   modifier to keep all the same visual styling but flow it normally. */
+.back-btn.back-btn-inline {
+    position: static;
+    display: inline-flex;
+    margin: 20px 0 0 20px;
+    top: auto;
+    left: auto;
+}
+
+@media (max-width: 768px) {
+    .lesson-row.left,
+    .lesson-row.right {
+        justify-content: center;
+    }
+
+    .node {
+        width: 90px;
+        height: 90px;
+    }
+
+    .lessons-hero h1 {
+        font-size: 2rem;
+    }
+
+    .progress-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 10px;
+    }
+
+    .lesson-grid {
+        grid-template-columns: 1fr;
+    }
+}

--- a/game/static/game/css/theme.css
+++ b/game/static/game/css/theme.css
@@ -1,51 +1,6 @@
-/* ==========================================================================
-   theme.css (GLOBAL VARIABLES AND FIXES)
-   ========================================================================== */
+/* theme.css */
 
-:root {
-    /* Your Default Dark Theme Colors */
-    --bg-primary: #0b1020;
-    --bg-dark: #0f0f1a;
-    --nav-bg: #12121f;
-    --card-bg: #16162a;
-    --card-border: #252545;
-    --card-hover: #1a1a35;
-    --text-primary: #d0d0d0;
-    --text-title: #ffffff;
-    --text-secondary: #aaaaaa;
-    --accent-gold: #f0c040;
-    --border-color: rgba(255,255,255,0.1);
-    --danger-red: #ff6b6b;
-    --input-bg: #1a1a2e;
-    --input-border: #444;
-    --input-text: #ffffff;
-    --input-placeholder: #8a8aaa;
-}
-
-[data-theme="light"] {
-    /* Your Light Theme Colors */
-    --bg-primary: #f5f7fb;
-    --bg-dark: #f5f7fb;
-    --nav-bg: #ffffff;
-    --card-bg: #ffffff;
-    --card-border: #d1d5db;
-    --card-hover: #f3f4f6;
-    --text-primary: #111827;
-    --text-title: #000000;
-    --text-secondary: #4b5563;
-    --accent-gold: #b47505;
-    --border-color: rgba(0,0,0,0.1);
-    --input-bg: #ffffff;
-    --input-border: #d1d5db;
-    --input-text: #111827;
-    --input-placeholder: #6b7280;
-}
-
-/* ==========================================================================
-   GLOBAL LIGHT THEME FIXES
-   ========================================================================== */
-
-/* 1. Fix the Navbar (Frosted glass effect) */
+/* Navbar */
 [data-theme="light"] .navbar {
     background: rgba(253, 251, 247, 0.9) !important;
     border: 1px solid rgba(0, 0, 0, 0.05) !important;
@@ -56,7 +11,7 @@
 [data-theme="light"] .btn-primary-gold,
 [data-theme="light"] .btn-register,
 [data-theme="light"] .btn-primary {
-    background: #f0c040 !important;
+    background: var(--accent-gold) !important;
     color: #0f0f1a !important; 
     font-weight: bold !important;
     border: 1px solid rgba(0, 0, 0, 0.1) !important;
@@ -551,3 +506,302 @@
         background: rgba(255, 255, 255, 0.08);
     }
 }
+/* Legal & Contact Modals — shared across footer.html */
+
+.legal-modal {
+    display: none; /* toggled to flex by footer.html's wireModal() */
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.85);
+    z-index: 9999;
+    align-items: center;
+    justify-content: center;
+}
+
+.legal-modal-inner {
+    position: relative;
+    background: var(--card-bg);
+    border: 1px solid rgba(240, 192, 64, 0.2);
+    border-radius: 16px;
+    width: 90%;
+    max-width: 900px;
+    max-height: 88vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.legal-modal-header {
+    padding: 24px 28px 16px;
+    border-bottom: 1px solid var(--border-color);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-shrink: 0;
+}
+
+.legal-modal-title {
+    color: var(--accent-gold);
+    font-size: 1.6rem;
+    font-weight: 700;
+    letter-spacing: -0.3px;
+}
+
+.legal-modal-close {
+    background: rgba(255, 255, 255, 0.08);
+    border: none;
+    color: var(--text-primary);
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    cursor: pointer;
+    font-size: 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.2s ease;
+}
+
+.legal-modal-close:hover {
+    background: rgba(240, 192, 64, 0.15);
+    color: var(--accent-gold);
+}
+
+.legal-modal-body {
+    overflow-y: auto;
+    padding: 24px 28px;
+    flex: 1;
+}
+
+.legal-modal-sections {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.legal-modal-section {
+    background: var(--card-hover);
+    border: 1px solid var(--card-border);
+    border-radius: 12px;
+    padding: 20px 22px;
+    display: flex;
+    gap: 16px;
+    align-items: flex-start;
+}
+
+.legal-modal-badge {
+    background: rgba(240, 192, 64, 0.15);
+    color: var(--accent-gold);
+    border-radius: 50%;
+    width: 30px;
+    height: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    font-size: 0.85rem;
+    flex-shrink: 0;
+}
+
+.legal-modal-section h2 {
+    color: var(--text-title);
+    font-size: 1.05rem;
+    font-weight: 600;
+    margin-bottom: 8px;
+}
+
+.legal-modal-section p {
+    color: var(--text-secondary);
+    font-size: 0.92rem;
+    line-height: 1.7;
+    margin: 0 0 10px 0;
+}
+
+.legal-modal-section p:last-child {
+    margin-bottom: 0;
+}
+
+.legal-modal-section ul {
+    margin-left: 18px;
+    color: var(--text-secondary);
+    font-size: 0.92rem;
+    line-height: 1.7;
+}
+
+.legal-modal-section ul li {
+    margin-bottom: 6px;
+}
+
+.legal-modal-section ul li:last-child {
+    margin-bottom: 0;
+}
+
+.legal-modal-section strong {
+    color: var(--accent-gold);
+}
+
+.legal-modal-updated {
+    color: #64748b; /* matches .footer-copy's muted tone elsewhere in landing.css */
+    font-size: 0.82rem;
+    margin-top: 6px;
+}
+
+.legal-modal-footer {
+    padding: 16px 28px;
+    border-top: 1px solid var(--border-color);
+    display: flex;
+    justify-content: flex-end;
+    flex-shrink: 0;
+    background: var(--card-bg);
+}
+
+.legal-modal-agree {
+    background: linear-gradient(135deg, var(--accent-gold), #d4a020);
+    color: #0f0f1a;
+    border: none;
+    padding: 10px 28px;
+    border-radius: 8px;
+    font-weight: 700;
+    font-size: 0.95rem;
+    cursor: pointer;
+    box-shadow: 0 4px 16px rgba(240, 192, 64, 0.3);
+    transition: filter 0.2s ease;
+}
+
+.legal-modal-agree:hover {
+    filter: brightness(1.06);
+}
+
+/* ── Contact modal ── */
+
+.contact-modal-intro {
+    color: var(--text-secondary);
+    font-size: 0.93rem;
+    margin-bottom: 28px;
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 20px;
+}
+
+.contact-modal-grid {
+    display: grid;
+    grid-template-columns: 0.8fr 1.5fr;
+    gap: 40px;
+}
+
+.contact-modal-info {
+    display: flex;
+    flex-direction: column;
+    gap: 28px;
+}
+
+.contact-modal-info h3 {
+    color: var(--text-title);
+    font-size: 1rem;
+    font-weight: 600;
+    margin-bottom: 8px;
+}
+
+.contact-modal-info p {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    line-height: 1.6;
+}
+
+.contact-modal-info a {
+    color: var(--accent-gold);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.contact-modal-info a:hover {
+    text-decoration: underline;
+}
+
+.contact-modal-form {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.contact-modal-field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.contact-modal-field label {
+    color: var(--text-title);
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    opacity: 0.9;
+}
+
+.contact-modal-field input,
+.contact-modal-field textarea {
+    background: var(--input-bg);
+    border: 1px solid var(--input-border);
+    border-radius: 8px;
+    padding: 13px 16px;
+    color: var(--input-text);
+    font-size: 0.95rem;
+    font-family: inherit;
+    width: 100%;
+    transition: border-color 0.25s, box-shadow 0.25s;
+}
+
+.contact-modal-field input::placeholder,
+.contact-modal-field textarea::placeholder {
+    color: var(--input-placeholder);
+}
+
+.contact-modal-field input:focus,
+.contact-modal-field textarea:focus {
+    outline: none;
+    border-color: var(--accent-gold);
+    box-shadow: 0 0 0 4px rgba(240, 192, 64, 0.12);
+}
+
+.contact-modal-field textarea {
+    resize: vertical;
+    min-height: 130px;
+}
+
+.contact-modal-submit {
+    background: linear-gradient(135deg, var(--accent-gold), #d4a020);
+    color: #1a1a2e;
+    border: none;
+    padding: 14px 28px;
+    font-size: 1rem;
+    font-weight: 700;
+    border-radius: 8px;
+    cursor: pointer;
+    align-self: flex-start;
+    box-shadow: 0 4px 15px rgba(240, 192, 64, 0.2);
+    transition: filter 0.25s ease;
+}
+
+.contact-modal-submit:hover {
+    filter: brightness(1.06);
+}
+
+@media (max-width: 640px) {
+    .contact-modal-grid {
+        grid-template-columns: 1fr;
+        gap: 24px;
+    }
+
+    .legal-modal-inner {
+        width: 95%;
+        max-height: 92vh;
+    }
+
+    .legal-modal-header,
+    .legal-modal-body,
+    .legal-modal-footer {
+        padding-left: 18px;
+        padding-right: 18px;
+    }
+}
+

--- a/game/templates/base.html
+++ b/game/templates/base.html
@@ -1,0 +1,40 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{% block title %}Checkora | Play AI Chess Online with Hybrid Engine{% endblock %}</title>
+  <link rel="icon" type="image/jpeg" href="{% static 'game/favicon.jpeg' %}" />
+
+  {% block meta %}{% endblock %}
+
+  <!-- Fonts (previously only loaded on landing.html, now loaded everywhere) -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Inter:wght@400;500;600;700&family=Rajdhani:wght@600&display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="{% static 'game/css/theme.css' %}?v=2" />
+  <link rel="stylesheet" href="{% static 'game/css/landing.css' %}?v=2" />
+  <link rel="stylesheet" href="{% static 'game/css/lessons-shared.css' %}?v=1" />
+
+  {% block extra_css %}{% endblock %}
+</head>
+
+<body{% block body_attrs %}{% endblock %}>
+
+  {% include "partials/navbar.html" %}
+
+  <main>
+    {% block content %}{% endblock %}
+  </main>
+
+  {% include "partials/footer.html" %}
+  {% include "partials/back_to_top.html" %}
+
+  <script src="{% static 'game/js/dropdown.js' %}?v=2"></script>
+  <script src="{% static 'game/js/theme.js' %}?v=1"></script>
+
+  {% block extra_js %}{% endblock %}
+</body>
+</html>

--- a/game/templates/game/landing.html
+++ b/game/templates/game/landing.html
@@ -1,1992 +1,1420 @@
-{% load static %}
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <!-- ──preloader on loading page reload ── -->
-    <script>
-        (function () {
-        var nav = performance.getEntriesByType('navigation')[0];
-        if (nav && nav.type === 'reload') {
-          window.location.replace("{% url 'preloader' %}");
-        }
-        })();
-    </script>
-    <script>
-      if (navigator.webdriver) {
-        document.documentElement.style.setProperty('scroll-behavior', 'auto', 'important');
-      }
-    </script>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Checkora | Play AI Chess Online with Hybrid Engine</title>
-    <meta
-      name="google-site-verification"
-      content="MkxTJ-CxFDWDussY1CsgoyiG0_nwTVd_HRl5r76MpwM"
-    />
-    <meta
-      name="description"
-      content="Play Checkora, a powerful hybrid chess engine orchestrating Python logic with a high-performance C++ minimax engine. Challenge the AI, track your stats, and master the board."
-    />
-    <meta
-      name="keywords"
-      content="Checkora, Chess, AI Chess, Hybrid Chess Engine, Play Chess Online, Minimax Chess, Django Chess"
-    />
+{% extends "base.html" %} {% load static %} {% block title %}Checkora | Play AI
+Chess Online with Hybrid Engine{% endblock %} {% block content %}
 
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://checkora.vercel.app/" />
-    <meta property="og:title" content="Checkora | Play AI Chess Online" />
-    <meta
-      property="og:description"
-      content="Experience high-performance chess with Checkora's hybrid C++ engine. Play for free online."
-    />
-    <meta
-      property="og:image"
-      content="{% static 'game/checkora_icon_only.png' %}"
-    />
+<main class="hero" id="hero">
+  <div class="ambient-glow glow-gold"></div>
+  <div class="ambient-glow glow-blue"></div>
 
-    <meta property="twitter:card" content="summary_large_image" />
-    <meta property="twitter:url" content="https://checkora.vercel.app/" />
-    <meta property="twitter:title" content="Checkora | Play AI Chess Online" />
-    <meta
-      property="twitter:description"
-      content="Experience high-performance chess with Checkora's hybrid C++ engine. Play for free online."
-    />
-    <meta
-      property="twitter:image"
-      content="{% static 'game/checkora_icon_only.png' %}"
-    />
+  <div id="chess-board-bg"></div>
+  <div class="hero-board-vignette"></div>
 
-    <script type="application/ld+json">
-      {
-        "@context": "https://schema.org",
-        "@type": "SoftwareApplication",
-        "name": "Checkora",
-        "operatingSystem": "Web",
-        "applicationCategory": "GameApplication",
-        "aggregateRating": {
-          "@type": "AggregateRating",
-          "ratingValue": "4.8",
-          "ratingCount": "150"
-        },
-        "offers": {
-          "@type": "Offer",
-          "price": "0",
-          "priceCurrency": "USD"
-        }
-      }
-    </script>
+  <div class="hero-inner-wrapper">
+    <h1 class="hero-title">
+      Master Chess with Checkora's<br />
+      <span class="gradient-text-gold">Hybrid Intelligence</span>
+    </h1>
 
-    <link
-      rel="icon"
-      type="image/jpeg"
-      href="{% static 'game/favicon.jpeg' %}"
-    />
-   
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
+    <p class="hero-tagline">
+      Play. Learn. <span class="cycle-word" id="cycleWord">Compete</span>
+    </p>
 
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@600&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="{% static 'game/css/landing.css' %}" />
-    <link rel="stylesheet" href="{% static 'game/css/theme.css' %}?v=1" />
-    <style>
-        /* ── Navbar avatar thumbnail ── */
-        .nav-avatar {
-            width: 26px;
-            height: 26px;
-            border-radius: 50%;
-            object-fit: cover;
-            border: 1.5px solid rgba(250, 204, 21, 0.6);
-            vertical-align: middle;
-            margin-right: 4px;
-            flex-shrink: 0;
-        }
-        .nav-avatar-icon {
-            width: 26px;
-            height: 26px;
-            border-radius: 50%;
-            background: rgba(255,255,255,0.08);
-            border: 1.5px solid rgba(255,255,255,0.15);
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            margin-right: 4px;
-            flex-shrink: 0;
-            color: #94a3b8;
-            vertical-align: middle;
-        }
-    </style>
-  </head>
+    <div class="hero-actions">
+      <a href="{% url 'index' %}" class="btn-primary-gold">Start Game</a>
+      <a
+        href="{% url 'lessons' %}"
+        class="btn-primary-gold"
+        aria-label="Chess Lessons"
+        >Lessons</a
+      >
+      <a href="#about" class="btn-secondary-ghost">Learn More</a>
+    </div>
+  </div>
+</main>
 
-  <body>
-    {% include 'game/includes/navbar.html' %}
-
-    <main class="hero" id="hero">
-      <div class="ambient-glow glow-gold"></div>
-      <div class="ambient-glow glow-blue"></div>
-
-      <div id="chess-board-bg"></div>
-      <div class="hero-board-vignette"></div>
-
-      <div class="hero-inner-wrapper">
-
-        <h1 class="hero-title">
-          Master Chess with Checkora's<br />
-          <span class="gradient-text-gold">Hybrid Intelligence</span>
-        </h1>
-
-        <p class="hero-tagline">
-          Play. Learn. <span class="cycle-word" id="cycleWord">Compete</span>
-        </p>
-
-        <div class="hero-actions">
-          <a href="{% url 'index' %}" class="btn-primary-gold">Start Game</a>
-          <a href="{% url 'lessons' %}" class="btn-primary-gold" aria-label="Chess Lessons">📚 Lessons</a>
-          <a href="#about" class="btn-secondary-ghost">Learn More</a>
-        </div>
+<!-- ── Platform Growth Statistics Section ── -->
+<section class="platform-stats-section">
+  <div class="stats-container">
+    <div class="stat-box">
+      <div class="stat-icon">
+        <svg aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="14.5 17.5 3 6 3 3 6 3 17.5 14.5" />
+          <line x1="13" x2="19" y1="19" y2="13" />
+          <line x1="16" x2="20" y1="16" y2="20" />
+          <line x1="19" x2="21" y1="21" y2="19" />
+          <polyline points="14.5 6.5 18 3 21 3 21 6 17.5 9.5" />
+          <line x1="5" x2="9" y1="14" y2="18" />
+          <line x1="7" x2="4" y1="17" y2="20" />
+          <line x1="3" x2="5" y1="19" y2="21" />
+        </svg>
       </div>
-
-      <script>
-        const board = document.getElementById('chess-board-bg');
-        const pieces = ['♛','♚','♞','♝','♜','♟'];
-        const darkSquares = [];
-
-        for(let r=0;r<20;r++){
-          for(let c=0;c<20;c++){
-            const sq = document.createElement('div');
-            sq.className = (r+c)%2===1 ? 'csq dark' : 'csq light';
-            sq.dataset.r = r; sq.dataset.c = c;
-            board.appendChild(sq);
-            if((r+c)%2===1) darkSquares.push({el:sq,r,c});
-          }
-        }
-
-        function isBehindText(r,c){ return r>=7&&r<=13&&c>=7&&c<=13; }
-
-        function triggerPiece(zone){
-          let pool;
-          if(zone==='right') pool = darkSquares.filter(s=>s.c>=5&&!s.el.dataset.busy);
-          else if(zone==='left') pool = darkSquares.filter(s=>s.c<=2&&!s.el.dataset.busy);
-          else pool = darkSquares.filter(s=>!s.el.dataset.busy);
-          if(!pool.length) return;
-          const chosen = pool[Math.floor(Math.random()*pool.length)];
-          const sq = chosen.el;
-          const behind = isBehindText(chosen.r, chosen.c);
-          sq.dataset.busy='1';
-          const dur = 2000+Math.random()*900;
-          const glow = document.createElement('div');
-          glow.className = behind ? 'sq-glow dim' : 'sq-glow bright';
-          glow.style.animationDuration = dur+'ms';
-          sq.appendChild(glow);
-          const icon = document.createElement('div');
-          icon.textContent = pieces[Math.floor(Math.random()*pieces.length)];
-          icon.className = behind ? 'sq-piece dim' : 'sq-piece bright';
-          icon.style.animationDuration = dur+'ms';
-          sq.appendChild(icon);
-          setTimeout(()=>{
-            glow.remove(); icon.remove(); delete sq.dataset.busy;
-          }, dur+50);
-        }
-
-      const intervals = [];
-      intervals.push(setInterval(()=>triggerPiece('right'), 450));
-      intervals.push(setInterval(()=>triggerPiece('left'), 550));
-      intervals.push(setInterval(()=>triggerPiece(null), 250));
-      intervals.push(setInterval(()=>triggerPiece(null), 380));
-      
-
-      document.addEventListener('visibilitychange', () => {
-        if (document.hidden) {
-          intervals.forEach(id => clearInterval(id));
-          intervals.length = 0;
-        } else {
-          intervals.push(setInterval(()=>triggerPiece('right'), 450));
-          intervals.push(setInterval(()=>triggerPiece('left'), 550));
-          intervals.push(setInterval(()=>triggerPiece(null), 250));
-          intervals.push(setInterval(()=>triggerPiece(null), 380));
-        }
-      });
-
-      window.addEventListener('beforeunload', () => {
-        intervals.forEach(id => clearInterval(id));
-      });
-      </script>
-    </main>
-
-    <!-- ── Platform Growth Statistics Section ── -->
-    <section class="platform-stats-section">
-      <div class="stats-container">
-        <div class="stat-box">
-          <div class="stat-icon">⚔️</div>
-          <div class="stat-number-wrapper">
-            <span class="stat-num" data-target="1250000">0</span><span class="stat-plus">+</span>
-          </div>
-          <p class="stat-label">Games Played</p>
-        </div>
-        <div class="stat-box">
-          <div class="stat-icon">👑</div>
-          <div class="stat-number-wrapper">
-            <span class="stat-num" data-target="45000">0</span><span class="stat-plus">+</span>
-          </div>
-          <p class="stat-label">Active Players</p>
-        </div>
-        <div class="stat-box">
-          <div class="stat-icon">⚡</div>
-          <div class="stat-number-wrapper">
-            <span class="stat-num" data-target="850">0</span><span class="stat-suffix">k/s</span>
-          </div>
-          <p class="stat-label">Engine Node Speed</p>
-        </div>
-        <div class="stat-box">
-          <div class="stat-icon">🏆</div>
-          <div class="stat-number-wrapper">
-            <span class="stat-num" data-target="180">0</span><span class="stat-plus">+</span>
-          </div>
-          <p class="stat-label">Countries Represented</p>
-        </div>
+      <div class="stat-number-wrapper">
+        <span class="stat-num" data-target="1250000">0</span
+        ><span class="stat-plus">+</span>
       </div>
-    </section>
-
-    <section id="features" class="features-capabilities">
-      <div class="bento-container">
-        <h2 class="section-title">Platform Capabilities</h2>
-        <p class="section-subtitle">A premium suite of tools built for players of all skill levels.</p>
-        <div class="bento-grid">
-          
-          <!-- AI Opponent -->
-          <div class="bento-card bento-wide">
-            <div class="bento-visual ai-visual">
-              <div class="ai-brain-container">
-                 <div class="ai-node n1"></div>
-                 <div class="ai-node n2"></div>
-                 <div class="ai-node n3"></div>
-                 <div class="ai-node n4"></div>
-                 <div class="ai-node n5"></div>
-                 <svg class="ai-edges" viewBox="0 0 200 100">
-                    <line x1="100" y1="20" x2="50" y2="80" class="ai-edge" />
-                    <line x1="100" y1="20" x2="150" y2="80" class="ai-edge" />
-                    <line x1="50" y1="80" x2="20" y2="150" class="ai-edge" />
-                    <line x1="150" y1="80" x2="180" y2="150" class="ai-edge" />
-                 </svg>
-              </div>
-              <div class="ai-hud">
-                 <span class="hud-dot"></span> Alpha-Beta Pruning: Active<br>
-                 <span class="hud-dot"></span> Depth: 12
-              </div>
-            </div>
-            <div class="bento-content">
-              <div class="bento-title-row">
-                <div class="bento-icon-small">
-                  <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M12 2a3 3 0 0 0-3 3c0 .8.3 1.5.8 2H8a3 3 0 0 0-3 3v2h14v-2a3 3 0 0 0-3-3h-1.2c.5-.5.8-1.2.8-2a3 3 0 0 0-3-3z"/>
-                    <path d="M19 21H5a1 1 0 0 1-1-1v-2c0-1.7 1.3-3 3-3h10c1.7 0 3 1.3 3 3v2a1 1 0 0 1-1 1z"/>
-                    <line x1="6" y1="18" x2="18" y2="18"/>
-                  </svg>
-                </div>
-                <h3 class="bento-title">AI Opponent</h3>
-              </div>
-              <p class="bento-desc">Challenge an advanced AI opponent utilizing minimax search with alpha-beta pruning optimization.</p>
-            </div>
-          </div>
-
-          <!-- Game Timer -->
-          <div class="bento-card">
-            <div class="bento-visual timer-visual">
-               <div class="digital-clock">05<span class="blink">:</span>00</div>
-               <div class="timer-controls">
-                  <button class="t-btn">⏸</button>
-                  <button class="t-btn active">▶</button>
-               </div>
-            </div>
-            <div class="bento-content">
-              <div class="bento-title-row">
-                <div class="bento-icon-small">
-                  <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <circle cx="12" cy="12" r="10"></circle>
-                    <polyline points="12 6 12 12 15 14"></polyline>
-                  </svg>
-                </div>
-                <h3 class="bento-title">Game Timer</h3>
-              </div>
-              <p class="bento-desc">Configure Bullet, Blitz, or Rapid timers featuring real-time synchronization.</p>
-            </div>
-          </div>
-
-          <!-- Live Material Score -->
-          <div class="bento-card">
-            <div class="bento-visual score-visual">
-               <div class="material-row white-mat">
-                  <span class="mat-pieces">♙ ♙ ♘</span>
-                  <span class="mat-score">+3</span>
-               </div>
-               <div class="material-row black-mat">
-                  <span class="mat-pieces">♟</span>
-                  <span class="mat-score">-</span>
-               </div>
-            </div>
-            <div class="bento-content">
-              <div class="bento-title-row">
-                <div class="bento-icon-small">
-                  <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <line x1="18" y1="20" x2="18" y2="10"/>
-                    <line x1="12" y1="20" x2="12" y2="4"/>
-                    <line x1="6" y1="20" x2="6" y2="14"/>
-                  </svg>
-                </div>
-                <h3 class="bento-title">Live Material Score</h3>
-              </div>
-              <p class="bento-desc">Monitor point differentials and track captured pieces dynamically.</p>
-            </div>
-          </div>
-
-          <!-- PvP & PvE -->
-          <div class="bento-card mode-interactive-card">
-            <div class="bento-visual modes-visual">
-               <div class="mode-switch-container">
-                  <div class="mode-switch">
-                     <div class="m-option opt-pvp active">PvP</div>
-                     <div class="m-option opt-pve">PvE</div>
-                  </div>
-               </div>
-               <div class="mode-avatars-wrap">
-                  <div class="mode-avatars pvp-mode">
-                     <div class="m-avatar player1">🧑</div>
-                     <div class="m-vs">VS</div>
-                     <div class="m-avatar player2">🧑</div>
-                  </div>
-                  <div class="mode-avatars pve-mode">
-                     <div class="m-avatar player1">🧑</div>
-                     <div class="m-vs">VS</div>
-                     <div class="m-avatar player2">🤖</div>
-                  </div>
-               </div>
-            </div>
-            <div class="bento-content">
-              <div class="bento-title-row">
-                <div class="bento-icon-small">
-                  <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
-                    <circle cx="9" cy="7" r="4"/>
-                    <path d="M23 21v-2a4 4 0 0 0-3-3.87"/>
-                    <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
-                  </svg>
-                </div>
-                <h3 class="bento-title">PvP & PvE Modes</h3>
-              </div>
-              <p class="bento-desc">Compete locally against friends in Pass & Play mode, or test your skills against the engine.</p>
-            </div>
-          </div>
-
-          <!-- Full Move Validation -->
-          <div class="bento-card">
-            <div class="bento-visual valid-visual">
-               <div class="chess-grid-mini">
-                  <div class="cg-sq light"></div><div class="cg-sq dark"><span class="cg-piece">♞</span></div><div class="cg-sq light"></div>
-                  <div class="cg-sq dark"></div><div class="cg-sq light"></div><div class="cg-sq dark"></div>
-                  <div class="cg-sq light valid-target"></div><div class="cg-sq dark"></div><div class="cg-sq light"></div>
-                  <svg class="cg-arrow" viewBox="0 0 100 100" preserveAspectRatio="none">
-                     <path d="M 50 15 L 50 85 L 15 85" fill="none" stroke="var(--accent-gold)" stroke-width="4" stroke-linejoin="round" marker-end="url(#arrowhead)"/>
-                     <defs>
-                        <marker id="arrowhead" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-                          <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--accent-gold)" />
-                        </marker>
-                      </defs>
-                  </svg>
-               </div>
-            </div>
-            <div class="bento-content">
-              <div class="bento-title-row">
-                <div class="bento-icon-small">
-                  <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
-                    <polyline points="9 11 11 13 15 9"/>
-                  </svg>
-                </div>
-                <h3 class="bento-title">Full Move Validation</h3>
-              </div>
-              <p class="bento-desc">Rigorous real-time move validation covering castling, en passant, and promotions.</p>
-            </div>
-          </div>
-
-          <!-- Interactive Lessons — full width (bento-full, moved above PvP row) -->
-          <div class="bento-card bento-full">
-            <div class="lessons-inner">
-
-              <!-- LEFT: existing lesson mockup + text -->
-              <div class="lessons-left">
-                <div class="bento-visual lessons-visual" style="flex:1; margin-bottom:1rem;">
-                  <div class="lesson-mockup">
-                    <div class="lm-video">
-                      <div class="lm-play-btn">▶</div>
-                    </div>
-                    <div class="lm-details">
-                      <span class="lm-badge">Chapter 4</span>
-                      <div class="lm-title">Mastering the Sicilian Defense</div>
-                      <div class="lm-progress-bg"><div class="lm-progress-fill"></div></div>
-                    </div>
-                  </div>
-                </div>
-                <div class="bento-content">
-                  <div class="bento-title-row">
-                    <div class="bento-icon-small">
-                      <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"/>
-                      </svg>
-                    </div>
-                    <h3 class="bento-title">Interactive Lessons</h3>
-                  </div>
-                  <p class="bento-desc">Learn openings, endgames, and tactics through step-by-step tutorials — then test yourself with end-of-lesson quizzes.</p>
-                </div>
-              </div>
-
-              <!-- DIVIDER -->
-              <div class="lessons-divider"></div>
-
-              <!-- RIGHT: quiz preview diagram -->
-              <div class="lessons-right">
-                <div class="quiz-preview-badge">Quiz · End of Chapter</div>
-                <div class="quiz-preview-question">Which move opens the Sicilian Defence?</div>
-                <div class="quiz-preview-opts">
-                  <div class="qpo">a) &nbsp;1. d4</div>
-                  <div class="qpo qpo-correct">b) &nbsp;1. e4 c5 ✓</div>
-                  <div class="qpo">c) &nbsp;1. Nf3</div>
-                  <div class="qpo">d) &nbsp;1. c4</div>
-                </div>
-                <div class="quiz-preview-footer">
-                  <span class="qpf-dot qpf-done"></span>
-                  <span class="qpf-dot qpf-done"></span>
-                  <span class="qpf-dot qpf-active"></span>
-                  <span class="qpf-dot"></span>
-                  <span class="qpf-label">Q 3 of 4</span>
-                </div>
-              </div>
-
-            </div>
-          </div>
-
-        </div>
+      <p class="stat-label">Games Played</p>
+    </div>
+    <div class="stat-box">
+      <div class="stat-icon">
+        <svg aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M3 8 6 11 12 4 18 11 21 8 19 18H5z" />
+          <path d="M5 18h14" />
+        </svg>
       </div>
-    </section>
-
-    <section id="about" class="about-pin-section">
-        <div class="about-pin-sticky">
-
-          <h2 class="section-title">About Us</h2>
-
-          <div class="about-box">
-
-            <!-- Pause/Play Button -->
-            <button id="aboutPausePlayBtn" class="about-pause-play-btn" aria-label="Pause Auto-Slide">
-                <svg id="icon-pause" width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="4" width="4" height="16"></rect><rect x="14" y="4" width="4" height="16"></rect></svg>
-                <svg id="icon-play" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style="display:none;"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg>
-            </button>
-
-            <!-- Progress Bar -->
-            <div class="about-progress-bar">
-                <div class="about-progress-fill" id="aboutProgressFill"></div>
-            </div>
-
-            <!-- Card Counter -->
-            <div class="about-counter">
-                <span id="aboutCurrentCard">1</span>
-                <span class="about-counter-sep">/</span>
-                <span>4</span>
-            </div>
-
-            <!-- Track -->
-            <div class="about-track-wrapper">
-                <div class="about-track" id="aboutTrack">
-
-                    <!-- Card 1 — Mission & Vision -->
-                    <div class="about-card">
-                        <div class="about-card-visual">
-                            <div class="mv-icon-wrap">
-                                <span class="mv-piece">♚</span>
-                                <div class="mv-ring ring1"></div>
-                                <div class="mv-ring ring2"></div>
-                                <div class="mv-ring ring3"></div>
-                            </div>
-                            <div class="mv-path">
-                                <div class="mv-path-dot"></div>
-                                <div class="mv-path-line"></div>
-                                <div class="mv-path-dot"></div>
-                                <div class="mv-path-line"></div>
-                                <div class="mv-path-dot active"></div>
-                            </div>
-                        </div>
-                        <div class="about-card-content">
-                            <span class="about-card-tag">Mission & Vision</span>
-                            <h3 class="about-card-title">Play Smarter. Grow Further.</h3>
-                            <p class="about-card-desc">Checkora was built with a single mission — to make high-performance chess accessible to everyone. Our vision is a platform where every player, from beginner to expert, can challenge themselves, track real growth, and experience chess the way it was meant to be played.</p>
-                            <div class="about-stats-row">
-                                <div class="about-stat">
-                                    <span class="about-stat-num" data-target="3">0</span>
-                                    <span class="about-stat-label">Game Modes</span>
-                                </div>
-                                <div class="about-stat">
-                                    <div style="display: flex; align-items: baseline;"><span class="about-stat-num" data-target="50">0</span><span style="color:var(--accent-gold);font-weight:800;font-size:2.2rem;font-family:'Exo 2', sans-serif;">+</span></div>
-                                    <span class="about-stat-label">Achievements</span>
-                                </div>
-                                <div class="about-stat">
-                                    <div style="display: flex; align-items: baseline;"><span class="about-stat-num" data-target="100">0</span><span style="color:var(--accent-gold);font-weight:800;font-size:2.2rem;font-family:'Exo 2', sans-serif;">%</span></div>
-                                    <span class="about-stat-label">Free to Play</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Card 2 — Open Source -->
-                    <div class="about-card">
-                        <div class="about-card-visual">
-                            <div class="os-graph">
-                                <div class="os-graph-title">Contribution Activity</div>
-                                <div class="os-grid" id="osGrid"></div>
-                                <div class="os-graph-footer">
-                                    <span>Open Source on GitHub</span>
-                                    <span class="os-badge">MIT License</span>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="about-card-content">
-                            <span class="about-card-tag">Open Source & Community</span>
-                            <h3 class="about-card-title">Built in the Open. Grown Together.</h3>
-                            <p class="about-card-desc">Checkora is fully open source under the MIT License. Every feature, every fix, every improvement is a community effort. Join developers worldwide contributing to the engine, the interface, and the future of the platform.</p>
-                            <div class="os-links">
-                                <a href="https://github.com/Checkora" target="_blank" class="os-link-btn">
-                                    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
-                                    GitHub
-                                </a>
-                                <a href="https://discord.gg/WfrpMuNZn" target="_blank" class="os-link-btn discord">
-                                    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M19.27 5.33C17.94 4.71 16.5 4.26 15 4a.09.09 0 0 0-.07.03c-.18.33-.39.76-.53 1.09a16.09 16.09 0 0 0-4.8 0c-.14-.34-.35-.76-.54-1.09c-.01-.02-.04-.03-.07-.03c-1.5.26-2.93.71-4.27 1.33c-.01 0-.02.01-.03.02c-2.72 4.07-3.47 8.03-3.1 11.95c0 .02.02.04.03.05c1.8 1.32 3.53 2.12 5.24 2.65c.03.01.06 0 .07-.02c.4-.55.76-1.13 1.07-1.74c.02-.04 0-.08-.04-.09c-.57-.22-1.11-.48-1.64-.78c-.04-.02-.04-.08-.01-.11c.11-.08.22-.17.33-.25c.02-.02.05-.02.07-.01c3.44 1.57 7.15 1.57 10.55 0c.02-.01.05-.01.07.01c.11.09.22.17.33.26c.04.03.04.09-.01.11c-.52.31-1.07.56-1.64.78c-.04.01-.05.06-.04.09c.32.61.68 1.19 1.07 1.74c.03.01.06 0 .09.01c1.72-.53 3.45-1.33 5.25-2.65c.02-.01.03-.03.03-.05.44-4.53-.73-8.46-3.1-11.95c-.01-.01-.02-.02-.04-.02zM8.52 14.91c-1.03 0-1.89-.95-1.89-2.12s.84-2.12 1.89-2.12c1.06 0 1.9.96 1.89 2.12c0 1.17-.84 2.12-1.89 2.12zm6.97 0c-1.03 0-1.89-.95-1.89-2.12s.84-2.12 1.89-2.12c1.06 0 1.9.96 1.89 2.12c0 1.17-.83 2.12-1.89 2.12z"/></svg>
-                                    Discord
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Card 3 — Technical Architecture -->
-                      <div class="about-card">
-                        <div class="about-card-visual">
-                            <div class="perf-meter">
-                                <div class="perf-gauge-wrap">
-                                  <svg class="perf-svg" viewBox="0 0 200 120" xmlns="http://www.w3.org/2000/svg">
-                                      <!-- Track arc -->
-                                      <path d="M 20 100 A 80 80 0 0 1 180 100" fill="none" stroke="rgba(255,255,255,0.06)" stroke-width="12" stroke-linecap="round"/>
-                                      <!-- Gold fill arc -->
-                                      <path class="perf-arc" d="M 20 100 A 80 80 0 0 1 180 100" fill="none" stroke="url(#goldGrad)" stroke-width="12" stroke-linecap="round" stroke-dasharray="251" stroke-dashoffset="251"/>
-                                      <!-- Needle -->
-                                      <line class="perf-needle" x1="100" y1="100" x2="100" y2="30" stroke="#f0c040" stroke-width="2.5" stroke-linecap="round" transform-origin="100 100"/>
-                                      <!-- Center dot -->
-                                      <circle cx="100" cy="100" r="6" fill="#f0c040" filter="url(#glow)"/>
-                                      <defs>
-                                          <linearGradient id="goldGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-                                              <stop offset="0%" stop-color="#d4a020"/>
-                                              <stop offset="100%" stop-color="#ffeaa7"/>
-                                          </linearGradient>
-                                          <filter id="glow">
-                                              <feGaussianBlur stdDeviation="2" result="blur"/>
-                                              <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
-                                          </filter>
-                                      </defs>
-                                  </svg>
-                                  <div class="perf-value-wrap">
-                                      <span class="perf-value" id="perfValue">0</span>
-                                      <span class="perf-unit">k nodes/s</span>
-                                  </div>
-                              </div>
-                              <div class="perf-chips">
-                                  <div class="perf-chip">
-                                      <span class="perf-chip-dot"></span>
-                                      <span class="perf-chip-label">Depth</span>
-                                      <span class="perf-chip-val" id="depthVal">0</span>
-                                  </div>
-                                  <div class="perf-chip">
-                                      <span class="perf-chip-dot green"></span>
-                                      <span class="perf-chip-label">Alpha-Beta</span>
-                                      <span class="perf-chip-val">ON</span>
-                                  </div>
-                                  <div class="perf-chip">
-                                      <span class="perf-chip-dot blue"></span>
-                                      <span class="perf-chip-label">Engine</span>
-                                      <span class="perf-chip-val">C++17</span>
-                                  </div>
-                              </div>
-                            </div>
-                          </div>
-                        <div class="about-card-content">
-                            <span class="about-card-tag">Technical Architecture</span>
-                            <h3 class="about-card-title">Fast by Design. Powerful by Nature.</h3>
-                            <p class="about-card-desc">Under the hood, Checkora runs a high-performance C++17 minimax engine with alpha-beta pruning for lightning-fast move calculations. Python orchestrates game logic while Django handles routing and authentication — a true hybrid stack built for performance.</p>
-                            <div class="tech-pills">
-                                <span class="tech-pill">Alpha-Beta Pruning</span>
-                                <span class="tech-pill">Minimax Search</span>
-                                <span class="tech-pill">REST API</span>
-                                <span class="tech-pill">Django Auth</span>
-                                <span class="tech-pill">C++17</span>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Card 4 — Built for Chess Players -->
-                    <div class="about-card">
-                        <div class="about-card-visual">
-                            <div class="chess-visual-wrap">
-                                <div class="mini-board-inner" id="miniBoard"></div>
-                                <div class="mini-board-label">Sicilian Defence</div>
-                            </div>
-                        </div>
-                        <div class="about-card-content">
-                            <span class="about-card-tag">Built for Chess Players</span>
-                            <h3 class="about-card-title">Every Move. Every Player.</h3>
-                            <p class="about-card-desc">Whether you are learning your first opening or grinding ranked games, Checkora is built for you. Full FIDE rule support, multiple time controls, live material tracking, achievements, leaderboards, and interactive lessons — everything a chess player needs in one place.</p>
-                            <div class="chess-features-list">
-                                <div class="chess-feature-item">
-                                    <span class="chess-feature-icon">♟</span>
-                                    <span>Full FIDE Rules — castling, en passant, promotion</span>
-                                </div>
-                                <div class="chess-feature-item">
-                                    <span class="chess-feature-icon">⏱</span>
-                                    <span>Bullet, Blitz & Rapid time controls</span>
-                                </div>
-                                <div class="chess-feature-item">
-                                    <span class="chess-feature-icon">📊</span>
-                                    <span>Live material tracking & game stats</span>
-                                </div>
-                                <div class="chess-feature-item">
-                                    <span class="chess-feature-icon">🏆</span>
-                                    <span>Leaderboards & achievement system</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                </div>
-            </div>
-
-            <!-- Dot Indicators -->
-            <div class="about-dots" id="aboutDots">
-                <button type="button" class="about-dot active" data-index="0" aria-label="Go to slide 1" aria-pressed="true"></button>
-                <button type="button" class="about-dot" data-index="1" aria-label="Go to slide 2" aria-pressed="false"></button>
-                <button type="button" class="about-dot" data-index="2" aria-label="Go to slide 3" aria-pressed="false"></button>
-                <button type="button" class="about-dot" data-index="3" aria-label="Go to slide 4" aria-pressed="false"></button>
-            </div>
-          </div>
-
-        </div>
-    </section>
-
-    <!-- ── User Testimonials Section ── -->
-    <section id="testimonials" class="testimonials-section">
-      <div class="bento-container">
-        <h2 class="section-title">Community Feedback</h2>
-        <p class="section-subtitle">What players and developers worldwide are saying about Checkora's engine.</p>
-        
-        <div class="testimonials-grid">
-          
-          <!-- Testimonial 1 -->
-          <div class="testimonial-card">
-            <div class="testimonial-stars">★★★★★</div>
-            <p class="testimonial-text">"The performance shift when calculating endgames natively with the C++ minimax engine core is unbelievable. Real-time material scores sync up instantly."</p>
-            <div class="testimonial-user">
-              <div class="user-avatar">🤖</div>
-              <div class="user-info">
-                <h4 class="user-name">Alex Rivera</h4>
-                <span class="user-title">National Master</span>
-              </div>
-            </div>
-          </div>
-
-          <!-- Testimonial 2 -->
-          <div class="testimonial-card highlight-card">
-            <div class="testimonial-stars">★★★★★</div>
-            <p class="testimonial-text">"As an open-source contributor, building feature modules on top of this Django framework has been super clean. Truly a state-of-the-art hybrid platform setup."</p>
-            <div class="testimonial-user">
-              <div class="user-avatar">🧑‍💻</div>
-              <div class="user-info">
-                <h4 class="user-name">Sarah Chen</h4>
-                <span class="user-title">Core Developer</span>
-              </div>
-            </div>
-          </div>
-
-          <!-- Testimonial 3 -->
-          <div class="testimonial-card">
-            <div class="testimonial-stars">★★★★★</div>
-            <p class="testimonial-text">"The interactive lessons and end-of-chapter quizzes transformed my Sicilian Defence opening lines. Highly recommend to club players grinding ranked matches!"</p>
-            <div class="testimonial-user">
-              <div class="user-avatar">♟️</div>
-              <div class="user-info">
-                <h4 class="user-name">Marcus Brody</h4>
-                <span class="user-title">Club Player (1900 ELO)</span>
-              </div>
-            </div>
-          </div>
-
-        </div>
+      <div class="stat-number-wrapper">
+        <span class="stat-num" data-target="45000">0</span
+        ><span class="stat-plus">+</span>
       </div>
-    </section>
+      <p class="stat-label">Active Players</p>
+    </div>
+    <div class="stat-box">
+      <div class="stat-icon">
+        <svg aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M13 2 4 14h6l-1 8 9-12h-6z" />
+        </svg>
+      </div>
+      <div class="stat-number-wrapper">
+        <span class="stat-num" data-target="850">0</span
+        ><span class="stat-suffix">k/s</span>
+      </div>
+      <p class="stat-label">Engine Node Speed</p>
+    </div>
+    <div class="stat-box">
+      <div class="stat-icon">
+        <svg aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M8 21h8" />
+          <path d="M12 17v4" />
+          <path d="M7 4h10v6a5 5 0 0 1-10 0z" />
+          <path d="M7 5H4a3 3 0 0 0 3 4" />
+          <path d="M17 5h3a3 3 0 0 1-3 4" />
+        </svg>
+      </div>
+      <div class="stat-number-wrapper">
+        <span class="stat-num" data-target="180">0</span
+        ><span class="stat-plus">+</span>
+      </div>
+      <p class="stat-label">Countries Represented</p>
+    </div>
+  </div>
+</section>
 
-    <section id="faq" class="faq-section">
-      <div class="faq-container">
-        <h2 class="section-title">Frequently Asked Questions</h2>
-        <p class="faq-subtitle">Everything you need to know about the Checkora chess platform architecture and functionality.</p>
-        
-        <div class="faq-wrapper">
-          <div class="faq-item">
-            <button class="faq-question">
-              <span>What makes Checkora a "Hybrid Intelligence" engine?</span>
-              <span class="faq-icon-arrow">
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
-              </span>
-            </button>
-            <div class="faq-answer">
-              <div class="faq-answer-content">
-                Checkora offloads complex, compute-intensive tactical configurations and minimax analytics natively to a super-fast, highly optimized C++17 core. Meanwhile, a flexible Python and Django application framework manages sessions, game data validation routing, and smooth presentation handling seamlessly.
-              </div>
-            </div>
+<section id="features" class="features-capabilities">
+  <div class="bento-container">
+    <h2 class="section-title">Platform Capabilities</h2>
+    <p class="section-subtitle">
+      A premium suite of tools built for players of all skill levels.
+    </p>
+    <div class="bento-grid">
+      <!-- AI Opponent -->
+      <div class="bento-card bento-wide">
+        <div class="bento-visual ai-visual">
+          <div class="ai-brain-container">
+            <div class="ai-node n1"></div>
+            <div class="ai-node n2"></div>
+            <div class="ai-node n3"></div>
+            <div class="ai-node n4"></div>
+            <div class="ai-node n5"></div>
+            <svg class="ai-edges" viewBox="0 0 200 100">
+              <line x1="100" y1="20" x2="50" y2="80" class="ai-edge" />
+              <line x1="100" y1="20" x2="150" y2="80" class="ai-edge" />
+              <line x1="50" y1="80" x2="20" y2="150" class="ai-edge" />
+              <line x1="150" y1="80" x2="180" y2="150" class="ai-edge" />
+            </svg>
           </div>
-
-          <div class="faq-item">
-            <button class="faq-question">
-              <span>Can I customize the game timing modes?</span>
-              <span class="faq-icon-arrow">
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
-              </span>
-            </button>
-            <div class="faq-answer">
-              <div class="faq-answer-content">
-                Yes! The platform natively supports configuration profiles optimized for Bullet, Blitz, and Rapid variants. Match setups are backed up by accurate real-time validation layers that support timing pause-and-resume cycles on active connections.
-              </div>
-            </div>
-          </div>
-
-          <div class="faq-item">
-            <button class="faq-question">
-              <span>Does the platform support official FIDE rules?</span>
-              <span class="faq-icon-arrow">
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
-              </span>
-            </button>
-            <div class="faq-answer">
-              <div class="faq-answer-content">
-                Absolutely. Checkora's structural architecture natively features rigorous full move validation processes checking rulesets for castling permissions, en passant states, standard checking conditions, stalemates, and dynamic pawn promotion updates.
-              </div>
-            </div>
-          </div>
-
-          <div class="faq-item">
-            <button class="faq-question">
-              <span>Is my gameplay history and analytical tracking private?</span>
-              <span class="faq-icon-arrow">
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
-              </span>
-            </button>
-            <div class="faq-answer">
-              <div class="faq-answer-content">
-                All metrics are securely tied inside Django application instances. Users gain standalone access controls over structural game analytics, tracking dashboard components, and full options to wipe historical records cleanly via account deletion pathways.
-              </div>
-            </div>
+          <div class="ai-hud">
+            <span class="hud-dot"></span> Alpha-Beta Pruning: Active<br />
+            <span class="hud-dot"></span> Depth: 12
           </div>
         </div>
-      </div>
-    </section>
-
-    <footer class="footer">
-      <div class="footer-container">
-        <div class="footer-col brand-column">
-          <a href="{% url 'landing' %}" class="logo-link">
-            <img
-              src="{% static 'game/checkora_icon_only.png' %}"
-              alt="Checkora Logo"
-              class="logo-img"
-            />
-            <span class="logo-text">CHECK<span class="logo-accent">ORA</span></span>
-          </a>
-          <p class="brand-desc">
-            Experience high-performance chess with Checkora's hybrid C++ engine.
-            Challenge the AI, track your stats, and master the board.
+        <div class="bento-content">
+          <div class="bento-title-row">
+            <div class="bento-icon-small">
+              <svg
+                aria-hidden="true"
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path
+                  d="M12 2a3 3 0 0 0-3 3c0 .8.3 1.5.8 2H8a3 3 0 0 0-3 3v2h14v-2a3 3 0 0 0-3-3h-1.2c.5-.5.8-1.2.8-2a3 3 0 0 0-3-3z"
+                />
+                <path
+                  d="M19 21H5a1 1 0 0 1-1-1v-2c0-1.7 1.3-3 3-3h10c1.7 0 3 1.3 3 3v2a1 1 0 0 1-1 1z"
+                />
+                <line x1="6" y1="18" x2="18" y2="18" />
+              </svg>
+            </div>
+            <h3 class="bento-title">AI Opponent</h3>
+          </div>
+          <p class="bento-desc">
+            Challenge an advanced AI opponent utilizing minimax search with
+            alpha-beta pruning optimization.
           </p>
         </div>
+      </div>
 
-        <div class="footer-col">
-          <h4>Platform</h4>
-          <ul class="footer-nav-list">
-            <li><a href="{% url 'index' %}" class="footer-link">Play Game</a></li>
-            <li><a href="{% url 'leaderboard' %}" class="footer-link">Leaderboard</a></li>
-            <li><a href="{% url 'achievements' %}" class="footer-link">Achievements</a></li>
-            <li><a href="{% url 'stats' %}" class="footer-link">Statistics</a></li>
-            <li><a href="{% url 'rules' %}" class="footer-link">Rulebook</a></li>
-            <li><a href="{% url 'lessons' %}" class="footer-link">Lessons</a></li>
-            <li><a href="{% url 'puzzles' %}" class="footer-link">Puzzles</a></li>
-          </ul>
+      <!-- Game Timer -->
+      <div class="bento-card">
+        <div class="bento-visual timer-visual">
+          <div class="digital-clock">05<span class="blink">:</span>00</div>
+          <div class="timer-controls">
+            <button class="t-btn">⏸</button>
+            <button class="t-btn active">▶</button>
+          </div>
         </div>
-
-        <div class="footer-col">
-          <h4>Community</h4>
-          <ul class="footer-nav-list">
-            <li>
-              <a href="https://github.com/Checkora" target="_blank" rel="noopener noreferrer" class="footer-link">
-                GitHub Organization
-              </a>
-            </li>
-            <li>
-              <a href="https://discord.gg/WfrpMuNZn" target="_blank" rel="noopener noreferrer" class="footer-link">
-                Discord Community
-              </a>
-            </li>
-            <li class="maintainer-item">
-  <span class="footer-meta-text">
-    Core Maintainers:
-    <a href="https://github.com/EDWARD-012"
-       target="_blank"
-       rel="noopener noreferrer">
-      @EDWARD-012
-    </a>
-    &amp;
-    <a href="https://github.com/triemerge"
-       target="_blank"
-       rel="noopener noreferrer">
-      @triemerge
-    </a>
-  </span>
-</li>
-
-<li class="maintainer-item">
-  <span class="footer-meta-text">
-    Contributors:
-    <!-- Replace these with the actual contributors -->
-    <a href="https://github.com/username1"
-       target="_blank"
-       rel="noopener noreferrer">
-      @username1
-    </a>
-    &amp;
-    <a href="https://github.com/username2"
-       target="_blank"
-       rel="noopener noreferrer">
-      @username2
-    </a>
-  </span>
-</li>
-</ul>
-</div>
-      
-        <div class="footer-col">
-          <h4>Legal</h4>
-          <ul class="footer-nav-list">
-            <li><a href="#" class="footer-link" data-modal-trigger="privacyModal">Privacy Policy</a></li>
-            <li><a href="#" class="footer-link" onclick="openTermsModal(); return false;">Terms & Conditions</a></li>     
-            <li><a href="#" class="footer-link" onclick="openDisclaimerModal(); return false;">Disclaimer</a></li>
-            <li><a href="#" class="footer-link" onclick="openContactModal(); return false;">Contact Us</a></li>
-          </ul>
+        <div class="bento-content">
+          <div class="bento-title-row">
+            <div class="bento-icon-small">
+              <svg
+                aria-hidden="true"
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <circle cx="12" cy="12" r="10"></circle>
+                <polyline points="12 6 12 12 15 14"></polyline>
+              </svg>
+            </div>
+            <h3 class="bento-title">Game Timer</h3>
+          </div>
+          <p class="bento-desc">
+            Configure Bullet, Blitz, or Rapid timers featuring real-time
+            synchronization.
+          </p>
         </div>
       </div>
 
-      <div class="footer-bottom">
-        <span class="footer-copy">
-          &copy; {% now "Y" %} Checkora Hybrid Engine. All rights reserved.
-        </span>
-        <div class="footer-socials">
-          <a href="https://github.com/Checkora" target="_blank" rel="noopener noreferrer" aria-label="GitHub Link">
-            <svg width="20" height="20" viewBox="0 0 24 24">
-              <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" fill="currentColor"/>
-            </svg>
-          </a>
-          <a href="https://discord.gg/WfrpMuNZn" target="_blank" rel="noopener noreferrer" aria-label="Discord Link">
-            <svg width="20" height="20" viewBox="0 0 24 24">
-              <path d="M19.27 5.33C17.94 4.71 16.5 4.26 15 4a.09.09 0 0 0-.07.03c-.18.33-.39.76-.53 1.09a16.09 16.09 0 0 0-4.8 0c-.14-.34-.35-.76-.54-1.09c-.01-.02-.04-.03-.07-.03c-1.5.26-2.93.71-4.27 1.33c-.01 0-.02.01-.03.02c-2.72 4.07-3.47 8.03-3.1 11.95c0 .02.02.04.03.05c1.8 1.32 3.53 2.12 5.24 2.65c.03.01.06 0 .07-.02c.4-.55.76-1.13 1.07-1.74c.02-.04 0-.08-.04-.09c-.57-.22-1.11-.48-1.64-.78c-.04-.02-.04-.08-.01-.11c.11-.08.22-.17.33-.25c.02-.02.05-.02.07-.01c3.44 1.57 7.15 1.57 10.55 0c.02-.01.05-.01.07.01c.11.09.22.17.33.26c.04.03.04.09-.01.11c-.52.31-1.07.56-1.64.78c-.04.01-.05.06-.04.09c.32.61.68 1.19 1.07 1.74c.03.01.06 0 .09.01c1.72-.53 3.45-1.33 5.25-2.65c.02-.01.03-.03.03-.05.44-4.53-.73-8.46-3.1-11.95c-.01-.01-.02-.02-.04-.02zM8.52 14.91c-1.03 0-1.89-.95-1.89-2.12s.84-2.12 1.89-2.12c1.06 0 1.9.96 1.89 2.12c0 1.17-.84 2.12-1.89 2.12zm6.97 0c-1.03 0-1.89-.95-1.89-2.12s.84-2.12 1.89-2.12c1.06 0 1.9.96 1.89 2.12c0 1.17-.83 2.12-1.89 2.12z" fill="currentColor"/>
-            </svg>
-          </a>
+      <!-- Live Material Score -->
+      <div class="bento-card">
+        <div class="bento-visual score-visual">
+          <div class="material-row white-mat">
+            <span class="mat-pieces">♙ ♙ ♘</span>
+            <span class="mat-score">+3</span>
+          </div>
+          <div class="material-row black-mat">
+            <span class="mat-pieces">♟</span>
+            <span class="mat-score">-</span>
+          </div>
+        </div>
+        <div class="bento-content">
+          <div class="bento-title-row">
+            <div class="bento-icon-small">
+              <svg
+                aria-hidden="true"
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <line x1="18" y1="20" x2="18" y2="10" />
+                <line x1="12" y1="20" x2="12" y2="4" />
+                <line x1="6" y1="20" x2="6" y2="14" />
+              </svg>
+            </div>
+            <h3 class="bento-title">Live Material Score</h3>
+          </div>
+          <p class="bento-desc">
+            Monitor point differentials and track captured pieces dynamically.
+          </p>
         </div>
       </div>
 
-     </footer>
+      <!-- PvP & PvE -->
+      <div class="bento-card mode-interactive-card">
+        <div class="bento-visual modes-visual">
+          <div class="mode-switch-container">
+            <div class="mode-switch">
+              <div class="m-option opt-pvp active">PvP</div>
+              <div class="m-option opt-pve">PvE</div>
+            </div>
+          </div>
+          <div class="mode-avatars-wrap">
+            <div class="mode-avatars pvp-mode">
+              <div class="m-avatar player1">
+                <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <circle cx="12" cy="8" r="4" />
+                  <path d="M4 21c0-4.4 3.6-7 8-7s8 2.6 8 7" />
+                </svg>
+              </div>
+              <div class="m-vs">VS</div>
+              <div class="m-avatar player2">
+                <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <circle cx="12" cy="8" r="4" />
+                  <path d="M4 21c0-4.4 3.6-7 8-7s8 2.6 8 7" />
+                </svg>
+              </div>
+            </div>
+            <div class="mode-avatars pve-mode">
+              <div class="m-avatar player1">
+                <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <circle cx="12" cy="8" r="4" />
+                  <path d="M4 21c0-4.4 3.6-7 8-7s8 2.6 8 7" />
+                </svg>
+              </div>
+              <div class="m-vs">VS</div>
+              <div class="m-avatar player2">
+                <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <rect x="5" y="8" width="14" height="11" rx="2" />
+                  <path d="M12 8V4" />
+                  <circle cx="12" cy="3" r="1" />
+                  <circle cx="9" cy="13" r="1.2" />
+                  <circle cx="15" cy="13" r="1.2" />
+                  <path d="M9 17h6" />
+                  <path d="M2 12h3" />
+                  <path d="M19 12h3" />
+                </svg>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="bento-content">
+          <div class="bento-title-row">
+            <div class="bento-icon-small">
+              <svg
+                aria-hidden="true"
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+                <circle cx="9" cy="7" r="4" />
+                <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+                <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+              </svg>
+            </div>
+            <h3 class="bento-title">PvP & PvE Modes</h3>
+          </div>
+          <p class="bento-desc">
+            Compete locally against friends in Pass & Play mode, or test your
+            skills against the engine.
+          </p>
+        </div>
+      </div>
 
-    <div id="backToTopWrapper">
-      <span id="backToTopTooltip">Back to Top</span>
-      <button type="button" id="backToTopBtn" aria-label="Back to top" onclick="window.scrollTo({top:0,behavior:'smooth'})">
-        <span class="btn-arrow">^</span>
+      <!-- Full Move Validation -->
+      <div class="bento-card">
+        <div class="bento-visual valid-visual">
+          <div class="chess-grid-mini">
+            <div class="cg-sq light"></div>
+            <div class="cg-sq dark"><span class="cg-piece">♞</span></div>
+            <div class="cg-sq light"></div>
+            <div class="cg-sq dark"></div>
+            <div class="cg-sq light"></div>
+            <div class="cg-sq dark"></div>
+            <div class="cg-sq light valid-target"></div>
+            <div class="cg-sq dark"></div>
+            <div class="cg-sq light"></div>
+            <svg
+              class="cg-arrow"
+              viewBox="0 0 100 100"
+              preserveAspectRatio="none"
+            >
+              <path
+                d="M 50 15 L 50 85 L 15 85"
+                fill="none"
+                stroke="var(--accent-gold)"
+                stroke-width="4"
+                stroke-linejoin="round"
+                marker-end="url(#arrowhead)"
+              />
+              <defs>
+                <marker
+                  id="arrowhead"
+                  viewBox="0 0 10 10"
+                  refX="5"
+                  refY="5"
+                  markerWidth="6"
+                  markerHeight="6"
+                  orient="auto-start-reverse"
+                >
+                  <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--accent-gold)" />
+                </marker>
+              </defs>
+            </svg>
+          </div>
+        </div>
+        <div class="bento-content">
+          <div class="bento-title-row">
+            <div class="bento-icon-small">
+              <svg
+                aria-hidden="true"
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+                <polyline points="9 11 11 13 15 9" />
+              </svg>
+            </div>
+            <h3 class="bento-title">Full Move Validation</h3>
+          </div>
+          <p class="bento-desc">
+            Rigorous real-time move validation covering castling, en passant,
+            and promotions.
+          </p>
+        </div>
+      </div>
+
+      <!-- Interactive Lessons -->
+      <div class="bento-card bento-full">
+        <div class="lessons-inner">
+          <div class="lessons-left">
+            <div
+              class="bento-visual lessons-visual"
+              style="flex: 1; margin-bottom: 1rem"
+            >
+              <div class="lesson-mockup">
+                <div class="lm-video">
+                  <div class="lm-play-btn">▶</div>
+                </div>
+                <div class="lm-details">
+                  <span class="lm-badge">Chapter 4</span>
+                  <div class="lm-title">Mastering the Sicilian Defense</div>
+                  <div class="lm-progress-bg">
+                    <div class="lm-progress-fill"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="bento-content">
+              <div class="bento-title-row">
+                <div class="bento-icon-small">
+                  <svg
+                    aria-hidden="true"
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <path
+                      d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"
+                    />
+                  </svg>
+                </div>
+                <h3 class="bento-title">Interactive Lessons</h3>
+              </div>
+              <p class="bento-desc">
+                Learn openings, endgames, and tactics through step-by-step
+                tutorials — then test yourself with end-of-lesson quizzes.
+              </p>
+            </div>
+          </div>
+
+          <div class="lessons-divider"></div>
+
+          <div class="lessons-right">
+            <div class="quiz-preview-badge">Quiz · End of Chapter</div>
+            <div class="quiz-preview-question">
+              Which move opens the Sicilian Defence?
+            </div>
+            <div class="quiz-preview-opts">
+              <div class="qpo">a) &nbsp;1. d4</div>
+              <div class="qpo qpo-correct">b) &nbsp;1. e4 c5 ✓</div>
+              <div class="qpo">c) &nbsp;1. Nf3</div>
+              <div class="qpo">d) &nbsp;1. c4</div>
+            </div>
+            <div class="quiz-preview-footer">
+              <span class="qpf-dot qpf-done"></span>
+              <span class="qpf-dot qpf-done"></span>
+              <span class="qpf-dot qpf-active"></span>
+              <span class="qpf-dot"></span>
+              <span class="qpf-label">Q 3 of 4</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="about" class="about-pin-section">
+  <div class="about-pin-sticky">
+    <h2 class="section-title">About Us</h2>
+
+    <div class="about-box">
+      <button
+        id="aboutPausePlayBtn"
+        class="about-pause-play-btn"
+        aria-label="Pause Auto-Slide"
+      >
+        <svg
+          id="icon-pause"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+        >
+          <rect x="6" y="4" width="4" height="16"></rect>
+          <rect x="14" y="4" width="4" height="16"></rect>
+        </svg>
+        <svg
+          id="icon-play"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          style="display: none"
+        >
+          <polygon points="5 3 19 12 5 21 5 3"></polygon>
+        </svg>
       </button>
-    </div>
-  
-    <script>
-      const backToTopWrapper = document.getElementById('backToTopWrapper');
-      window.addEventListener('scroll', () => {
-        backToTopWrapper.classList.toggle('visible', window.scrollY > 300);
-      });
-    
-      document.querySelectorAll('.faq-question').forEach(button => {
-        button.addEventListener('click', () => {
-          const faqItem = button.parentElement;
-          const answer = button.nextElementSibling;
-          document.querySelectorAll('.faq-item').forEach(item => {
-            if (item !== faqItem && item.classList.contains('active')) {
-              item.classList.remove('active');
-              item.querySelector('.faq-answer').style.maxHeight = null;
-            }
-          });
-          faqItem.classList.toggle('active');
-          if (faqItem.classList.contains('active')) {
-            answer.style.maxHeight = answer.scrollHeight + "px";
-          } else {
-            answer.style.maxHeight = null;
-          }
-        });
-      });
-    
-      document.addEventListener('DOMContentLoaded', function() {
-        const privacyModal = document.getElementById('privacyModal');
-        if (!privacyModal) return;
-        const privacyInner = privacyModal.querySelector('[tabindex="-1"]');
-        if (!privacyInner) return;
-        let lastFocused;
-    
-        window.openPrivacyModal = function(e) {
-          lastFocused = e ? e.target : document.activeElement;
-          privacyModal.style.display = 'flex';
-          privacyInner.focus();
-        };
-    
-        window.closePrivacyModal = function() {
-          privacyModal.style.display = 'none';
-          if (lastFocused) lastFocused.focus();
-        };
-    
-        document.querySelector('[data-modal-trigger="privacyModal"]').addEventListener('click', function(e) {
-          e.preventDefault();
-          openPrivacyModal(e);
-        });
-    
-        privacyModal.addEventListener('click', function(e) {
-          if (e.target === privacyModal) closePrivacyModal();
-        });
-    
-        document.addEventListener('keydown', function(e) {
-          if (e.key === 'Escape' && privacyModal.style.display === 'flex') closePrivacyModal();
-        });
-    
-        privacyModal.addEventListener('keydown', function(e) {
-          if (e.key === 'Tab') {
-            const focusable = privacyModal.querySelectorAll('button, [href], [tabindex]:not([tabindex="-1"])');
-            const first = focusable[0];
-            const last = focusable[focusable.length - 1];
-            if (e.shiftKey && document.activeElement === first) {
-              e.preventDefault(); last.focus();
-            } else if (!e.shiftKey && document.activeElement === last) {
-              e.preventDefault(); first.focus();
-            }
-          }
-        });
-      });
-    </script>
-    <div id="privacyModal" role="dialog" aria-modal="true" aria-labelledby="privacyModalTitle" style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.85); z-index:9999; align-items:center; justify-content:center;">
-      <div tabindex="-1" style="position:relative; background:#131522; border:1px solid rgba(240,192,64,0.2); border-radius:16px; width:90%; max-width:900px; max-height:88vh; display:flex; flex-direction:column; overflow:hidden;">
-        <div style="padding:24px 28px 16px; border-bottom:1px solid rgba(255,255,255,0.07); display:flex; justify-content:space-between; align-items:center; flex-shrink:0;">
-          <h1 id="privacyModalTitle" style="color:#f0c040; font-size:1.6rem; font-weight:700; letter-spacing:-0.3px;">Privacy Policy</h1>
-          <button type="button" aria-label="Close privacy policy" onclick="closePrivacyModal()" style="background:rgba(255,255,255,0.08); border:none; color:#fff; width:32px; height:32px; border-radius:50%; cursor:pointer; font-size:1rem; display:flex; align-items:center; justify-content:center;">✕</button>
-        </div>
-        <div class="modal-scroll-content" style="overflow-y:auto; padding:24px 28px; flex:1;">
-          <div style="display:flex; flex-direction:column; gap:14px;">
-            <div style="background:#1a1c2e; border:1px solid rgba(255,255,255,0.06); border-radius:12px; padding:20px 22px; display:flex; gap:16px; align-items:flex-start;">
-              <span style="background:rgba(240,192,64,0.15); color:#f0c040; border-radius:50%; width:30px; height:30px; display:flex; align-items:center; justify-content:center; font-weight:700; font-size:0.85rem; flex-shrink:0;">1</span>
-              <div>
-                <h2 style="color:#fff; font-size:1.05rem; font-weight:600; margin-bottom:8px;">Information We Collect</h2>
-                <p style="color:rgba(255,255,255,0.7); font-size:0.92rem; line-height:1.7; margin:0 0 10px 0;">Checkora only collects basic information necessary to manage user authentication and orchestrate your chess matches:</p>
-                <ul style="margin-left:18px; color:rgba(255,255,255,0.7); font-size:0.92rem; line-height:1.7;">
-                  <li style="margin-bottom:6px;"><strong style="color:#f0c040;">Account Data:</strong> Username, email address, and encrypted password profiles when you register.</li>
-                  <li style="margin-bottom:6px;"><strong style="color:#f0c040;">Gameplay Metrics:</strong> Move history, win/loss stats, match durations, and time preferences for leaderboard rankings.</li>
-                  <li><strong style="color:#f0c040;">Technical Logs:</strong> Minimal session tokens to keep you securely logged in across page reloads.</li>
-                </ul>
+
+      <div class="about-progress-bar">
+        <div class="about-progress-fill" id="aboutProgressFill"></div>
+      </div>
+
+      <div class="about-counter">
+        <span id="aboutCurrentCard">1</span>
+        <span class="about-counter-sep">/</span>
+        <span>4</span>
+      </div>
+
+      <div class="about-track-wrapper">
+        <div class="about-track" id="aboutTrack">
+          <!-- Card 1 — Mission & Vision -->
+          <div class="about-card">
+            <div class="about-card-visual">
+              <div class="mv-icon-wrap">
+                <span class="mv-piece">♚</span>
+                <div class="mv-ring ring1"></div>
+                <div class="mv-ring ring2"></div>
+                <div class="mv-ring ring3"></div>
+              </div>
+              <div class="mv-path">
+                <div class="mv-path-dot"></div>
+                <div class="mv-path-line"></div>
+                <div class="mv-path-dot"></div>
+                <div class="mv-path-line"></div>
+                <div class="mv-path-dot active"></div>
               </div>
             </div>
-            <div style="background:#1a1c2e; border:1px solid rgba(255,255,255,0.06); border-radius:12px; padding:20px 22px; display:flex; gap:16px; align-items:flex-start;">
-              <span style="background:rgba(240,192,64,0.15); color:#f0c040; border-radius:50%; width:30px; height:30px; display:flex; align-items:center; justify-content:center; font-weight:700; font-size:0.85rem; flex-shrink:0;">2</span>
-              <div>
-                <h2 style="color:#fff; font-size:1.05rem; font-weight:600; margin-bottom:8px;">How Your Data is Used</h2>
-                <p style="color:rgba(255,255,255,0.7); font-size:0.92rem; line-height:1.7; margin:0 0 10px 0;">Your data remains dedicated exclusively to powering your active application experiences:</p>
-                <ul style="margin-left:18px; color:rgba(255,255,255,0.7); font-size:0.92rem; line-height:1.7;">
-                  <li style="margin-bottom:6px;">Maintain your personalized player profile dashboard and performance metrics.</li>
-                  <li style="margin-bottom:6px;">Calculate real-time material scores and process live move-validation checks.</li>
-                  <li>Optimize the sync pipeline between backend systems and computation services.</li>
-                </ul>
+            <div class="about-card-content">
+              <span class="about-card-tag">Mission & Vision</span>
+              <h3 class="about-card-title">Play Smarter. Grow Further.</h3>
+              <p class="about-card-desc">
+                Checkora was built with a single mission — to make
+                high-performance chess accessible to everyone. Our vision is a
+                platform where every player, from beginner to expert, can
+                challenge themselves, track real growth, and experience chess
+                the way it was meant to be played.
+              </p>
+              <div class="about-stats-row">
+                <div class="about-stat">
+                  <span class="about-stat-num" data-target="3">0</span>
+                  <span class="about-stat-label">Game Modes</span>
+                </div>
+                <div class="about-stat">
+                  <div style="display: flex; align-items: baseline">
+                    <span class="about-stat-num" data-target="50">0</span
+                    ><span
+                      style="
+                        color: var(--accent-gold);
+                        font-weight: 800;
+                        font-size: 2.2rem;
+                        font-family: &quot;Exo 2&quot;, sans-serif;
+                      "
+                      >+</span
+                    >
+                  </div>
+                  <span class="about-stat-label">Achievements</span>
+                </div>
+                <div class="about-stat">
+                  <div style="display: flex; align-items: baseline">
+                    <span class="about-stat-num" data-target="100">0</span
+                    ><span
+                      style="
+                        color: var(--accent-gold);
+                        font-weight: 800;
+                        font-size: 2.2rem;
+                        font-family: &quot;Exo 2&quot;, sans-serif;
+                      "
+                      >%</span
+                    >
+                  </div>
+                  <span class="about-stat-label">Free to Play</span>
+                </div>
               </div>
             </div>
-            <div style="background:#1a1c2e; border:1px solid rgba(255,255,255,0.06); border-radius:12px; padding:20px 22px; display:flex; gap:16px; align-items:flex-start;">
-              <span style="background:rgba(240,192,64,0.15); color:#f0c040; border-radius:50%; width:30px; height:30px; display:flex; align-items:center; justify-content:center; font-weight:700; font-size:0.85rem; flex-shrink:0;">3</span>
-              <div>
-                <h2 style="color:#fff; font-size:1.05rem; font-weight:600; margin-bottom:8px;">Cookies and Session Storage</h2>
-                <p style="color:rgba(255,255,255,0.7); font-size:0.92rem; line-height:1.7; margin:0;">We use essential cookies and local storage tokens to manage authentication states and secure form submissions against CSRF. No tracking cookies or behavioral profile monitors are embedded inside the platform.</p>
+          </div>
+
+          <!-- Card 2 — Open Source -->
+          <div class="about-card">
+            <div class="about-card-visual">
+              <div class="os-graph">
+                <div class="os-graph-title">Contribution Activity</div>
+                <div class="os-grid" id="osGrid"></div>
+                <div class="os-graph-footer">
+                  <span>Open Source on GitHub</span>
+                  <span class="os-badge">MIT License</span>
+                </div>
               </div>
             </div>
-            <div style="background:#1a1c2e; border:1px solid rgba(255,255,255,0.06); border-radius:12px; padding:20px 22px; display:flex; gap:16px; align-items:flex-start;">
-              <span style="background:rgba(240,192,64,0.15); color:#f0c040; border-radius:50%; width:30px; height:30px; display:flex; align-items:center; justify-content:center; font-weight:700; font-size:0.85rem; flex-shrink:0;">4</span>
-              <div>
-                <h2 style="color:#fff; font-size:1.05rem; font-weight:600; margin-bottom:8px;">Data Retention & Security</h2>
-                <p style="color:rgba(255,255,255,0.7); font-size:0.92rem; line-height:1.7; margin:0;">We retain your profile credentials and match logs for as long as your account remains active. Passwords are securely stored using Django authentication hashing mechanisms.</p>
+            <div class="about-card-content">
+              <span class="about-card-tag">Open Source & Community</span>
+              <h3 class="about-card-title">
+                Built in the Open. Grown Together.
+              </h3>
+              <p class="about-card-desc">
+                Checkora is fully open source under the MIT License. Every
+                feature, every fix, every improvement is a community effort.
+                Join developers worldwide contributing to the engine, the
+                interface, and the future of the platform.
+              </p>
+              <div class="os-links">
+                <a
+                  href="https://github.com/Checkora"
+                  target="_blank"
+                  class="os-link-btn"
+                >
+                  <svg
+                    width="18"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                  >
+                    <path
+                      d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"
+                    />
+                  </svg>
+                  GitHub
+                </a>
+                <a
+                  href="https://discord.gg/WfrpMuNZn"
+                  target="_blank"
+                  class="os-link-btn discord"
+                >
+                  <svg
+                    width="18"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                  >
+                    <path
+                      d="M19.27 5.33C17.94 4.71 16.5 4.26 15 4a.09.09 0 0 0-.07.03c-.18.33-.39.76-.53 1.09a16.09 16.09 0 0 0-4.8 0c-.14-.34-.35-.76-.54-1.09c-.01-.02-.04-.03-.07-.03c-1.5.26-2.93.71-4.27 1.33c-.01 0-.02.01-.03.02c-2.72 4.07-3.47 8.03-3.1 11.95c0 .02.02.04.03.05c1.8 1.32 3.53 2.12 5.24 2.65c.03.01.06 0 .07-.02c.4-.55.76-1.13 1.07-1.74c.02-.04 0-.08-.04-.09c-.57-.22-1.11-.48-1.64-.78c-.04-.02-.04-.08-.01-.11c.11-.08.22-.17.33-.25c.02-.02.05-.02.07-.01c3.44 1.57 7.15 1.57 10.55 0c.02-.01.05-.01.07.01c.11.09.22.17.33.26c.04.03.04.09-.01.11c-.52.31-1.07.56-1.64.78c-.04.01-.05.06-.04.09c.32.61.68 1.19 1.07 1.74c.03.01.06 0 .09.01c1.72-.53 3.45-1.33 5.25-2.65c.02-.01.03-.03.03-.05.44-4.53-.73-8.46-3.1-11.95c-.01-.01-.02-.02-.04-.02zM8.52 14.91c-1.03 0-1.89-.95-1.89-2.12s.84-2.12 1.89-2.12c1.06 0 1.9.96 1.89 2.12c0 1.17-.84 2.12-1.89 2.12zm6.97 0c-1.03 0-1.89-.95-1.89-2.12s.84-2.12 1.89-2.12c1.06 0 1.9.96 1.89 2.12c0 1.17-.83 2.12-1.89 2.12z"
+                    />
+                  </svg>
+                  Discord
+                </a>
               </div>
             </div>
-            <div style="background:#1a1c2e; border:1px solid rgba(255,255,255,0.06); border-radius:12px; padding:20px 22px; display:flex; gap:16px; align-items:flex-start;">
-              <span style="background:rgba(240,192,64,0.15); color:#f0c040; border-radius:50%; width:30px; height:30px; display:flex; align-items:center; justify-content:center; font-weight:700; font-size:0.85rem; flex-shrink:0;">5</span>
-              <div>
-                <h2 style="color:#fff; font-size:1.05rem; font-weight:600; margin-bottom:8px;">Open Source Transparency & User Rights</h2>
-                <p style="color:rgba(255,255,255,0.7); font-size:0.92rem; line-height:1.7; margin:0;">In alignment with our open-source framework and GSSoC community policies, users maintain full authority over their data and may request account deletion or data removal at any time.</p>
+          </div>
+
+          <!-- Card 3 — Technical Architecture -->
+          <div class="about-card">
+            <div class="about-card-visual">
+              <div class="perf-meter">
+                <div class="perf-gauge-wrap">
+                  <svg
+                    class="perf-svg"
+                    viewBox="0 0 200 120"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M 20 100 A 80 80 0 0 1 180 100"
+                      fill="none"
+                      stroke="rgba(255,255,255,0.06)"
+                      stroke-width="12"
+                      stroke-linecap="round"
+                    />
+                    <path
+                      class="perf-arc"
+                      d="M 20 100 A 80 80 0 0 1 180 100"
+                      fill="none"
+                      stroke="url(#goldGrad)"
+                      stroke-width="12"
+                      stroke-linecap="round"
+                      stroke-dasharray="251"
+                      stroke-dashoffset="251"
+                    />
+                    <line
+                      class="perf-needle"
+                      x1="100"
+                      y1="100"
+                      x2="100"
+                      y2="30"
+                      stroke="var(--accent-gold)"
+                      stroke-width="2.5"
+                      stroke-linecap="round"
+                      transform-origin="100 100"
+                    />
+                    <circle
+                      cx="100"
+                      cy="100"
+                      r="6"
+                      fill="var(--accent-gold)"
+                      filter="url(#glow)"
+                    />
+                    <defs>
+                      <linearGradient
+                        id="goldGrad"
+                        x1="0%"
+                        y1="0%"
+                        x2="100%"
+                        y2="0%"
+                      >
+                        <stop offset="0%" stop-color="#d4a020" />
+                        <stop offset="100%" stop-color="#ffeaa7" />
+                      </linearGradient>
+                      <filter id="glow">
+                        <feGaussianBlur stdDeviation="2" result="blur" />
+                        <feMerge>
+                          <feMergeNode in="blur" />
+                          <feMergeNode in="SourceGraphic" />
+                        </feMerge>
+                      </filter>
+                    </defs>
+                  </svg>
+                  <div class="perf-value-wrap">
+                    <span class="perf-value" id="perfValue">0</span>
+                    <span class="perf-unit">k nodes/s</span>
+                  </div>
+                </div>
+                <div class="perf-chips">
+                  <div class="perf-chip">
+                    <span class="perf-chip-dot"></span>
+                    <span class="perf-chip-label">Depth</span>
+                    <span class="perf-chip-val" id="depthVal">0</span>
+                  </div>
+                  <div class="perf-chip">
+                    <span class="perf-chip-dot green"></span>
+                    <span class="perf-chip-label">Alpha-Beta</span>
+                    <span class="perf-chip-val">ON</span>
+                  </div>
+                  <div class="perf-chip">
+                    <span class="perf-chip-dot blue"></span>
+                    <span class="perf-chip-label">Engine</span>
+                    <span class="perf-chip-val">C++17</span>
+                  </div>
+                </div>
               </div>
             </div>
-            <div style="background:#1a1c2e; border:1px solid rgba(255,255,255,0.06); border-radius:12px; padding:20px 22px; display:flex; gap:16px; align-items:flex-start;">
-              <span style="background:rgba(240,192,64,0.15); color:#f0c040; border-radius:50%; width:30px; height:30px; display:flex; align-items:center; justify-content:center; font-weight:700; font-size:0.85rem; flex-shrink:0;">6</span>
-              <div>
-                <h2 style="color:#fff; font-size:1.05rem; font-weight:600; margin-bottom:8px;">Contact & Community Channels</h2>
-                <p style="color:rgba(255,255,255,0.7); font-size:0.92rem; line-height:1.7; margin:0;">If you have questions or feedback regarding this Privacy Policy, please open an issue on our GitHub repository or contact the project maintainers directly.</p>
+            <div class="about-card-content">
+              <span class="about-card-tag">Technical Architecture</span>
+              <h3 class="about-card-title">
+                Fast by Design. Powerful by Nature.
+              </h3>
+              <p class="about-card-desc">
+                Under the hood, Checkora runs a high-performance C++17 minimax
+                engine with alpha-beta pruning for lightning-fast move
+                calculations. Python orchestrates game logic while Django
+                handles routing and authentication — a true hybrid stack built
+                for performance.
+              </p>
+              <div class="tech-pills">
+                <span class="tech-pill">Alpha-Beta Pruning</span>
+                <span class="tech-pill">Minimax Search</span>
+                <span class="tech-pill">REST API</span>
+                <span class="tech-pill">Django Auth</span>
+                <span class="tech-pill">C++17</span>
               </div>
             </div>
-            <p style="color:#64748b; font-size:0.82rem; margin-top:6px;">Last updated: May 2026</p>
+          </div>
+
+          <!-- Card 4 — Built for Chess Players -->
+          <div class="about-card">
+            <div class="about-card-visual">
+              <div class="chess-visual-wrap">
+                <div class="mini-board-inner" id="miniBoard"></div>
+                <div class="mini-board-label">Sicilian Defence</div>
+              </div>
+            </div>
+            <div class="about-card-content">
+              <span class="about-card-tag">Built for Chess Players</span>
+              <h3 class="about-card-title">Every Move. Every Player.</h3>
+              <p class="about-card-desc">
+                Whether you are learning your first opening or grinding ranked
+                games, Checkora is built for you. Full FIDE rule support,
+                multiple time controls, live material tracking, achievements,
+                leaderboards, and interactive lessons — everything a chess
+                player needs in one place.
+              </p>
+              <div class="chess-features-list">
+                <div class="chess-feature-item">
+                  <span class="chess-feature-icon">♟</span>
+                  <span>Full FIDE Rules — castling, en passant, promotion</span>
+                </div>
+                <div class="chess-feature-item">
+                  <span class="chess-feature-icon">
+                    <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="12" cy="13" r="8" />
+                      <path d="M12 9v4l3 2" />
+                      <path d="M9 2h6" />
+                      <path d="M19 5l1.5-1.5" />
+                    </svg>
+                  </span>
+                  <span>Bullet, Blitz & Rapid time controls</span>
+                </div>
+                <div class="chess-feature-item">
+                  <span class="chess-feature-icon">
+                    <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                      <line x1="18" y1="20" x2="18" y2="10" />
+                      <line x1="12" y1="20" x2="12" y2="4" />
+                      <line x1="6" y1="20" x2="6" y2="14" />
+                    </svg>
+                  </span>
+                  <span>Live material tracking & game stats</span>
+                </div>
+                <div class="chess-feature-item">
+                  <span class="chess-feature-icon">
+                    <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M8 21h8" />
+                      <path d="M12 17v4" />
+                      <path d="M7 4h10v6a5 5 0 0 1-10 0z" />
+                      <path d="M7 5H4a3 3 0 0 0 3 4" />
+                      <path d="M17 5h3a3 3 0 0 1-3 4" />
+                    </svg>
+                  </span>
+                  <span>Leaderboards & achievement system</span>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
-        <div style="padding:16px 28px; border-top:1px solid rgba(255,255,255,0.07); display:flex; justify-content:flex-end; flex-shrink:0; background:#131522;">
-          <button type="button" aria-label="Close privacy policy" onclick="closePrivacyModal()" style="background:linear-gradient(135deg,#f0c040,#d4a020); color:#0f0f1a; border:none; padding:10px 28px; border-radius:8px; font-weight:700; font-size:0.95rem; cursor:pointer; box-shadow:0 4px 16px rgba(240,192,64,0.3);">I Agree</button>
-        </div>
+      </div>
+
+      <div class="about-dots" id="aboutDots">
+        <button
+          type="button"
+          class="about-dot active"
+          data-index="0"
+          aria-label="Go to slide 1"
+          aria-pressed="true"
+        ></button>
+        <button
+          type="button"
+          class="about-dot"
+          data-index="1"
+          aria-label="Go to slide 2"
+          aria-pressed="false"
+        ></button>
+        <button
+          type="button"
+          class="about-dot"
+          data-index="2"
+          aria-label="Go to slide 3"
+          aria-pressed="false"
+        ></button>
+        <button
+          type="button"
+          class="about-dot"
+          data-index="3"
+          aria-label="Go to slide 4"
+          aria-pressed="false"
+        ></button>
       </div>
     </div>
-    <div id="termsModal" role="dialog" aria-modal="true" aria-labelledby="termsModalTitle" style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.85); z-index:9999; align-items:center; justify-content:center;">
-      <div tabindex="-1" style="position:relative; background:#131522; border:1px solid rgba(240,192,64,0.2); border-radius:16px; width:90%; max-width:900px; max-height:88vh; display:flex; flex-direction:column; overflow:hidden;">
-        <div style="padding:24px 28px 16px; border-bottom:1px solid rgba(255,255,255,0.07); display:flex; justify-content:space-between; align-items:center; flex-shrink:0;">
-          <h1 id="termsModalTitle" style="color:#f0c040; font-size:1.6rem; font-weight:700; letter-spacing:-0.3px;">Terms and Conditions</h1>
-          <button type="button" aria-label="Close terms and conditions" onclick="closeTermsModal()" style="background:rgba(255,255,255,0.08); border:none; color:#fff; width:32px; height:32px; border-radius:50%; cursor:pointer; font-size:1rem; display:flex; align-items:center; justify-content:center;">✕</button>
-        </div>
-        <div class="modal-scroll-content" style="overflow-y:auto; padding:24px 28px; flex:1;">
-          <div style="display:flex; flex-direction:column; gap:14px;">
-            <div style="background:#1a1c2e; border:1px solid rgba(255,255,255,0.06); border-radius:12px; padding:20px 22px; display:flex; gap:16px; align-items:flex-start;">
-              <span style="background:rgba(240,192,64,0.15); color:#f0c040; border-radius:50%; width:30px; height:30px; display:flex; align-items:center; justify-content:center; font-weight:700; font-size:0.85rem; flex-shrink:0;">1</span>
-              <div>
-                <h2 style="color:#fff; font-size:1.05rem; font-weight:600; margin-bottom:8px;">Acceptance of Terms</h2>
-                <p style="color:rgba(255,255,255,0.7); font-size:0.92rem; line-height:1.7; margin:0;">By accessing, registering for, or interacting with the Checkora Chess Platform, you agree to comply with and be bound by these Terms and Conditions. If you do not accept these parameters, you are advised to discontinue platform interaction.</p>
-              </div>
-            </div>
-            <div style="background:#1a1c2e; border:1px solid rgba(255,255,255,0.06); border-radius:12px; padding:20px 22px; display:flex; gap:16px; align-items:flex-start;">
-              <span style="background:rgba(240,192,64,0.15); color:#f0c040; border-radius:50%; width:30px; height:30px; display:flex; align-items:center; justify-content:center; font-weight:700; font-size:0.85rem; flex-shrink:0;">2</span>
-              <div>
-                <h2 style="color:#fff; font-size:1.05rem; font-weight:600; margin-bottom:8px;">Fair Play and Anti-Cheat Policy</h2>
-                <p style="color:rgba(255,255,255,0.7); font-size:0.92rem; line-height:1.7; margin:0 0 10px 0;">Checkora runs a native high-performance C++ minimax engine designed to provide competitive gameplay. To safeguard integrity:</p>
-                <ul style="margin-left:18px; color:rgba(255,255,255,0.7); font-size:0.92rem; line-height:1.7;">
-                  <li style="margin-bottom:6px;">Use of third-party engine assistance, browser modifications, or state-manipulation scripts is strictly prohibited.</li>
-                  <li>Intentionally stalling game clocks or throwing matches to manipulate metrics violates our guidelines.</li>
-                </ul>
-              </div>
-            </div>
-            <div style="background:#1a1c2e; border:1px solid rgba(255,255,255,0.06); border-radius:12px; padding:20px 22px; display:flex; gap:16px; align-items:flex-start;">
-              <span style="background:rgba(240,192,64,0.15); color:#f0c040; border-radius:50%; width:30px; height:30px; display:flex; align-items:center; justify-content:center; font-weight:700; font-size:0.85rem; flex-shrink:0;">3</span>
-              <div>
-                <h2 style="color:#fff; font-size:1.05rem; font-weight:600; margin-bottom:8px;">Account Management and Security</h2>
-                <p style="color:rgba(255,255,255,0.7); font-size:0.92rem; line-height:1.7; margin:0;">When creating profile credentials and completing OTP verification, you are fully accountable for preserving credential confidentiality. Checkora reserves authority to clean up idle ghost accounts that remain abandoned to free system namespaces.</p>
-              </div>
-            </div>
-            <div style="background:#1a1c2e; border:1px solid rgba(255,255,255,0.06); border-radius:12px; padding:20px 22px; display:flex; gap:16px; align-items:flex-start;">
-              <span style="background:rgba(240,192,64,0.15); color:#f0c040; border-radius:50%; width:30px; height:30px; display:flex; align-items:center; justify-content:center; font-weight:700; font-size:0.85rem; flex-shrink:0;">4</span>
-              <div>
-                <h2 style="color:#fff; font-size:1.05rem; font-weight:600; margin-bottom:8px;">Open Source and Modifications</h2>
-                <p style="color:rgba(255,255,255,0.7); font-size:0.92rem; line-height:1.7; margin:0;">Checkora operates openly under the MIT License. While customization of backend logic modules is encouraged for developer variants, users are requested to interact fairly and maintain the software's style parameters.</p>
-              </div>
-            </div>
-            <div style="background:#1a1c2e; border:1px solid rgba(255,255,255,0.06); border-radius:12px; padding:20px 22px; display:flex; gap:16px; align-items:flex-start;">
-              <span style="background:rgba(240,192,64,0.15); color:#f0c040; border-radius:50%; width:30px; height:30px; display:flex; align-items:center; justify-content:center; font-weight:700; font-size:0.85rem; flex-shrink:0;">5</span>
-              <div>
-                <h2 style="color:#fff; font-size:1.05rem; font-weight:600; margin-bottom:8px;">Disclaimer of Liability</h2>
-                <p style="color:rgba(255,255,255,0.7); font-size:0.92rem; line-height:1.7; margin:0;">The platform services and integrated AI engines are offered on an "as-is" operational basis. The maintenance team assumes no liability for match state disruptions, profile cache rollbacks during server updates, or local dependency failures in client-side setups.</p>
-              </div>
-            </div>
-            <p style="color:#64748b; font-size:0.82rem; margin-top:6px;">Last updated: May 2026</p>
-          </div>
-        </div>
-        <div style="padding:16px 28px; border-top:1px solid rgba(255,255,255,0.07); display:flex; justify-content:flex-end; flex-shrink:0; background:#131522;">
-          <button type="button" onclick="closeTermsModal()" style="background:linear-gradient(135deg,#f0c040,#d4a020); color:#0f0f1a; border:none; padding:10px 28px; border-radius:8px; font-weight:700; font-size:0.95rem; cursor:pointer; transition:all 0.2s ease; box-shadow:0 4px 16px rgba(240,192,64,0.3);">I Agree</button>        </div>
-      </div>
   </div>
-  <script>
-    (function() {
-      const modal = document.getElementById('termsModal');
-      const modalInner = modal.querySelector('[tabindex="-1"]');
-      let lastFocused;
-  
-      function openTermsModal() {
-        lastFocused = document.activeElement;
-        modal.style.display = 'flex';
-        modalInner.focus();
-      }
-  
-      function closeTermsModal() {
-        modal.style.display = 'none';
-        if (lastFocused) lastFocused.focus();
-      }
-  
-      window.openTermsModal = openTermsModal;
-      window.closeTermsModal = closeTermsModal;
-  
-      document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape' && modal.style.display === 'flex') {
-          closeTermsModal();
-        }
-      });
-  
-      modal.addEventListener('click', function(e) {
-        if (e.target === modal) closeTermsModal();
-      });
-      modal.addEventListener('keydown', function(e) {
-        if (e.key === 'Tab') {
-          const focusable = modal.querySelectorAll('button, [href], [tabindex]:not([tabindex="-1"])');
-          const first = focusable[0];
-          const last = focusable[focusable.length - 1];
-          if (e.shiftKey && document.activeElement === first) {
-            e.preventDefault();
-            last.focus();
-          } else if (!e.shiftKey && document.activeElement === last) {
-            e.preventDefault();
-            first.focus();
-          }
-        }
-      });
-    })();
-  </script>
+</section>
 
-  <div id="contactModal" role="dialog" aria-modal="true" aria-labelledby="contactModalTitle" style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.85); z-index:9999; align-items:center; justify-content:center;">
-    <div tabindex="-1" style="position:relative; background:#131522; border:1px solid rgba(240,192,64,0.2); border-radius:16px; width:90%; max-width:900px; max-height:88vh; display:flex; flex-direction:column; overflow:hidden;">
-      <div style="padding:24px 28px 16px; border-bottom:1px solid rgba(255,255,255,0.07); display:flex; justify-content:space-between; align-items:center; flex-shrink:0;">
-        <h1 id="contactModalTitle" style="color:#f0c040; font-size:1.6rem; font-weight:700; letter-spacing:-0.3px;">Contact Us</h1>
-        <button type="button" aria-label="Close contact form" onclick="closeContactModal()" style="background:rgba(255,255,255,0.08); border:none; color:#fff; width:32px; height:32px; border-radius:50%; cursor:pointer; font-size:1rem; display:flex; align-items:center; justify-content:center;">✕</button>
-      </div>
-      <div class="modal-scroll-content" style="overflow-y:auto; padding:24px 28px; flex:1;">
-        <p style="color:rgba(255,255,255,0.6); font-size:0.93rem; margin-bottom:28px; border-bottom:1px solid rgba(255,255,255,0.06); padding-bottom:20px;">Have questions about the C++ platform integration or found a glitch? Reach out to the maintainers.</p>
-        <div style="display:grid; grid-template-columns:0.8fr 1.5fr; gap:40px;">
+<!-- ── User Testimonials Section ── -->
+<section id="testimonials" class="testimonials-section">
+  <div class="bento-container">
+    <h2 class="section-title">Community Feedback</h2>
+    <p class="section-subtitle">
+      What players and developers worldwide are saying about Checkora's engine.
+    </p>
 
-          <div style="display:flex; flex-direction:column; gap:28px;">
-            <div>
-              <h3 style="color:#fff; font-size:1rem; font-weight:600; margin-bottom:8px;">Community Support</h3>
-              <p style="color:rgba(255,255,255,0.6); font-size:0.9rem; line-height:1.6;">For instant technical coordination, join our active development spaces on the <a href="https://discord.gg/WfrpMuNZn" target="_blank" rel="noopener noreferrer" style="color:#f0c040; text-decoration:none; font-weight:500;">Discord Server</a>.</p>
-            </div>
-            <div>
-              <h3 style="color:#fff; font-size:1rem; font-weight:600; margin-bottom:8px;">Open Source &amp; Bugs</h3>
-              <p style="color:rgba(255,255,255,0.6); font-size:0.9rem; line-height:1.6;">Found a bug? Open a thread on our <a href="https://github.com/Checkora" target="_blank" rel="noopener noreferrer" style="color:#f0c040; text-decoration:none; font-weight:500;">GitHub Issue Tracker</a>.</p>
-            </div>
-            <div>
-              <h3 style="color:#fff; font-size:1rem; font-weight:600; margin-bottom:8px;">Maintainer Reach</h3>
-              <p style="color:rgba(255,255,255,0.6); font-size:0.9rem; line-height:1.6;">Email: <a href="mailto:support@checkora.example.com" style="color:#f0c040; text-decoration:none; font-weight:500;">support@checkora.example.com</a></p>
-            </div>
+    <div class="testimonials-grid">
+      <div class="testimonial-card">
+        <div class="testimonial-stars">★★★★★</div>
+        <p class="testimonial-text">
+          "The performance shift when calculating endgames natively with the C++
+          minimax engine core is unbelievable. Real-time material scores sync up
+          instantly."
+        </p>
+        <div class="testimonial-user">
+          <div class="user-avatar">
+            <svg aria-hidden="true" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="5" y="8" width="14" height="11" rx="2" />
+              <path d="M12 8V4" />
+              <circle cx="12" cy="3" r="1" />
+              <circle cx="9" cy="13" r="1.2" />
+              <circle cx="15" cy="13" r="1.2" />
+              <path d="M9 17h6" />
+              <path d="M2 12h3" />
+              <path d="M19 12h3" />
+            </svg>
           </div>
+          <div class="user-info">
+            <h4 class="user-name">Alex Rivera</h4>
+            <span class="user-title">National Master</span>
+          </div>
+        </div>
+      </div>
 
-          <form id="contactForm" style="display:flex; flex-direction:column; gap:20px;" onsubmit="handleContactSubmit(event)">
-            {% csrf_token %}
-            <div style="display:flex; flex-direction:column; gap:8px;">
-              <label for="contact-name" style="color:#fff; font-size:0.85rem; font-weight:600; letter-spacing:0.5px; text-transform:uppercase; opacity:0.9;">Name</label>
-              <input type="text" id="contact-name" name="name" placeholder="Your name" required style="background:#1a1d30; border:1px solid #2b2f4a; border-radius:8px; padding:13px 16px; color:#fff; font-size:0.95rem; font-family:inherit; transition:border-color 0.25s,box-shadow 0.25s; width:100%;" onfocus="this.style.borderColor='#f0c040';this.style.boxShadow='0 0 0 4px rgba(240,192,64,0.12)'" onblur="this.style.borderColor='#2b2f4a';this.style.boxShadow='none'" />
-            </div>
-            <div style="display:flex; flex-direction:column; gap:8px;">
-              <label for="contact-email" style="color:#fff; font-size:0.85rem; font-weight:600; letter-spacing:0.5px; text-transform:uppercase; opacity:0.9;">Email Address</label>
-              <input type="email" id="contact-email" name="email" placeholder="username@example.com" required style="background:#1a1d30; border:1px solid #2b2f4a; border-radius:8px; padding:13px 16px; color:#fff; font-size:0.95rem; font-family:inherit; transition:border-color 0.25s,box-shadow 0.25s; width:100%;" onfocus="this.style.borderColor='#f0c040';this.style.boxShadow='0 0 0 4px rgba(240,192,64,0.12)'" onblur="this.style.borderColor='#2b2f4a';this.style.boxShadow='none'" />
-            </div>
-            <div style="display:flex; flex-direction:column; gap:8px;">
-              <label for="contact-message" style="color:#fff; font-size:0.85rem; font-weight:600; letter-spacing:0.5px; text-transform:uppercase; opacity:0.9;">Message</label>
-              <textarea id="contact-message" name="message" placeholder="Type your query regarding engine or interface states..." required rows="5" style="background:#1a1d30; border:1px solid #2b2f4a; border-radius:8px; padding:13px 16px; color:#fff; font-size:0.95rem; font-family:inherit; resize:vertical; min-height:130px; transition:border-color 0.25s,box-shadow 0.25s; width:100%;" onfocus="this.style.borderColor='#f0c040';this.style.boxShadow='0 0 0 4px rgba(240,192,64,0.12)'" onblur="this.style.borderColor='#2b2f4a';this.style.boxShadow='none'"></textarea>
-            </div>
-            <button type="submit" style="background:linear-gradient(135deg,#f0c040,#d4a020); color:#1a1a2e; border:none; padding:14px 28px; font-size:1rem; font-weight:700; border-radius:8px; cursor:pointer; align-self:flex-start; box-shadow:0 4px 15px rgba(240,192,64,0.2); transition:all 0.25s ease;">Send Message</button>
-          </form>
+      <div class="testimonial-card highlight-card">
+        <div class="testimonial-stars">★★★★★</div>
+        <p class="testimonial-text">
+          "As an open-source contributor, building feature modules on top of
+          this Django framework has been super clean. Truly a state-of-the-art
+          hybrid platform setup."
+        </p>
+        <div class="testimonial-user">
+          <div class="user-avatar">
+            <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="12" cy="8" r="4" />
+              <path d="M4 21c0-4.4 3.6-7 8-7s8 2.6 8 7" />
+            </svg>
+          </div>
+          <div class="user-info">
+            <h4 class="user-name">Sarah Chen</h4>
+            <span class="user-title">Core Developer</span>
+          </div>
+        </div>
+      </div>
 
+      <div class="testimonial-card">
+        <div class="testimonial-stars">★★★★★</div>
+        <p class="testimonial-text">
+          "The interactive lessons and end-of-chapter quizzes transformed my
+          Sicilian Defence opening lines. Highly recommend to club players
+          grinding ranked matches!"
+        </p>
+        <div class="testimonial-user">
+          <div class="user-avatar">♙</div>
+          <div class="user-info">
+            <h4 class="user-name">Marcus Brody</h4>
+            <span class="user-title">Club Player (1900 ELO)</span>
+          </div>
         </div>
       </div>
     </div>
   </div>
+</section>
 
-  <script>
-  (function() {
-    const modal = document.getElementById('contactModal');
-    const modalInner = modal.querySelector('[tabindex="-1"]');
-    let lastFocused;
+<section id="faq" class="faq-section">
+  <div class="faq-container">
+    <h2 class="section-title">Frequently Asked Questions</h2>
+    <p class="faq-subtitle">
+      Everything you need to know about the Checkora chess platform architecture
+      and functionality.
+    </p>
 
-    function openContactModal() {
-      lastFocused = document.activeElement;
-      modal.style.display = 'flex';
-      modalInner.focus();
-    }
-
-    function closeContactModal() {
-      modal.style.display = 'none';
-      if (lastFocused) lastFocused.focus();
-    }
-
-    window.openContactModal = openContactModal;
-    window.closeContactModal = closeContactModal;
-
-    window.handleContactSubmit = function(e) {
-      e.preventDefault();
-      alert('Message logged locally inside development environment container loop.');
-      closeContactModal();
-      document.getElementById('contactForm').reset();
-    };
-
-    modal.addEventListener('click', function(e) {
-      if (e.target === modal) closeContactModal();
-    });
-
-    document.addEventListener('keydown', function(e) {
-      if (e.key === 'Escape' && modal.style.display === 'flex') closeContactModal();
-    });
-
-    modal.addEventListener('keydown', function(e) {
-      if (e.key === 'Tab') {
-        const focusable = modal.querySelectorAll('button, input, textarea, [href], [tabindex]:not([tabindex="-1"])');
-        const first = focusable[0];
-        const last = focusable[focusable.length - 1];
-        if (e.shiftKey && document.activeElement === first) {
-          e.preventDefault(); last.focus();
-        } else if (!e.shiftKey && document.activeElement === last) {
-          e.preventDefault(); first.focus();
-        }
-      }
-    });
-  })();
-  </script>
-
-  <div id="disclaimerModal" role="dialog" aria-modal="true" aria-labelledby="disclaimerModalTitle"
-      style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.85); z-index:9999; align-items:center; justify-content:center;">
-
-    <div tabindex="-1" style="position:relative; background:#131522; border:1px solid rgba(240,192,64,0.2); border-radius:16px; width:90%; max-width:900px; max-height:88vh; display:flex; flex-direction:column; overflow:hidden;">
-
-      <div style="padding:24px 28px 16px; border-bottom:1px solid rgba(255,255,255,0.07); display:flex; justify-content:space-between; align-items:center;">
-        <h1 id="disclaimerModalTitle" style="color:#f0c040; font-size:1.6rem; font-weight:700;">Disclaimer</h1>
-
-        <button type="button" aria-label="Close disclaimer" onclick="closeDisclaimerModal()"
-                style="background:rgba(255,255,255,0.08); border:none; color:#fff; width:32px; height:32px; border-radius:50%; cursor:pointer;">
-          ✕
+    <div class="faq-wrapper">
+      <div class="faq-item">
+        <button class="faq-question">
+          <span>What makes Checkora a "Hybrid Intelligence" engine?</span>
+          <span class="faq-icon-arrow">
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </span>
         </button>
-      </div>
-
-      <div class="modal-scroll-content" style="overflow-y:auto; padding:24px 28px; flex:1;">
-        <div style="display:flex; flex-direction:column; gap:14px;">
-
-          <div style="background:#1a1c2e; border:1px solid rgba(255,255,255,0.06); border-radius:12px; padding:20px 22px; display:flex; gap:16px; align-items:flex-start;">
-            <span style="background:rgba(240,192,64,0.15); color:#f0c040; border-radius:50%; width:30px; height:30px; display:flex; align-items:center; justify-content:center; font-weight:700; font-size:0.85rem; flex-shrink:0;">1</span>
-            <div>
-              <h2 style="color:#fff; font-size:1.05rem; font-weight:600; margin-bottom:8px;">
-                General Information
-              </h2>
-              <p style="color:rgba(255,255,255,0.7); font-size:0.92rem; line-height:1.7; margin:0 0 10px 0;">
-                The information, services, and structural match simulation environments provided on the Checkora chess platform are intended solely for general informational, educational, and recreational entertainment purposes.
-              </p>
-              <p style="color:rgba(255,255,255,0.7); font-size:0.92rem; line-height:1.7; margin:0;">
-                All modules are interactive and provided on an "as-is" and "as-available" execution model without absolute performance assertions of any kind.
-              </p>
-            </div>
+        <div class="faq-answer">
+          <div class="faq-answer-content">
+            Checkora offloads complex, compute-intensive tactical configurations
+            and minimax analytics natively to a super-fast, highly optimized
+            C++17 core. Meanwhile, a flexible Python and Django application
+            framework manages sessions, game data validation routing, and smooth
+            presentation handling seamlessly.
           </div>
-
-          <div style="background:#1a1c2e; border:1px solid rgba(255,255,255,0.06); border-radius:12px; padding:20px 22px; display:flex; gap:16px; align-items:flex-start;">
-            <span style="background:rgba(240,192,64,0.15); color:#f0c040; border-radius:50%; width:30px; height:30px; display:flex; align-items:center; justify-content:center; font-weight:700; font-size:0.85rem; flex-shrink:0;">2</span>
-            <div>
-              <h2 style="color:#fff; font-size:1.05rem; font-weight:600; margin-bottom:8px;">
-                Limitation of Liability
-              </h2>
-              <p style="color:rgba(255,255,255,0.7); font-size:0.92rem; line-height:1.7; margin:0 0 10px 0;">
-                To the fullest extent permitted by applicable law, Checkora, its core architects, and open-source contribution members shall assume no accountability for any direct, indirect, accidental, or consequential operational data disruptions.
-              </p>
-
-              <ul style="margin-left:18px; color:rgba(255,255,255,0.7); font-size:0.92rem; line-height:1.7;">
-                <li style="margin-bottom:6px;">Server connection synchronization issues.</li>
-                <li style="margin-bottom:6px;">Temporary match-state profile resets.</li>
-                <li style="margin-bottom:6px;">Algorithmic parsing variances.</li>
-                <li>System downtime occurrences.</li>
-              </ul>
-            </div>
-          </div>
-
-          <div style="background:#1a1c2e; border:1px solid rgba(255,255,255,0.06); border-radius:12px; padding:20px 22px; display:flex; gap:16px; align-items:flex-start;">
-            <span style="background:rgba(240,192,64,0.15); color:#f0c040; border-radius:50%; width:30px; height:30px; display:flex; align-items:center; justify-content:center; font-weight:700; font-size:0.85rem; flex-shrink:0;">3</span>
-            <div>
-              <h2 style="color:#fff; font-size:1.05rem; font-weight:600; margin-bottom:8px;">
-                Accuracy of Information
-              </h2>
-
-              <p style="color:rgba(255,255,255,0.7); font-size:0.92rem; line-height:1.7; margin:0 0 10px 0;">
-                While our platform utilizes a custom C++ Minimax engine alongside Python web orchestration, we make no absolute guarantees regarding analytical precision.
-              </p>
-
-              <ul style="margin-left:18px; color:rgba(255,255,255,0.7); font-size:0.92rem; line-height:1.7;">
-                <li style="margin-bottom:6px;">Position evaluations are algorithmic estimates.</li>
-                <li style="margin-bottom:6px;">Material calculations may vary.</li>
-                <li>Strategic suggestions are not official chess arbitration metrics.</li>
-              </ul>
-            </div>
-          </div>
-
-          <div style="background:#1a1c2e; border:1px solid rgba(255,255,255,0.06); border-radius:12px; padding:20px 22px; display:flex; gap:16px; align-items:flex-start;">
-            <span style="background:rgba(240,192,64,0.15); color:#f0c040; border-radius:50%; width:30px; height:30px; display:flex; align-items:center; justify-content:center; font-weight:700; font-size:0.85rem; flex-shrink:0;">4</span>
-            <div>
-              <h2 style="color:#fff; font-size:1.05rem; font-weight:600; margin-bottom:8px;">
-                External Links
-              </h2>
-
-              <p style="color:rgba(255,255,255,0.7); font-size:0.92rem; line-height:1.7; margin:0 0 10px 0;">
-                Checkora may reference external resources and community platforms.
-              </p>
-
-              <ul style="margin-left:18px; color:rgba(255,255,255,0.7); font-size:0.92rem; line-height:1.7;">
-                <li style="margin-bottom:6px;">GitHub repositories.</li>
-                <li style="margin-bottom:6px;">Discord community servers.</li>
-                <li>Official chess federation resources.</li>
-              </ul>
-
-              <p style="color:rgba(255,255,255,0.7); font-size:0.92rem; line-height:1.7; margin-top:10px;">
-                We do not control or guarantee the content, policies, or privacy practices of third-party services.
-              </p>
-            </div>
-          </div>
-
-          <div style="background:#1a1c2e; border:1px solid rgba(255,255,255,0.06); border-radius:12px; padding:20px 22px; display:flex; gap:16px; align-items:flex-start;">
-            <span style="background:rgba(240,192,64,0.15); color:#f0c040; border-radius:50%; width:30px; height:30px; display:flex; align-items:center; justify-content:center; font-weight:700; font-size:0.85rem; flex-shrink:0;">5</span>
-            <div>
-              <h2 style="color:#fff; font-size:1.05rem; font-weight:600; margin-bottom:8px;">
-                User Responsibility Statement
-              </h2>
-
-              <p style="color:rgba(255,255,255,0.7); font-size:0.92rem; line-height:1.7; margin:0 0 10px 0;">
-                By using Checkora, you acknowledge responsibility for maintaining fair and secure usage of the platform.
-              </p>
-
-              <ul style="margin-left:18px; color:rgba(255,255,255,0.7); font-size:0.92rem; line-height:1.7;">
-                <li style="margin-bottom:6px;">Maintain secure account credentials.</li>
-                <li style="margin-bottom:6px;">Follow fair-play policies.</li>
-                <li style="margin-bottom:6px;">Ensure client-side system reliability.</li>
-                <li>Accept timer synchronization limitations inherent to online systems.</li>
-              </ul>
-            </div>
-          </div>
-
-          <p style="color:#64748b; font-size:0.82rem; margin-top:6px;">
-            Last updated: June 2026
-          </p>
-
         </div>
       </div>
 
-      <div style="padding:16px 28px; border-top:1px solid rgba(255,255,255,0.07); display:flex; justify-content:flex-end;">
-        <button type="button"
-                onclick="closeDisclaimerModal()"
-                style="background:linear-gradient(135deg,#f0c040,#d4a020); color:#0f0f1a; border:none; padding:10px 28px; border-radius:8px; font-weight:700; cursor:pointer;">
-          I Understand
+      <div class="faq-item">
+        <button class="faq-question">
+          <span>Can I customize the game timing modes?</span>
+          <span class="faq-icon-arrow">
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </span>
         </button>
+        <div class="faq-answer">
+          <div class="faq-answer-content">
+            Yes! The platform natively supports configuration profiles optimized
+            for Bullet, Blitz, and Rapid variants. Match setups are backed up by
+            accurate real-time validation layers that support timing
+            pause-and-resume cycles on active connections.
+          </div>
+        </div>
       </div>
 
-    </div>
-  </div>
-
-  <script>
-  (function () {
-      const modal = document.getElementById('disclaimerModal');
-      const modalInner = modal.querySelector('[tabindex="-1"]');
-      let lastFocused;
-
-      function openDisclaimerModal() {
-          lastFocused = document.activeElement;
-          modal.style.display = 'flex';
-          modalInner.focus();
-      }
-
-      function closeDisclaimerModal() {
-          modal.style.display = 'none';
-          if (lastFocused) lastFocused.focus();
-      }
-
-      window.openDisclaimerModal = openDisclaimerModal;
-      window.closeDisclaimerModal = closeDisclaimerModal;
-
-      document.addEventListener('keydown', function (e) {
-          if (e.key === 'Escape' && modal.style.display === 'flex') {
-              closeDisclaimerModal();
-          }
-      });
-
-      modal.addEventListener('click', function (e) {
-          if (e.target === modal) closeDisclaimerModal();
-      });
-
-      modal.addEventListener('keydown', function (e) {
-          if (e.key === 'Tab') {
-              const focusable = modal.querySelectorAll(
-                  'button,[href],[tabindex]:not([tabindex="-1"])'
-              );
-
-              const first = focusable[0];
-              const last = focusable[focusable.length - 1];
-
-              if (e.shiftKey && document.activeElement === first) {
-                  e.preventDefault();
-                  last.focus();
-              } else if (!e.shiftKey && document.activeElement === last) {
-                  e.preventDefault();
-                  first.focus();
-              }
-          }
-      });
-  })();
-  </script>
-  
-  <script>
-    const words = ["Compete.", "Improve.", "Dominate.", "Achieve."];
-    let wordIndex = 0;
-    let charIndex = 0;
-    let isDeleting = false;
-    const cycleWord = document.getElementById("cycleWord");
-
-    function typeWriter() {
-        const current = words[wordIndex];
-
-        if (isDeleting) {
-            cycleWord.textContent = current.substring(0, charIndex - 1);
-            charIndex--;
-        } else {
-            cycleWord.textContent = current.substring(0, charIndex + 1);
-            charIndex++;
-        }
-
-        let speed = isDeleting ? 60 : 100;
-
-        if (!isDeleting && charIndex === current.length) {
-            speed = 1500; // pause at end
-            isDeleting = true;
-        } else if (isDeleting && charIndex === 0) {
-            isDeleting = false;
-            wordIndex = (wordIndex + 1) % words.length;
-            speed = 400; // pause before next word
-        }
-
-        setTimeout(typeWriter, speed);
-    }
-
-    typeWriter();
-  </script>
-  
-  <script>
-    // ── Contribution Graph ──
-    const osGrid = document.getElementById('osGrid');
-    if (osGrid) {
-        for (let i = 0; i < 140; i++) {
-            const cell = document.createElement('div');
-            cell.className = 'os-cell';
-            const rand = Math.random();
-            if      (rand > 0.85) cell.classList.add('active-4');
-            else if (rand > 0.65) cell.classList.add('active-3');
-            else if (rand > 0.45) cell.classList.add('active-2');
-            else if (rand > 0.25) cell.classList.add('active-1');
-            osGrid.appendChild(cell);
-        }
-    }
-
-    // ── Mini Chessboard ──
-    const sicilian = [
-        ['♜','♞','♝','♛','♚','♝','♞','♜'],
-        ['♟','♟','♟','','♟','♟','♟','♟'],
-        ['','','','','','','',''],
-        ['','','','♟','','','',''],
-        ['','','','','♙','','',''],
-        ['','','♘','','','','',''],
-        ['♙','♙','♙','♙','','♙','♙','♙'],
-        ['♖','','♗','♕','♔','♗','♘','♖']
-    ];
-
-    const highlighted = [[3,3],[4,4]];
-    const miniBoard = document.getElementById('miniBoard');
-    if (miniBoard) {
-        sicilian.forEach((row, r) => {
-            row.forEach((piece, c) => {
-                const sq = document.createElement('div');
-                sq.className = `mini-sq ${(r+c)%2===1 ? 'dark' : 'light'}`;
-                if (highlighted.some(([hr,hc]) => hr===r && hc===c)) sq.classList.add('highlighted');
-                sq.textContent = piece;
-                miniBoard.appendChild(sq);
-            });
-        });
-    }
-
-    // ── Reusable Stat Counters Animation ──
-    function setupCounterAnimation(sectionSelector, numSelector) {
-        let statsAnimated = false;
-        
-        const observer = new IntersectionObserver((entries) => {
-            entries.forEach(e => {
-                if (e.isIntersecting && !statsAnimated) {
-                    statsAnimated = true;
-                    
-                    e.target.querySelectorAll(numSelector).forEach(el => {
-                        const target = parseInt(el.dataset.target);
-                        let count = 0;
-                        const stepsCount = target > 500000 ? 60 : 40;
-                        const step = Math.ceil(target / stepsCount);
-                        
-                        const interval = setInterval(() => {
-                            count = Math.min(count + step, target);
-                            
-                            if (target >= 1000000) {
-                                el.textContent = (count / 1000000).toFixed(1) + "M";
-                            } else {
-                                el.textContent = count.toLocaleString();
-                            }
-                            
-                            if (count >= target) {
-                                clearInterval(interval);
-                            }
-                        }, 35);
-                    });
-                    observer.disconnect();
-                }
-            });
-        }, { threshold: 0.2 });
-
-        const section = document.querySelector(sectionSelector);
-        if (section) observer.observe(section);
-    }
-
-    // Fire observers for both statistics modules smoothly
-    setupCounterAnimation('.platform-stats-section', '.stat-num');
-    setupCounterAnimation('.about-pin-section', '.about-stat-num');
-
-    // ── Automatic Carousel ──
-    const track       = document.getElementById('aboutTrack');
-    const progressFill = document.getElementById('aboutProgressFill');
-    const currentCardEl = document.getElementById('aboutCurrentCard');
-    const dots        = document.querySelectorAll('.about-dot');
-    const CARD_COUNT  = 4;
-    let currentCardIndex = 0;
-    let carouselInterval;
-    let isPausedManually = false;
-
-    const pausePlayBtn = document.getElementById('aboutPausePlayBtn');
-    const iconPause = document.getElementById('icon-pause');
-    const iconPlay = document.getElementById('icon-play');
-
-    function goToCard(index) {
-        currentCardIndex = index;
-        if (track) track.style.transform = `translateX(-${currentCardIndex * 25}%)`;
-        const progress = (currentCardIndex / (CARD_COUNT - 1)) * 100;
-        if (progressFill) progressFill.style.width = `${progress}%`;
-        if (currentCardEl) currentCardEl.textContent = currentCardIndex + 1;
-        dots.forEach((dot, i) => {
-            dot.classList.toggle('active', i === currentCardIndex);
-            dot.setAttribute('aria-pressed', i === currentCardIndex ? 'true' : 'false');
-        });
-    }
-
-    function nextCard() {
-        let nextIndex = (currentCardIndex + 1) % CARD_COUNT;
-        goToCard(nextIndex);
-    }
-
-    function startCarousel() {
-        if (!carouselInterval && !isPausedManually) {
-            carouselInterval = setInterval(nextCard, 5000);
-        }
-    }
-
-    function stopCarousel() {
-        if (carouselInterval) {
-            clearInterval(carouselInterval);
-            carouselInterval = null;
-        }
-    }
-
-    dots.forEach((dot, i) => {
-        dot.addEventListener('click', () => {
-            goToCard(i);
-            stopCarousel();
-            startCarousel();
-        });
-    });
-
-    if (pausePlayBtn) {
-        pausePlayBtn.addEventListener('click', () => {
-            if (isPausedManually) {
-                isPausedManually = false;
-                if (iconPlay) iconPlay.style.display = 'none';
-                if (iconPause) iconPause.style.display = 'block';
-                startCarousel();
-            } else {
-                isPausedManually = true;
-                stopCarousel();
-                if (iconPause) iconPause.style.display = 'none';
-                if (iconPlay) iconPlay.style.display = 'block';
-            }
-        });
-    }
-
-    if (track) {
-        goToCard(0);
-        startCarousel();
-
-        const aboutBox = document.querySelector('.about-box');
-        if (aboutBox) {
-            aboutBox.addEventListener('mouseenter', () => {
-                if (!isPausedManually) stopCarousel();
-            });
-            aboutBox.addEventListener('mouseleave', () => {
-                if (!isPausedManually) startCarousel();
-            });
-        }
-    }
-
-    // ── Smooth Scrolling for Anchor Links ──
-    document.querySelectorAll('a[href^="#"]').forEach(anchor => {
-        anchor.addEventListener('click', function (e) {
-            const targetId = this.getAttribute('href');
-            if (targetId === '#') return;
-            const targetElement = document.querySelector(targetId);
-            if (targetElement) {
-                e.preventDefault();
-                targetElement.scrollIntoView({
-                    behavior: 'smooth',
-                    block: 'start'
-                });
-            }
-        });
-    });
-  </script>
-  
-  <script>
-    // ── Performance Meter Animation ──
-    (function() {
-        const perfValue = document.getElementById('perfValue');
-        const depthVal  = document.getElementById('depthVal');
-        const arc       = document.querySelector('.perf-arc');
-        const needle    = document.querySelector('.perf-needle');
-
-        if (!perfValue || !arc || !needle) return;
-
-        const maxNodes  = 850;
-        const maxDepth  = 12;
-        const arcLength = 251;
-
-        let current = 0;
-        let direction = 1;
-        let frame;
-
-        function animate() {
-            current += direction * (Math.random() * 18 + 6);
-
-            if (current >= maxNodes) { current = maxNodes; direction = -1; }
-            if (current <= 80)       { current = 80;       direction =  1; }
-
-            const pct    = current / maxNodes;
-            const offset = arcLength - pct * arcLength;
-            const angle  = -90 + pct * 180;
-            const depth  = Math.round(pct * maxDepth);
-
-            arc.style.strokeDashoffset    = offset;
-            needle.style.transform        = `rotate(${angle}deg)`;
-            perfValue.textContent         = Math.round(current);
-            if (depthVal) depthVal.textContent = depth;
-
-            frame = setTimeout(animate, 120);
-        }
-
-        const perfObserver = new IntersectionObserver((entries) => {
-            entries.forEach(e => {
-                if (e.isIntersecting) animate();
-                else clearTimeout(frame);
-            });
-        }, { threshold: 0.3 });
-
-        const card3 = document.querySelectorAll('.about-card')[2];
-        if (card3) perfObserver.observe(card3);
-    })();
-  </script>  
-  
-  <script>
-    function selectQuizOpt(el, isCorrect) {
-        const opts = el.parentElement.querySelectorAll('.quiz-opt');
-        opts.forEach(o => { o.onclick = null; o.style.pointerEvents = 'none'; });
-        el.classList.add(isCorrect ? 'selected-right' : 'selected-wrong');
-        if (! isCorrect) {
-            el.parentElement.querySelector('.quiz-correct').classList.add('selected-right');
-        }
-        const fb = document.getElementById('quizFeedback');
-        fb.style.display = 'block';
-        if (!isCorrect) { fb.style.color = '#ef4444'; fb.textContent = '✗ Not quite — 2.Nf3 is the key move.'; }
-    }
-  </script>
-
-  <!-- Keyboard Shortcuts Modal -->
-  <div
-    id="shortcutsModal"
-    role="dialog"
-    aria-modal="true"
-    aria-labelledby="shortcutsTitle"
-       style="display:none;position:fixed;inset:0;background:rgba(0,0,0,.85);z-index:99999;align-items:center;justify-content:center;">
-
-    <div style="background:#131522;color:white;padding:24px;border-radius:16px;width:90%;max-width:600px;border:1px solid rgba(240,192,64,.3);">
-
-      <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:20px;">
-        <h2 id="shortcutsTitle" style="color:#f0c040;">Keyboard Shortcuts</h2>
-        <button type="button" aria-label="Close keyboard shortcuts dialog" title="Close" onclick="closeShortcutsModal()" style="background:none;border:none;color:white;font-size:22px;cursor:pointer;">✕</button>
+      <div class="faq-item">
+        <button class="faq-question">
+          <span>Does the platform support official FIDE rules?</span>
+          <span class="faq-icon-arrow">
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </span>
+        </button>
+        <div class="faq-answer">
+          <div class="faq-answer-content">
+            Absolutely. Checkora's structural architecture natively features
+            rigorous full move validation processes checking rulesets for
+            castling permissions, en passant states, standard checking
+            conditions, stalemates, and dynamic pawn promotion updates.
+          </div>
+        </div>
       </div>
 
-      <table style="width:100%;">
-        <tr>
-          <td><strong>Shift + /</strong></td>
-          <td>Open shortcuts help</td>
-        </tr>
-        <tr>
-          <td><strong>Esc</strong></td>
-          <td>Close modal</td>
-        </tr>
-        <tr>
-          <td><strong>g + h</strong></td>
-          <td>Go to Home</td>
-        </tr>
-        <tr>
-          <td><strong>g + p</strong></td>
-          <td>Play Game</td>
-        </tr>
-        <tr>
-          <td><strong>g + l</strong></td>
-          <td>Leaderboard</td>
-        </tr>
-        <tr>
-          <td><strong>g + s</strong></td>
-          <td>Lessons</td>
-        </tr>
-      </table>
-
+      <div class="faq-item">
+        <button class="faq-question">
+          <span>Is my gameplay history and analytical tracking private?</span>
+          <span class="faq-icon-arrow">
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </span>
+        </button>
+        <div class="faq-answer">
+          <div class="faq-answer-content">
+            All metrics are securely tied inside Django application instances.
+            Users gain standalone access controls over structural game
+            analytics, tracking dashboard components, and full options to wipe
+            historical records cleanly via account deletion pathways.
+          </div>
+        </div>
+      </div>
     </div>
   </div>
+</section>
+{% endblock %}
 
-  <script>
-  (function () {
-    let gPressed = false;
-    const modal = document.getElementById("shortcutsModal");
+{% block extra_js %}
+<script>
+  // ── Hero chess-board background piece animation ──
+  const board = document.getElementById("chess-board-bg");
+  const pieces = ["♛", "♚", "♞", "♝", "♜", "♟"];
+  const darkSquares = [];
 
-    window.openShortcutsModal = function () {
-      modal.style.display = "flex";
-    };
+  for (let r = 0; r < 20; r++) {
+    for (let c = 0; c < 20; c++) {
+      const sq = document.createElement("div");
+      sq.className = (r + c) % 2 === 1 ? "csq dark" : "csq light";
+      sq.dataset.r = r;
+      sq.dataset.c = c;
+      board.appendChild(sq);
+      if ((r + c) % 2 === 1) darkSquares.push({ el: sq, r, c });
+    }
+  }
 
-    window.closeShortcutsModal = function () {
-      modal.style.display = "none";
-    };
+  function isBehindText(r, c) {
+    return r >= 7 && r <= 13 && c >= 7 && c <= 13;
+  }
 
-    document.addEventListener("keydown", function (e) {
-      const tag = document.activeElement.tagName;
-      if (
-        tag === "INPUT" ||
-        tag === "TEXTAREA" ||
-        tag === "SELECT" ||
-        document.activeElement.isContentEditable
-      ) {
-        return;
-      }
+  function triggerPiece(zone) {
+    let pool;
+    if (zone === "right")
+      pool = darkSquares.filter((s) => s.c >= 5 && !s.el.dataset.busy);
+    else if (zone === "left")
+      pool = darkSquares.filter((s) => s.c <= 2 && !s.el.dataset.busy);
+    else pool = darkSquares.filter((s) => !s.el.dataset.busy);
+    if (!pool.length) return;
+    const chosen = pool[Math.floor(Math.random() * pool.length)];
+    const sq = chosen.el;
+    const behind = isBehindText(chosen.r, chosen.c);
+    sq.dataset.busy = "1";
+    const dur = 2000 + Math.random() * 900;
+    const glow = document.createElement("div");
+    glow.className = behind ? "sq-glow dim" : "sq-glow bright";
+    glow.style.animationDuration = dur + "ms";
+    sq.appendChild(glow);
+    const icon = document.createElement("div");
+    icon.textContent = pieces[Math.floor(Math.random() * pieces.length)];
+    icon.className = behind ? "sq-piece dim" : "sq-piece bright";
+    icon.style.animationDuration = dur + "ms";
+    sq.appendChild(icon);
+    setTimeout(() => {
+      glow.remove();
+      icon.remove();
+      delete sq.dataset.busy;
+    }, dur + 50);
+  }
 
-      if (e.shiftKey && e.key === "?") {
-        e.preventDefault();
-        openShortcutsModal();
-        return;
-      }
+  const heroIntervals = [];
+  heroIntervals.push(setInterval(() => triggerPiece("right"), 450));
+  heroIntervals.push(setInterval(() => triggerPiece("left"), 550));
+  heroIntervals.push(setInterval(() => triggerPiece(null), 250));
+  heroIntervals.push(setInterval(() => triggerPiece(null), 380));
 
-      if (e.key === "Escape") {
-        closeShortcutsModal();
-        return;
-      }
-
-      if (e.key.toLowerCase() === "g") {
-        gPressed = true;
-        setTimeout(() => { gPressed = false; }, 1000);
-        return;
-      }
-
-      if (modal.style.display === "flex") return;
-      if (!gPressed) return;
-
-      switch (e.key.toLowerCase()) {
-        case "h":
-          window.location.href = "{% url 'landing' %}";
-          break;
-        case "p":
-          window.location.href = "{% url 'index' %}";
-          break;
-        case "l":
-          window.location.href = "{% url 'leaderboard' %}";
-          break;
-        case "s":
-          window.location.href = "{% url 'lessons' %}";
-          break;
-      }
-      gPressed = false;
-    });
-
-    modal.addEventListener("click", function(e){
-      if(e.target === modal) closeShortcutsModal();
-    });
-  })();
-  </script>
-
-  <div class="cursor"></div>
-  
-  <script>
-    // Idempotent init — only run once even if this script is included twice.
-    if (window.__checkoraCursorInited) {
-      // Already initialized on this page; do nothing.
+  document.addEventListener("visibilitychange", () => {
+    if (document.hidden) {
+      heroIntervals.forEach((id) => clearInterval(id));
+      heroIntervals.length = 0;
     } else {
-      window.__checkoraCursorInited = true;
+      heroIntervals.push(setInterval(() => triggerPiece("right"), 450));
+      heroIntervals.push(setInterval(() => triggerPiece("left"), 550));
+      heroIntervals.push(setInterval(() => triggerPiece(null), 250));
+      heroIntervals.push(setInterval(() => triggerPiece(null), 380));
+    }
+  });
 
-      const cursor = document.querySelector('.cursor');
-      const cursorDropdown = document.querySelector('.cursor-dropdown');
-      const cursorTrigger = document.getElementById('cursorTypeTrigger');
-      const cursorTypeLabel = document.getElementById('cursorTypeLabel');
-      const cursorOptions = document.querySelectorAll('.cursor-type-option');
-      const CURSOR_STORAGE_KEY = 'checkora:cursor-type';
-      const VALID_CURSOR_TYPES = ['default', 'glow', 'trail', 'sparkle', 'orbit', 'chess'];
+  window.addEventListener("beforeunload", () => {
+    heroIntervals.forEach((id) => clearInterval(id));
+  });
+</script>
 
-      // ── Accessibility / device guards ────────────────────────────────
-      // Respect users who set the OS-level "reduce motion" preference.
-      const prefersReducedMotion = window.matchMedia &&
-        window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-      // Skip the custom cursor entirely on touch-only devices.
-      const isTouchDevice = window.matchMedia &&
-        window.matchMedia('(pointer: coarse)').matches;
-
-      let activeCursor = 'default';
-      let mouseX = 0;
-      let mouseY = 0;
-      let rafRunning = false;
-
-      // ── Position update: compositor-only transform ──────────────────
-      // This is the perf fix — writing left/top triggers layout every
-      // frame. Writing transform: translate3d() stays on the compositor
-      // (GPU layer) and gives 60+ FPS.
-      //
-      // The CSS positions the cursor at top:0; left:0 with width/height
-      // matching its size. JS writes translate3d(mouseX, mouseY, 0) to
-      // place the cursor's top-left corner at the mouse position. The
-      // CSS-rendered size then naturally extends down/right from there.
-      // (Earlier versions centered via translate(-50%, -50%) but that
-      //  collided with CSS animations on pseudo-elements.)
-      const CURSOR_OFFSETS = {
-        default: 8,
-        glow: 9,
-        trail: 6,
-        sparkle: 8,
-        orbit: 20,
-        chess: 12
-      };
-      let cursorOffset = CURSOR_OFFSETS.default;
-      function updateCursorPosition() {
-        cursor.style.transform =
-          'translate3d(' + (mouseX - cursorOffset) + 'px, ' + (mouseY - cursorOffset) + 'px, 0)';
-        rafRunning = false;
-      }
-
-      // mousemove only caches coords — no DOM writes here.
-      document.addEventListener('mousemove', e => {
-        mouseX = e.clientX;
-        mouseY = e.clientY;
-        if (!rafRunning && activeCursor !== 'default') {
-          rafRunning = true;
-          requestAnimationFrame(updateCursorPosition);
+<script>
+  // ── FAQ accordion ──
+  document.querySelectorAll(".faq-question").forEach((button) => {
+    button.addEventListener("click", () => {
+      const faqItem = button.parentElement;
+      const answer = button.nextElementSibling;
+      document.querySelectorAll(".faq-item").forEach((item) => {
+        if (item !== faqItem && item.classList.contains("active")) {
+          item.classList.remove("active");
+          item.querySelector(".faq-answer").style.maxHeight = null;
         }
-      }, { passive: true });
-
-      // ── localStorage helpers (safe — won't throw on disabled storage) ─
-      function safeGetStoredType() {
-        try {
-          const v = window.localStorage.getItem(CURSOR_STORAGE_KEY);
-          return VALID_CURSOR_TYPES.indexOf(v) >= 0 ? v : 'default';
-        } catch (e) { return 'default'; }
+      });
+      faqItem.classList.toggle("active");
+      if (faqItem.classList.contains("active")) {
+        answer.style.maxHeight = answer.scrollHeight + "px";
+      } else {
+        answer.style.maxHeight = null;
       }
-      function safeSetStoredType(type) {
-        try { window.localStorage.setItem(CURSOR_STORAGE_KEY, type); } catch (e) { /* ignore */ }
-      }
+    });
+  });
+</script>
 
-      // ── Apply a cursor type ─────────────────────────────────────────
-      function updateCursorType(type, persist) {
-        if (VALID_CURSOR_TYPES.indexOf(type) < 0) type = 'default';
-        // Auto-fallback for reduced-motion users (override non-default picks).
-        if ((isTouchDevice || prefersReducedMotion) && type !== 'default') type = 'default';
+<script>
+  // ── Hero tagline typewriter ──
+  const words = ["Compete.", "Improve.", "Dominate.", "Achieve."];
+  let wordIndex = 0;
+  let charIndex = 0;
+  let isDeleting = false;
+  const cycleWord = document.getElementById("cycleWord");
 
-        activeCursor = type;
-        cursor.className = 'cursor';
+  function typeWriter() {
+    const current = words[wordIndex];
 
-        if (type !== 'default') {
-          cursor.classList.add(type);
-          cursor.style.opacity = '0.98';
-          cursor.style.display = type === 'chess' ? 'flex' : 'block';
-        } else {
-          cursor.style.opacity = '0';
-          cursor.style.display = 'none';
-        }
+    if (isDeleting) {
+      cycleWord.textContent = current.substring(0, charIndex - 1);
+      charIndex--;
+    } else {
+      cycleWord.textContent = current.substring(0, charIndex + 1);
+      charIndex++;
+    }
 
-        cursorTypeLabel.textContent =
-          type.charAt(0).toUpperCase() + type.slice(1);
-        document.body.classList.toggle('hide-native-cursor', type !== 'default');
-        cursorOptions.forEach(option => {
-          option.classList.toggle('selected', option.dataset.cursor === type);
+    let speed = isDeleting ? 60 : 100;
+
+    if (!isDeleting && charIndex === current.length) {
+      speed = 1500;
+      isDeleting = true;
+    } else if (isDeleting && charIndex === 0) {
+      isDeleting = false;
+      wordIndex = (wordIndex + 1) % words.length;
+      speed = 400;
+    }
+
+    setTimeout(typeWriter, speed);
+  }
+
+  typeWriter();
+</script>
+
+<script>
+  // ── Contribution Graph ──
+  const osGrid = document.getElementById("osGrid");
+  if (osGrid) {
+    for (let i = 0; i < 140; i++) {
+      const cell = document.createElement("div");
+      cell.className = "os-cell";
+      const rand = Math.random();
+      if (rand > 0.85) cell.classList.add("active-4");
+      else if (rand > 0.65) cell.classList.add("active-3");
+      else if (rand > 0.45) cell.classList.add("active-2");
+      else if (rand > 0.25) cell.classList.add("active-1");
+      osGrid.appendChild(cell);
+    }
+  }
+
+  // ── Mini Chessboard ──
+  const sicilian = [
+    ["♜", "♞", "♝", "♛", "♚", "♝", "♞", "♜"],
+    ["♟", "♟", "♟", "", "♟", "♟", "♟", "♟"],
+    ["", "", "", "", "", "", "", ""],
+    ["", "", "", "♟", "", "", "", ""],
+    ["", "", "", "", "♙", "", "", ""],
+    ["", "", "♘", "", "", "", "", ""],
+    ["♙", "♙", "♙", "♙", "", "♙", "♙", "♙"],
+    ["♖", "", "♗", "♕", "♔", "♗", "♘", "♖"],
+  ];
+
+  const highlighted = [
+    [3, 3],
+    [4, 4],
+  ];
+  const miniBoard = document.getElementById("miniBoard");
+  if (miniBoard) {
+    sicilian.forEach((row, r) => {
+      row.forEach((piece, c) => {
+        const sq = document.createElement("div");
+        sq.className = `mini-sq ${(r + c) % 2 === 1 ? "dark" : "light"}`;
+        if (highlighted.some(([hr, hc]) => hr === r && hc === c))
+          sq.classList.add("highlighted");
+        sq.textContent = piece;
+        miniBoard.appendChild(sq);
+      });
+    });
+  }
+
+  // ── Reusable Stat Counters Animation ──
+  function setupCounterAnimation(sectionSelector, numSelector) {
+    let statsAnimated = false;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((e) => {
+          if (e.isIntersecting && !statsAnimated) {
+            statsAnimated = true;
+
+            e.target.querySelectorAll(numSelector).forEach((el) => {
+              const target = parseInt(el.dataset.target);
+              let count = 0;
+              const stepsCount = target > 500000 ? 60 : 40;
+              const step = Math.ceil(target / stepsCount);
+
+              const interval = setInterval(() => {
+                count = Math.min(count + step, target);
+
+                if (target >= 1000000) {
+                  el.textContent = (count / 1000000).toFixed(1) + "M";
+                } else {
+                  el.textContent = count.toLocaleString();
+                }
+
+                if (count >= target) {
+                  clearInterval(interval);
+                }
+              }, 35);
+            });
+            observer.disconnect();
+          }
         });
+      },
+      { threshold: 0.2 },
+    );
 
-        // Start/stop the rAF loop as needed.
-        if (type !== 'default' && !rafRunning) {
-          rafRunning = true;
-          requestAnimationFrame(updateCursorPosition);
-        }
+    const section = document.querySelector(sectionSelector);
+    if (section) observer.observe(section);
+  }
 
-        if (persist) safeSetStoredType(type);
+  setupCounterAnimation(".platform-stats-section", ".stat-num");
+  setupCounterAnimation(".about-pin-section", ".about-stat-num");
+
+  // ── Automatic Carousel ──
+  const track = document.getElementById("aboutTrack");
+  const progressFill = document.getElementById("aboutProgressFill");
+  const currentCardEl = document.getElementById("aboutCurrentCard");
+  const dots = document.querySelectorAll(".about-dot");
+  const CARD_COUNT = 4;
+  let currentCardIndex = 0;
+  let carouselInterval;
+  let isPausedManually = false;
+
+  const pausePlayBtn = document.getElementById("aboutPausePlayBtn");
+  const iconPause = document.getElementById("icon-pause");
+  const iconPlay = document.getElementById("icon-play");
+
+  function goToCard(index) {
+    currentCardIndex = index;
+    if (track) track.style.transform = `translateX(-${currentCardIndex * 25}%)`;
+    const progress = (currentCardIndex / (CARD_COUNT - 1)) * 100;
+    if (progressFill) progressFill.style.width = `${progress}%`;
+    if (currentCardEl) currentCardEl.textContent = currentCardIndex + 1;
+    dots.forEach((dot, i) => {
+      dot.classList.toggle("active", i === currentCardIndex);
+      dot.setAttribute(
+        "aria-pressed",
+        i === currentCardIndex ? "true" : "false",
+      );
+    });
+  }
+
+  function nextCard() {
+    let nextIndex = (currentCardIndex + 1) % CARD_COUNT;
+    goToCard(nextIndex);
+  }
+
+  function startCarousel() {
+    if (!carouselInterval && !isPausedManually) {
+      carouselInterval = setInterval(nextCard, 5000);
+    }
+  }
+
+  function stopCarousel() {
+    if (carouselInterval) {
+      clearInterval(carouselInterval);
+      carouselInterval = null;
+    }
+  }
+
+  dots.forEach((dot, i) => {
+    dot.addEventListener("click", () => {
+      goToCard(i);
+      stopCarousel();
+      startCarousel();
+    });
+  });
+
+  if (pausePlayBtn) {
+    pausePlayBtn.addEventListener("click", () => {
+      if (isPausedManually) {
+        isPausedManually = false;
+        if (iconPlay) iconPlay.style.display = "none";
+        if (iconPause) iconPause.style.display = "block";
+        startCarousel();
+      } else {
+        isPausedManually = true;
+        stopCarousel();
+        if (iconPause) iconPause.style.display = "none";
+        if (iconPlay) iconPlay.style.display = "block";
       }
+    });
+  }
 
-      // ── Init ────────────────────────────────────────────────────────
-      if (!isTouchDevice) {
-        const initialType = prefersReducedMotion ? 'default' : safeGetStoredType();
-        updateCursorType(initialType, false);
-      }
+  if (track) {
+    goToCard(0);
+    startCarousel();
 
-      // ── Dropdown wiring ─────────────────────────────────────────────
-      function closeCursorDropdown() {
-        cursorDropdown.classList.remove('active');
-        cursorTrigger.setAttribute('aria-expanded', 'false');
-      }
-      cursorTrigger.addEventListener('click', e => {
-        e.stopPropagation();
-        cursorDropdown.classList.toggle('active');
-        const expanded = cursorDropdown.classList.contains('active');
-        cursorTrigger.setAttribute('aria-expanded', expanded);
+    const aboutBox = document.querySelector(".about-box");
+    if (aboutBox) {
+      aboutBox.addEventListener("mouseenter", () => {
+        if (!isPausedManually) stopCarousel();
       });
-
-      cursorOptions.forEach(option => {
-        option.addEventListener('click', () => {
-          updateCursorType(option.dataset.cursor, true);
-          closeCursorDropdown();
-        });
-      });
-
-      document.addEventListener('click', e => {
-        if (!cursorDropdown.contains(e.target)) {
-          closeCursorDropdown();
-        }
-      });
-
-      document.addEventListener('keydown', e => {
-        if (e.key === 'Escape') {
-          closeCursorDropdown();
-        }
+      aboutBox.addEventListener("mouseleave", () => {
+        if (!isPausedManually) startCarousel();
       });
     }
-    window.addEventListener(
-      'scroll',
-      closeCursorDropdown,
-      { passive: true }
-    );
-  </script>
-  
-  <script src="{% static 'game/js/dropdown.js' %}?v=2"></script>
-  <script src="{% static 'game/js/theme.js' %}?v=1"></script>
-  
-  <script>
-    document.addEventListener('click', function(e) {
-        document.querySelectorAll('.profile-dropdown.active').forEach(function(menu) {
-            if (!menu.contains(e.target)) {
-                menu.classList.remove('active');
-            }
+  }
+
+  // ── Smooth Scrolling for in-page Anchor Links ──
+  document.querySelectorAll('a[href^="#"]').forEach((anchor) => {
+    anchor.addEventListener("click", function (e) {
+      const targetId = this.getAttribute("href");
+      if (targetId === "#") return;
+      const targetElement = document.querySelector(targetId);
+      if (targetElement) {
+        e.preventDefault();
+        targetElement.scrollIntoView({
+          behavior: "smooth",
+          block: "start",
         });
+      }
     });
-    </script>
-  </body>
-</html>
+  });
+</script>
+
+<script>
+  // ── Performance Meter Animation (About Card 3) ──
+  (function () {
+    const perfValue = document.getElementById("perfValue");
+    const depthVal = document.getElementById("depthVal");
+    const arc = document.querySelector(".perf-arc");
+    const needle = document.querySelector(".perf-needle");
+
+    if (!perfValue || !arc || !needle) return;
+
+    const maxNodes = 850;
+    const maxDepth = 12;
+    const arcLength = 251;
+
+    let current = 0;
+    let direction = 1;
+    let frame;
+
+    function animate() {
+      current += direction * (Math.random() * 18 + 6);
+
+      if (current >= maxNodes) {
+        current = maxNodes;
+        direction = -1;
+      }
+      if (current <= 80) {
+        current = 80;
+        direction = 1;
+      }
+
+      const pct = current / maxNodes;
+      const offset = arcLength - pct * arcLength;
+      const angle = -90 + pct * 180;
+      const depth = Math.round(pct * maxDepth);
+
+      arc.style.strokeDashoffset = offset;
+      needle.style.transform = `rotate(${angle}deg)`;
+      perfValue.textContent = Math.round(current);
+      if (depthVal) depthVal.textContent = depth;
+
+      frame = setTimeout(animate, 120);
+    }
+
+    const perfObserver = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((e) => {
+          if (e.isIntersecting) animate();
+          else clearTimeout(frame);
+        });
+      },
+      { threshold: 0.3 },
+    );
+
+    const card3 = document.querySelectorAll(".about-card")[2];
+    if (card3) perfObserver.observe(card3);
+  })();
+</script>
+{% endblock %}

--- a/game/templates/game/lesson_detail.html
+++ b/game/templates/game/lesson_detail.html
@@ -1,433 +1,295 @@
+{% extends "base.html" %}
 {% load static %}
 
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ lesson.title }} - Checkora</title>
-    <link rel="stylesheet" href="{% static 'game/css/lesson.css' %}">
-    <style>
-        @media (max-width: 480px) {
-            #backToTopWrapper {
-                bottom: 1rem;
-                right: 1rem;
-            }
+{% block title %}{{ lesson.title }} - Checkora{% endblock %}
 
-            #backToTopBtn {
-                width: 44px;
-                height: 44px;
-                font-size: 1.1rem;
-            }
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'game/css/lesson.css' %}">
+{% endblock %}
 
-            #backToTopTooltip {
-                font-size: 0.7rem;
-            }
-        }
-        
-        #backToTopWrapper {
-            position: fixed;
-            bottom: 2rem;
-            right: 2rem;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 6px;
-            opacity: 0;
-            pointer-events: none;
-            transition: opacity .3s ease;
-            z-index: 9999;
-        }
-
-        #backToTopWrapper.visible {
-            opacity: 1;
-            pointer-events: auto;
-        }
-
-        #backToTopTooltip {
-            background: rgba(15,15,26,.9);
-            color: #f0c040;
-            font-size: .75rem;
-            font-weight: 600;
-            padding: 4px 10px;
-            border-radius: 20px;
-            border: 1px solid rgba(240,192,64,.3);
-            opacity: 0;
-            transform: translateY(4px);
-            transition: .2s;
-            white-space: nowrap;
-        }
-
-        #backToTopWrapper:hover #backToTopTooltip,
-        #backToTopWrapper:focus-within #backToTopTooltip {
-            opacity: 1;
-            transform: translateY(0);
-        }
-
-        #backToTopBtn {
-            width: 52px;
-            height: 52px;
-            border-radius: 50%;
-            border: 1.5px solid rgba(0,0,0,.4);
-            background: linear-gradient(135deg,#f0c040,#d4a020);
-            color: #111;
-            font-size: 1.3rem;
-            font-weight: 800;
-            cursor: pointer;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            box-shadow: 0 4px 20px rgba(240,192,64,.35);
-            transition: .3s;
-        }
-
-        #backToTopBtn:focus-visible {
-            outline: 3px solid #ffffff;
-            outline-offset: 3px;
-        }
-
-        #backToTopBtn:hover {
-            background: linear-gradient(135deg,#f5cc55,#e0b030);
-            box-shadow: 0 6px 24px rgba(240,192,64,.6);
-        }
-
-        #backToTopBtn:hover .btn-arrow,
-        #backToTopBtn:focus-visible .btn-arrow {
-            animation: arrowBounce .6s infinite;
-        }
-
-        #backToTopBtn:active {
-            transform: scale(.92);
-        }
-
-        @keyframes arrowBounce {
-            0%,100% { transform: translateY(0); }
-            50% { transform: translateY(-4px); }
-        }
-    </style>
-</head>
-<body>
+{% block content %}
 
 <div class="container">
 
-    <a href="{% url 'lessons' %}" class="back-btn">
-        ← Back to Lessons
+    <a href="{% url 'lessons' %}" class="back-btn back-btn-inline">
+        &larr; Back to Lessons
     </a>
 
     <div class="lesson-box">
 
-    <h1>{{ lesson.title }}</h1>
+        <h1>{{ lesson.title }}</h1>
 
-    <p class="description">
-        {{ lesson.description }}
-    </p>
+        <p class="description">
+            {{ lesson.description }}
+        </p>
 
-    <h2>📖 Lesson Content</h2>
+        <h2>
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
+                <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
+            </svg>
+            Lesson Content
+        </h2>
 
-    {% if lesson.content %}
-    <ul class="lesson-content">
+        {% if lesson.content %}
+        <ul class="lesson-content">
+            {% for point in lesson.content %}
+            <li>{{ point }}</li>
+            {% endfor %}
+        </ul>
+        {% endif %}
 
-        {% for point in lesson.content %}
-        <li>{{ point }}</li>
-        {% endfor %}
-
-    </ul>
-    {% endif %}
-
-    <div class="coord-toggle-container">
-        <input type="checkbox" id="lessonCoordToggle" class="custom-checkbox" checked>
-        <label for="lessonCoordToggle" class="coord-toggle-label">Show Coordinates</label>
-    </div>
-
-    {% if board_examples %}
-   
-    <div class="board-demo">
-
-        <h2>♟ Interactive Board Example</h2>
-
-        <h3 id="example-title"></h3>
-        
-        <div class="lesson-board-aligned">
-            <div class="lesson-board-row">
-                <div class="lesson-ranks">
-                    <span>8</span><span>7</span><span>6</span><span>5</span><span>4</span><span>3</span><span>2</span><span>1</span>
-                </div>
-                <div id="demo-board"></div>
-            </div>
-            <div class="lesson-files">
-                <span>a</span><span>b</span><span>c</span><span>d</span><span>e</span><span>f</span><span>g</span><span>h</span>
-            </div>
-        </div>
-        <button
-            id="next-example-btn"
-            class="complete-btn"
-        >
-            Next Example
-        </button>
-    </div>
-
-    {{ board_examples|json_script:"board-examples-data" }}
-
-    {% endif %}
-
-    {% if lesson_steps %}
-
-    <div class="lesson-practice">
-
-        <h2>🎯 Practice Position</h2>
-
-        <p id="lesson-instruction"></p>
-
-        <div class="lesson-board-aligned">
-            <div class="lesson-board-row">
-                <div class="lesson-ranks">
-                    <span>8</span><span>7</span><span>6</span><span>5</span><span>4</span><span>3</span><span>2</span><span>1</span>
-                </div>
-                <div class="lesson-board-wrapper">
-                    <div id="practice-board" class="lesson-board"></div>
-                </div>
-            </div>
-            <div class="lesson-files">
-                <span>a</span><span>b</span><span>c</span><span>d</span><span>e</span><span>f</span><span>g</span><span>h</span>
-            </div>
+        <div class="coord-toggle-container">
+            <input type="checkbox" id="lessonCoordToggle" class="custom-checkbox" checked>
+            <label for="lessonCoordToggle" class="coord-toggle-label">Show Coordinates</label>
         </div>
 
-        <p id="lesson-result"></p>
+        {% if board_examples %}
 
-        <button
-            type="button"
-            id="retry-btn"
-            class="complete-btn"
-            style="display:none; margin-top:10px;"
-        >
-            🔄 Retry
-        </button>
+        <div class="board-demo">
 
-    </div>
+            <h2>&#9822; Interactive Board Example</h2>
 
-    {{ lesson_steps|json_script:"lesson-steps-data" }}
-    {{ practice_position|json_script:"practice-position-data" }}
+            <h3 id="example-title"></h3>
 
-    {% endif %}
+            <div class="lesson-board-aligned">
+                <div class="lesson-board-row">
+                    <div class="lesson-ranks">
+                        <span>8</span><span>7</span><span>6</span><span>5</span><span>4</span><span>3</span><span>2</span><span>1</span>
+                    </div>
+                    <div class="lesson-board-wrapper">
+                        <div id="demo-board" class="lesson-board"></div>
+                    </div>
+                </div>
+                <div class="lesson-files">
+                    <span>a</span><span>b</span><span>c</span><span>d</span><span>e</span><span>f</span><span>g</span><span>h</span>
+                </div>
+            </div>
 
-    {% if lesson.practice_question %}
-    <div class="coming-soon">
+            <button id="next-example-btn" class="complete-btn">Next Example</button>
+        </div>
 
-        <h3>📝 Practice Exercise</h3>
+        {{ board_examples|json_script:"board-examples-data" }}
 
-        <p><strong>Question:</strong> {{ lesson.practice_question }}</p>
+        {% endif %}
 
-        <details>
-            <summary>Show Answer</summary>
-            <p>{{ lesson.practice_answer }}</p>
-        </details>
+        {% if lesson_steps %}
 
-    </div>
-    {% endif %}
+        <div class="lesson-practice">
 
+            <h2>
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                    <circle cx="12" cy="12" r="9" />
+                    <circle cx="12" cy="12" r="5" />
+                    <circle cx="12" cy="12" r="1.2" fill="currentColor" stroke="none" />
+                </svg>
+                Practice Position
+            </h2>
 
-    <div style="margin-top:25px;">
-    
-    {% if is_completed %}
+            <p id="lesson-instruction"></p>
 
-    <button
-        class="complete-btn"
-        disabled
-    >
-        ✓ Completed
-    </button>
+            <div class="lesson-board-aligned">
+                <div class="lesson-board-row">
+                    <div class="lesson-ranks">
+                        <span>8</span><span>7</span><span>6</span><span>5</span><span>4</span><span>3</span><span>2</span><span>1</span>
+                    </div>
+                    <div class="lesson-board-wrapper">
+                        <div id="practice-board" class="lesson-board"></div>
+                    </div>
+                </div>
+                <div class="lesson-files">
+                    <span>a</span><span>b</span><span>c</span><span>d</span><span>e</span><span>f</span><span>g</span><span>h</span>
+                </div>
+            </div>
 
-    {% else %}
+            <p id="lesson-result"></p>
 
-    <form
-        method="post"
-        action="{% url 'complete_lesson' lesson.title|slugify %}"
-    >
-        {% csrf_token %}
-
-        <button
-            type="submit"
-            class="complete-btn"
-        >
-            ✓ Mark Lesson Complete
-        </button>
-    </form>
-
-    {% endif %}
-
-    </div>
-
-    {% if lesson.quiz_question %}
-
-    <div class="coming-soon">
-
-        <h3>🎯 Quick Quiz</h3>
-
-        <p>{{ lesson.quiz_question }}</p>
-
-        {% for option in lesson.quiz_options %}
-
-            <button
-                class="quiz-btn"
-                onclick="checkAnswer(this, '{{ option|escapejs }}', '{{ lesson.quiz_answer|escapejs }}')"
-            >
-                {{ option }}
+            <button type="button" id="retry-btn" class="complete-btn" style="display:none; margin-top:10px;">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="vertical-align:-2px; margin-right:4px;">
+                    <polyline points="1 4 1 10 7 10" />
+                    <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10" />
+                </svg>
+                Retry
             </button>
 
-            <br><br>
+        </div>
 
-        {% endfor %}
+        {{ lesson_steps|json_script:"lesson-steps-data" }}
+        {{ practice_position|json_script:"practice-position-data" }}
 
-        <p id="quiz-result"></p>
+        {% endif %}
 
-    </div>
+        {% if lesson.practice_question %}
+        <div class="coming-soon">
 
-    {% endif %}
-    <div class="lesson-navigation">
+            <h3>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="vertical-align:-2px; margin-right:4px;">
+                    <path d="M12 20h9" />
+                    <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
+                </svg>
+                Practice Exercise
+            </h3>
 
-        {% if previous_lesson %}
+            <p><strong>Question:</strong> {{ lesson.practice_question }}</p>
+
+            <details>
+                <summary>Show Answer</summary>
+                <p>{{ lesson.practice_answer }}</p>
+            </details>
+
+        </div>
+        {% endif %}
+
+        <div style="margin-top:25px;">
+
+            {% if is_completed %}
+
+            <button class="complete-btn" disabled>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="vertical-align:-2px; margin-right:4px;">
+                    <polyline points="20 6 9 17 4 12" />
+                </svg>
+                Completed
+            </button>
+
+            {% else %}
+
+            <form method="post" action="{% url 'complete_lesson' lesson.title|slugify %}">
+                {% csrf_token %}
+                <button type="submit" class="complete-btn">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="vertical-align:-2px; margin-right:4px;">
+                        <polyline points="20 6 9 17 4 12" />
+                    </svg>
+                    Mark Lesson Complete
+                </button>
+            </form>
+
+            {% endif %}
+
+        </div>
+
+        {% if lesson.quiz_question %}
+
+        <div class="coming-soon">
+
+            <h3>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true" style="vertical-align:-2px; margin-right:4px;">
+                    <circle cx="12" cy="12" r="9" />
+                    <circle cx="12" cy="12" r="5" />
+                    <circle cx="12" cy="12" r="1.2" fill="currentColor" stroke="none" />
+                </svg>
+                Quick Quiz
+            </h3>
+
+            <p>{{ lesson.quiz_question }}</p>
+
+            {% for option in lesson.quiz_options %}
+                <button class="quiz-btn" onclick="checkAnswer(this, '{{ option|escapejs }}', '{{ lesson.quiz_answer|escapejs }}')">
+                    {{ option }}
+                </button>
+                <br><br>
+            {% endfor %}
+
+            <p id="quiz-result"></p>
+
+        </div>
+
+        {% endif %}
+
+        <div class="lesson-navigation">
+
+            {% if previous_lesson %}
             <a href="{% url 'lesson_detail' previous_lesson|slugify %}">
-                ← {{ previous_lesson }}
+                &larr; {{ previous_lesson }}
             </a>
-        {% endif %}
+            {% endif %}
 
-        {% if next_lesson %}
+            {% if next_lesson %}
             <a href="{% url 'lesson_detail' next_lesson|slugify %}">
-                {{ next_lesson }} →
+                {{ next_lesson }} &rarr;
             </a>
-        {% endif %}
+            {% endif %}
+
+        </div>
+
     </div>
 
 </div>
 
+{% endblock %}
 
-</div>
-
-</div>
-
+{% block extra_js %}
 <script>
-document.addEventListener("DOMContentLoaded", () => {
-    const backToTop = document.getElementById("backToTopWrapper");
-
-    const toggleBackToTop = () => {
-        if (window.scrollY > 300) {
-            backToTop.classList.add("visible");
-        } else {
-            backToTop.classList.remove("visible");
-        }
-    };
-
-    window.addEventListener("scroll", toggleBackToTop);
-
-    // Show immediately if page is already scrolled
-    toggleBackToTop();
-});
-
 function checkAnswer(btn, selected, correct) {
-
-    const result =
-        document.getElementById("quiz-result");
+    const result = document.getElementById("quiz-result");
     const buttons = document.querySelectorAll(".quiz-btn");
 
-    // Reset previous states
-    buttons.forEach(b => {
+    buttons.forEach((b) => {
         b.classList.remove("correct", "incorrect");
     });
 
     if (selected.trim() === correct.trim()) {
-
         result.innerHTML =
-            "✅ Correct Answer!";
-
+            '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="vertical-align:-2px; margin-right:4px;"><polyline points="20 6 9 17 4 12"/></svg> Correct Answer!';
         result.style.color = "#4caf50";
         btn.classList.add("correct");
-
-        // Force re-trigger animation
         btn.classList.remove("correct");
         void btn.offsetWidth;
         btn.classList.add("correct");
-
         triggerCelebration(btn);
-
     } else {
-
         result.innerHTML =
-            "❌ Incorrect. Try Again.";
-
+            '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="vertical-align:-2px; margin-right:4px;"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg> Incorrect. Try Again.';
         result.style.color = "#ff5252";
         btn.classList.add("incorrect");
-
-        // Force re-trigger animation
         btn.classList.remove("incorrect");
-        void btn.offsetWidth; // trigger reflow
+        void btn.offsetWidth;
         btn.classList.add("incorrect");
     }
 }
 
 function triggerCelebration(btn) {
-    // Create confetti container if it doesn't exist
-    let confettiContainer = document.querySelector('.confetti-container');
+    let confettiContainer = document.querySelector(".confetti-container");
     if (!confettiContainer) {
-        confettiContainer = document.createElement('div');
-        confettiContainer.className = 'confetti-container';
+        confettiContainer = document.createElement("div");
+        confettiContainer.className = "confetti-container";
         document.body.appendChild(confettiContainer);
     }
+    confettiContainer.innerHTML = "";
 
-    // Clear existing confetti
-    confettiContainer.innerHTML = '';
-
-    // Create confetti pieces
-    const colors = ['#ffd700', '#f0c040', '#ff6b6b', '#4ecdc4', '#45b7d1', '#96ceb4', '#ff9ff3'];
-    const confettiCount = 100; // More for fullscreen effect
+    const colors = ["#ffd700", "var(--accent-gold)", "#ff6b6b", "#4ecdc4", "#45b7d1", "#96ceb4", "#ff9ff3"];
+    const confettiCount = 100;
 
     for (let i = 0; i < confettiCount; i++) {
-        const confetti = document.createElement('div');
-        confetti.className = 'confetti';
+        const confetti = document.createElement("div");
+        confetti.className = "confetti";
 
-        // Random properties
         const randomColor = colors[Math.floor(Math.random() * colors.length)];
         const randomLeft = Math.random() * 100;
-        const randomDelay = Math.random() * 1.5; // Spread out the start
+        const randomDelay = Math.random() * 1.5;
         const randomDuration = 2.5 + Math.random() * 2;
         const randomRotation = Math.random() * 360;
 
-        confetti.style.left = randomLeft + '%';
+        confetti.style.left = randomLeft + "%";
         confetti.style.background = randomColor;
-        confetti.style.animationDelay = randomDelay + 's';
-        confetti.style.animationDuration = randomDuration + 's';
+        confetti.style.animationDelay = randomDelay + "s";
+        confetti.style.animationDuration = randomDuration + "s";
         confetti.style.transform = `rotate(${randomRotation}deg)`;
 
-        // Random shapes
         if (Math.random() > 0.5) {
-            confetti.style.borderRadius = '50%';
+            confetti.style.borderRadius = "50%";
         }
 
         confettiContainer.appendChild(confetti);
     }
 
-    // Cleanup after animation
     setTimeout(() => {
         if (confettiContainer) {
             confettiContainer.remove();
         }
     }, 6000);
 }
-
 </script>
 <script src="{% static 'game/js/lesson_demo.js' %}"></script>
 <script src="{% static 'game/js/lesson_practice.js' %}"></script>
 <script src="{% static 'game/js/lesson_coordinates.js' %}"></script>
-<div id="backToTopWrapper">
-    <span id="backToTopTooltip">Back to Top</span>
-
-    <button
-        type="button"
-        id="backToTopBtn"
-        aria-label="Back to top"
-        onclick="window.scrollTo({top:0,behavior:'smooth'})"
-    >
-        <span class="btn-arrow">^</span>
-    </button>
-</div>
-</body>
-</html>
+{% endblock %}

--- a/game/templates/game/lesson_map.html
+++ b/game/templates/game/lesson_map.html
@@ -1,515 +1,36 @@
+{% extends "base.html" %}
 {% load static %}
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Learning Journey</title>
+{% block title %}Learning Journey - Checkora{% endblock %}
 
-<style>
-body{
-    margin:0;
-    background:
-    linear-gradient(
-    45deg,
-    #111 25%,
-    #0f0f0f 25%,
-    #0f0f0f 50%,
-    #111 50%,
-    #111 75%,
-    #0f0f0f 75%
-    );
+{% block body_attrs %} class="roadmap-checkerboard-bg"{% endblock %}
 
-background-size:60px 60px;
-    color:white;
-    font-family:Segoe UI,sans-serif;
-}
+{% block content %}
 
-.header{
-    text-align:center;
-    padding:30px;
-}
+{% include "partials/guest_alert.html" %}
 
-.header h1{
-    color:#f0c040;
-}
-
-.map-container{
-    max-width:900px;
-    margin:auto;
-    padding:20px;
-    position: relative;
-}
-
-.level-title{
-    text-align:center;
-    margin:80px 0 30px;
-    font-size:34px;
-    color:#f0c040;
-    font-weight:700;
-    text-shadow:0 0 15px rgba(240,192,64,.5);
-}
-
-.lesson-path{
-    display:flex;
-    flex-direction:column;
-    align-items:center;
-}
-
-.lesson-row{
-    width:100%;
-    display:flex;
-    margin: 10px 0;
-}
-
-.lesson-row.left{
-    justify-content:flex-start;
-    padding-left:120px;
-}
-
-.lesson-row.right{
-    justify-content:flex-end;
-    padding-right:120px;
-
-}
-
-.node{
-    width: 60px;
-    height: 60px;
-    background: #2a2a35;
-    border-radius:50%;
-    display:flex;
-    align-items:center;
-    justify-content:center;
-    font-size:24px;
-    border: 2px solid #444;
-    transition: transform 0.3s, box-shadow 0.3s;
-    text-decoration:none;
-    color:white;
-    position: relative;
-    z-index: 1;
-}
-
-.node:hover{
-    transform:scale(1.08);
-}
-
-.completed{
-    background:#22c55e;
-    box-shadow:0 0 25px #22c55e;
-}
-
-.current{
-    background:#3b82f6;
-    box-shadow:0 0 25px #3b82f6;
-    border:4px solid white;
-    transform:scale(1.12);
-    position:relative;
-}
-
-.current::before{
-    content:"NEXT";
-    position:absolute;
-    top:-12px;
-    background:white;
-    color:black;
-    font-size:10px;
-    font-weight:700;
-    padding:4px 8px;
-    border-radius:12px;
-}
-
-.locked{
-    background:#555;
-    cursor:not-allowed;
-}
-
-.lesson-name{
-    margin-top:12px;
-    text-align:center;
-    width:180px;
-    color:#ddd;
-}
-
-.lesson-card{
-    margin-top:12px;
-    background:#181818;
-    border:1px solid #2d2d2d;
-    border-radius:16px;
-    padding:12px;
-    width:180px;
-    text-align:center;
-    box-shadow:0 4px 12px rgba(0,0,0,.3);
-}
-
-.lesson-card:hover{
-    border-color:#f0c040;
-    transform:translateY(-3px);
-}
-
-.lesson-card h3{
-    margin:0 0 12px;
-    color:white;
-    font-size:18px;
-}
-
-.badge{
-    display:inline-block;
-    padding:6px 12px;
-    border-radius:20px;
-    font-size:12px;
-    font-weight:600;
-}
-
-.done{
-    background:#22c55e;
-    color:white;
-}
-
-.active{
-    background:#3b82f6;
-    color:white;
-}
-
-.locked-badge{
-    background:#555;
-    color:white;
-}
-
-.node span{
-    font-size:42px;
-}
-
-.node.current{
-    border:4px solid white;
-    transform:scale(1.15);
-}
-
-.progress-box{
-    max-width:700px;
-    margin:0 auto 60px;
-    background:linear-gradient(
-        135deg,
-        #181818,
-        #242424
-    );
-    padding:25px;
-    border-radius:24px;
-    border:1px solid #2d2d2d;
-}
-
-.progress-track{
-    height:12px;
-    background:#333;
-    border-radius:20px;
-    overflow:hidden;
-}
-
-.progress-fill{
-    height:100%;
-    background:linear-gradient(
-        90deg,
-        #22c55e,
-        #36e6c5
-    );
-}
-
-.lesson-wrapper{
-    display:flex;
-    flex-direction:column;
-    align-items:center;
-    position: relative; 
-    z-index: 2;
-}
-
-.back-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-
-    margin: 20px 0 0 20px;
-    padding: 0.6rem 1.2rem;
-
-    background: rgba(22, 22, 42, 0.6);
-    color: #ffffff;
-
-    font-size: 0.85rem;
-    font-weight: 600;
-    text-decoration: none;
-
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 30px;
-
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
-
-    transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.back-btn:hover {
-    color: #f0c040;
-    border-color: rgba(240, 192, 64, 0.3);
-
-    transform: translateX(-3px);
-
-    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.4);
-}
-
-@media(max-width:768px){
-
-    .lesson-row.left,
-    .lesson-row.right{
-        justify-content:center;
-    }
-
-    .node{
-        width:90px;
-        height:90px;
-    }
-}
-
-.alert-banner {
-    background: linear-gradient(135deg, #2c1f00, #1b1300);
-    border: 1px solid #f0c040;
-    border-radius: 12px;
-    padding: 16px 20px;
-    margin: 20px 20px 0 20px;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-    box-shadow: 0 4px 20px rgba(240, 192, 64, 0.15);
-    animation: fadeIn 0.5s ease;
-}
-
-.alert-content {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-}
-
-.alert-banner a.alert-link {
-    color: #f0c040;
-    text-decoration: underline;
-    font-weight: 600;
-    transition: color 0.2s ease;
-}
-
-.alert-banner a.alert-link:hover {
-    color: #ffdf70;
-}
-
-.alert-text {
-    font-size: 1rem;
-    color: #e0e0e0;
-    line-height: 1.5;
-}
-
-.alert-icon {
-    font-size: 1.25rem;
-}
-
-.alert-close {
-    background: transparent;
-    border: none;
-    color: #bdbdbd;
-    font-size: 1.5rem;
-    cursor: pointer;
-    padding: 0 4px;
-    line-height: 1;
-    transition: color 0.2s ease, transform 0.2s ease;
-}
-
-.alert-close:hover {
-    color: #ffffff;
-    transform: scale(1.1);
-}
-
-#backToTopWrapper {
-    position: fixed;
-    bottom: 2rem;
-    right: 2rem;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 6px;
-
-    opacity: 0;
-    pointer-events: none;
-
-    transition: opacity 0.3s ease;
-    z-index: 999;
-}
-
-#backToTopWrapper.visible {
-    opacity: 1;
-    pointer-events: auto;
-}
-
-#backToTopTooltip {
-    background: rgba(15, 15, 26, 0.9);
-    color: #f0c040;
-    font-size: 0.75rem;
-    font-weight: 600;
-    padding: 4px 10px;
-    border-radius: 20px;
-    border: 1px solid rgba(240, 192, 64, 0.3);
-    letter-spacing: 0.5px;
-    opacity: 0;
-    transform: translateY(4px);
-    transition: opacity 0.2s ease, transform 0.2s ease;
-    white-space: nowrap;
-    pointer-events: none;
-}
-
-#backToTopWrapper:hover #backToTopTooltip {
-    opacity: 1;
-    transform: translateY(0);
-}
-
-#backToTopBtn {
-    width: 52px;
-    height: 52px;
-    border-radius: 50%;
-    background: linear-gradient(135deg, #f0c040, #d4a020);
-    color: #0f0f1a;
-    border: 1.5px solid rgba(0, 0, 0, 0.4);
-    font-size: 1.3rem;
-    font-weight: 800;
-    cursor: pointer;
-    transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
-    box-shadow: 0 4px 20px rgba(240, 192, 64, 0.35);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-#backToTopBtn:hover {
-    background: linear-gradient(135deg, #f5cc55, #e0b030);
-    box-shadow: 0 6px 24px rgba(240, 192, 64, 0.6);
-}
-
-#backToTopBtn:hover .btn-arrow {
-    animation: arrow-bounce 0.6s ease infinite;
-}
-
-#backToTopBtn:active {
-    transform: scale(0.92);
-}
-
-@keyframes arrow-bounce {
-    0%, 100% {
-        transform: translateY(0);
-    }
-
-    50% {
-        transform: translateY(-4px);
-    }
-}
-
-@keyframes fadeIn {
-    from { opacity: 0; transform: translateY(-10px); }
-    to { opacity: 1; transform: translateY(0); }
-}
-
-
-/* Light Theme Overrides */
-[data-theme="light"] body {
-    background: #f5f7fb;
-    color: #111827;
-}
-
-[data-theme="light"] .header h1,
-[data-theme="light"] .level-title {
-    color: #d4a017;
-    text-shadow: none;
-}
-
-[data-theme="light"] .progress-box {
-    background: #ffffff;
-    border: 1px solid #e5e7eb;
-    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.05);
-}
-
-[data-theme="light"] .progress-box h3,
-[data-theme="light"] .progress-box p {
-    color: #111827;
-}
-
-[data-theme="light"] .progress-track {
-    background: #e5e7eb;
-}
-
-[data-theme="light"] .progress-fill {
-    background: linear-gradient(90deg, #d4a017, #fcd34d);
-}
-
-[data-theme="light"] .lesson-card {
-    background: #ffffff;
-    border: 1px solid #e5e7eb;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
-}
-
-[data-theme="light"] .lesson-card:hover {
-    border-color: #d4a017;
-    box-shadow: 0 10px 25px rgba(212, 160, 23, 0.2);
-}
-
-[data-theme="light"] .lesson-card h3 {
-    color: #111827;
-}
-
-[data-theme="light"] .node {
-    background: #f3f4f6;
-    border: 2px solid #cbd5e1;
-    color: #4b5563;
-}
-
-[data-theme="light"] .locked-badge {
-    background: #e2e8f0;
-    color: #64748b;
-}
-
-[data-theme="light"] .lesson-name {
-    color: #4b5563;
-}
-</style>
-<script src="{% static 'game/js/theme.js' %}?v=1"></script>
-</head>
-
-<body>
-
-{% if not user.is_authenticated %}
-<div class="alert-banner" id="guest-alert">
-    <div class="alert-content">
-        <span class="alert-icon">💡</span>
-        <span class="alert-text">
-            <a href="{% url 'login' %}" class="alert-link">Sign in</a> or <a href="{% url 'register' %}" class="alert-link">create a free account</a> to save your lesson progress.
-        </span>
-    </div>
-    <button class="alert-close" type="button" onclick="dismissAlert()" aria-label="Close message">&times;</button>
-</div>
-{% endif %}
-
-<a href="{% url 'landing' %}" class="back-btn">
-← Back to Home
+<a href="{% url 'landing' %}" class="back-btn back-btn-inline">
+    &larr; Back to Home
 </a>
 
-<div class="header">
-    <h1>🗺 Chess Learning Journey</h1>
+<div class="roadmap-header">
+    <h1>
+        <svg width="30" height="30" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <polygon points="1 6 1 22 8 18 16 22 23 18 23 2 16 6 8 2 1 6"/>
+            <line x1="8" y1="2" x2="8" y2="18"/>
+            <line x1="16" y1="6" x2="16" y2="22"/>
+        </svg>
+        Chess Learning Journey
+    </h1>
     <p>Complete lessons to unlock the next one.</p>
 </div>
 
-<div class="progress-box">
+<div class="roadmap-progress-box">
 
     <h3>Your Journey Progress</h3>
 
     <div class="progress-track">
         <div class="progress-fill" id="map-progress-fill" data-progress="{% widthratio completed_lessons|length total_lessons 100 %}"></div>
-        <script>document.getElementById('map-progress-fill').style.width = document.getElementById('map-progress-fill').dataset.progress + '%';</script>
     </div>
 
     <p>
@@ -524,7 +45,7 @@ background-size:60px 60px;
     {% for level in levels %}
 
     <div class="level-title">
-        Level {{ level.id }} • {{ level.title }}
+        Level {{ level.id }} &bull; {{ level.title }}
     </div>
 
     <div class="lesson-path">
@@ -539,27 +60,32 @@ background-size:60px 60px;
 
                         <a
                             href="{% url 'lesson_detail' lesson|slugify %}"
-                            class="node completed roadmap-node">
-                            <span>♔</span>
+                            class="node completed roadmap-node"
+                            aria-label="{{ lesson }} — completed">
+                            <span aria-hidden="true">&#9812;</span>
                         </a>
 
                     {% elif lesson in unlocked_lessons %}
 
                         <a
                             href="{% url 'lesson_detail' lesson|slugify %}"
-                            class="node current roadmap-node">
-                            <span>♕</span>
+                            class="node current roadmap-node"
+                            aria-label="{{ lesson }} — next lesson">
+                            <span aria-hidden="true">&#9813;</span>
                         </a>
 
                     {% else %}
 
-                        <div class="node locked roadmap-node">
-                            <span>🔒</span>
+                        <div class="node locked roadmap-node" aria-label="{{ lesson }} — locked">
+                            <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                <rect x="3" y="11" width="18" height="11" rx="2"/>
+                                <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+                            </svg>
                         </div>
 
                     {% endif %}
 
-                    <div class="lesson-card">
+                    <div class="roadmap-lesson-card">
 
                         <h3>{{ lesson }}</h3>
 
@@ -586,60 +112,22 @@ background-size:60px 60px;
 
             </div>
 
-           
-
         {% endfor %}
 
     </div>
 
-{% endfor %}
+    {% endfor %}
 
 </div>
-<div id="backToTopWrapper">
-    <span id="backToTopTooltip">Back to Top</span>
-    <button type="button" id="backToTopBtn" aria-label="Back to top" onclick="window.scrollTo({top:0,behavior:'smooth'})">
-        <span class="btn-arrow">^</span>
-    </button>
-</div>
+
+{% endblock %}
+
+{% block extra_js %}
 <script src="{% static 'game/js/roadmap_connectors.js' %}"></script>
 <script>
-    document.addEventListener("DOMContentLoaded", () => {
-        const backToTop = document.getElementById("backToTopWrapper");
-
-        const toggleBackToTop = () => {
-            if (window.scrollY > 300) {
-                backToTop.classList.add("visible");
-            } else {
-                backToTop.classList.remove("visible");
-            }
-        };
-
-        window.addEventListener("scroll", toggleBackToTop);
-
-        // Sync initial state for restored scroll positions
-        toggleBackToTop();
+    document.addEventListener('DOMContentLoaded', function () {
+        var fill = document.getElementById('map-progress-fill');
+        if (fill) fill.style.width = fill.dataset.progress + '%';
     });
-    document.addEventListener('DOMContentLoaded', function() {
-        if (localStorage.getItem('lessons_guest_alert_dismissed') === 'true') {
-            var alert = document.getElementById('guest-alert');
-            if (alert) {
-                alert.style.display = 'none';
-            }
-        }
-    });
-
-    function dismissAlert() {
-        var alert = document.getElementById('guest-alert');
-        if (alert) {
-            alert.style.transition = 'opacity 0.3s ease, transform 0.3s ease';
-            alert.style.opacity = '0';
-            alert.style.transform = 'translateY(-10px)';
-            localStorage.setItem('lessons_guest_alert_dismissed', 'true');
-            setTimeout(function() {
-                alert.style.display = 'none';
-            }, 300);
-        }
-    }
 </script>
-</body>
-</html>
+{% endblock %}

--- a/game/templates/game/lessons.html
+++ b/game/templates/game/lessons.html
@@ -1,497 +1,129 @@
-{% load static %}
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <title>Chess Lessons - Checkora</title>
+{% extends "base.html" %} {% load static %} {% block title %}Chess Lessons -
+Checkora{% endblock %} {% block content %} {% include
+"partials/guest_alert.html" %}
 
-    <link rel="icon" href="{% static 'game/favicon.jpeg' %}?v=2">
-
-    <style>
-        body {
-            font-family: "Segoe UI", sans-serif;
-            background: #0f0f0f;
-            color: #ffffff;
-            padding: 30px;
-            margin: 0;
-        }       
-
-        a {
-            text-decoration: none;
-            color: inherit;
-        }
-
-        .hero {
-            text-align: center;
-            margin-bottom: 40px;
-        }
-
-        .hero h1 {
-            font-size: 3rem;
-            color: #f0c040;
-            margin-bottom: 10px;
-        }
-
-        .hero p {
-            color: #bdbdbd;
-            font-size: 1rem;
-        }
-
-        .progress-box {
-            background: linear-gradient(145deg, #1b1b1b, #242424);
-            border: 1px solid #333;
-            border-radius: 18px;
-            padding: 25px;
-            margin-bottom: 35px;
-        }
-
-        .progress-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 15px;
-        }
-
-        .progress-header h2 {
-            margin: 0;
-            color: #f0c040;
-        }
-
-        .progress-header span {
-            font-weight: 600;
-        }
-
-        .progress-bar {
-            width: 100%;
-            height: 12px;
-            background: #333;
-            border-radius: 20px;
-            overflow: hidden;
-        }
-
-        .progress-fill {
-            height: 100%;
-            background: linear-gradient(90deg, #f0c040, #ffdf70);
-            border-radius: 20px;
-        }
-
-        .continue-learning {
-            background: linear-gradient(145deg, #1b1b1b, #242424);
-            border: 1px solid #333;
-            border-radius: 18px;
-            padding: 25px;
-            margin-bottom: 40px;
-        }
-
-        .continue-learning h2 {
-            color: #f0c040;
-            margin-top: 0;
-        }
-
-        .continue-learning p {
-            color: #bdbdbd;
-            margin-bottom: 0;
-        }
-
-        .category {
-            margin-bottom: 45px;
-        }
-
-        .category-header {
-            display: flex;
-            align-items: center;
-            gap: 12px;
-            margin-bottom: 20px;
-        }
-
-        .category-header h2 {
-            margin: 0;
-            color: #f0c040;
-            font-size: 1.8rem;
-        }
-
-        .lesson-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-            gap: 22px;
-        }
-
-        .lesson-card {
-            background: linear-gradient(145deg, #1c1c1c, #262626);
-            border: 1px solid #333;
-            border-radius: 18px;
-            padding: 20px;
-            min-height: 180px;
-
-            display: flex;
-            flex-direction: column;
-            justify-content: space-between;
-
-            transition: all 0.3s ease;
-        }
-
-        .lesson-card:hover {
-            transform: translateY(-8px) scale(1.02);
-            border-color: #f0c040;
-            box-shadow: 0 14px 30px rgba(240, 192, 64, 0.30);
-        }
-
-        .lesson-top {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-        }
-
-        .lesson-icon {
-            font-size: 28px;
-        }
-
-        .lesson-card h3 {
-            color: white;
-            font-size: 1.2rem;
-            margin: 18px 0;
-            line-height: 1.4;
-        }
-
-        .lesson-meta {
-            color: #bdbdbd;
-            font-size: 0.9rem;
-        }
-
-        .status {
-            padding: 6px 12px;
-            border-radius: 30px;
-            font-size: 12px;
-            font-weight: 600;
-        }
-
-        .pending {
-            background: #f0c040;
-            color: #121212;
-        }
-
-        .completed {
-            background: #22c55e;
-            color: white;
-        }
-
-        .category-badge {
-            display: inline-block;
-            padding: 8px 16px;
-            border-radius: 20px;
-            font-weight: 600;
-            color: white;
-            margin-bottom: 15px;
-        }
-
-        .beginner {
-            background: #16a34a;
-        }
-
-        .intermediate {
-            background: #f59e0b;
-        }
-
-        .advanced {
-            background: #dc2626;
-        }
-
-        .learning-stats {
-            margin-top: 15px;
-            display: flex;
-            gap: 12px;
-            flex-wrap: wrap;
-        }
-
-        .learning-stats span {
-            background: rgba(240,192,64,0.15);
-            color: #f0c040;
-            padding: 8px 14px;
-            border-radius: 20px;
-            font-weight: 600;
-        }
-
-        .lesson-count {
-            background: #2a2a2a;
-            color: #f0c040;
-            padding: 6px 12px;
-            border-radius: 20px;
-            font-size: 13px;
-            font-weight: 600;
-        }
-
-       .progress-text {
-            margin-top: 12px;
-            color: #bdbdbd;
-            font-size: 0.9rem;
-        }
-
-        @media (max-width: 768px) {
-
-            body {
-                padding: 15px;
-            }
-
-            .hero h1 {
-                font-size: 2rem;
-            }
-
-            .progress-header {
-                flex-direction: column;
-                align-items: flex-start;
-                gap: 10px;
-            }
-
-            .lesson-grid {
-                grid-template-columns: 1fr;
-            }
-        }
-
-        /* Light Theme Overrides */
-        [data-theme="light"] body {
-            background: #f5f7fb;
-            color: #111827;
-        }
-        [data-theme="light"] h1, [data-theme="light"] h2 {
-            color: #111827;
-        }
-        [data-theme="light"] p {
-            color: #4b5563;
-        }
-        [data-theme="light"] .progress-box, [data-theme="light"] .continue-learning, [data-theme="light"] .lesson-card {
-            background: #ffffff;
-            border: 1px solid #d1d5db;
-        }
-        [data-theme="light"] .progress-header span {
-            color: #4b5563;
-        }
-        [data-theme="light"] .progress-bar {
-            background: #e5e7eb;
-        }
-        [data-theme="light"] .progress-fill {
-            background: #f0c040;
-        }
-        [data-theme="light"] .learning-stats span {
-            background: #fef3c7;
-            color: #b47505;
-        }
-        [data-theme="light"] .lesson-card:hover {
-            border-color: #f0c040;
-            box-shadow: 0 4px 15px rgba(240, 192, 64, 0.1);
-        }
-        [data-theme="light"] .lesson-card h3 {
-            color: #111827;
-        }
-        [data-theme="light"] .lesson-meta, [data-theme="light"] .progress-text {
-            color: #6b7280;
-        }
-        [data-theme="light"] .lesson-count {
-            background: #e5e7eb;
-            color: #4b5563;
-        }
-        [data-theme="light"] a {
-            text-decoration: none;
-        }
-
-        .alert-banner {
-            background: linear-gradient(135deg, #2c1f00, #1b1300);
-            border: 1px solid #f0c040;
-            border-radius: 12px;
-            padding: 16px 20px;
-            margin-bottom: 30px;
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            gap: 12px;
-            box-shadow: 0 4px 20px rgba(240, 192, 64, 0.15);
-            animation: fadeIn 0.5s ease;
-        }
-
-        .alert-content {
-            display: flex;
-            align-items: center;
-            gap: 12px;
-        }
-
-        .alert-banner a.alert-link {
-            color: #f0c040;
-            text-decoration: underline;
-            font-weight: 600;
-            transition: color 0.2s ease;
-        }
-
-        .alert-banner a.alert-link:hover {
-            color: #ffdf70;
-        }
-
-        .alert-text {
-            font-size: 1rem;
-            color: #e0e0e0;
-            line-height: 1.5;
-        }
-
-        .alert-icon {
-            font-size: 1.25rem;
-        }
-
-        .alert-close {
-            background: transparent;
-            border: none;
-            color: #bdbdbd;
-            font-size: 1.5rem;
-            cursor: pointer;
-            padding: 0 4px;
-            line-height: 1;
-            transition: color 0.2s ease, transform 0.2s ease;
-        }
-
-        .alert-close:hover {
-            color: #ffffff;
-            transform: scale(1.1);
-        }
-
-        @keyframes fadeIn {
-            from { opacity: 0; transform: translateY(-10px); }
-            to { opacity: 1; transform: translateY(0); }
-        }
-    </style>
-    <script src="{% static 'game/js/theme.js' %}?v=1"></script>
-</head>
-
-<body>
-
-{% if not user.is_authenticated %}
-<div class="alert-banner" id="guest-alert">
-    <div class="alert-content">
-        <span class="alert-icon">💡</span>
-        <span class="alert-text">
-            <a href="{% url 'login' %}" class="alert-link">Sign in</a> or <a href="{% url 'register' %}" class="alert-link">create a free account</a> to save your lesson progress.
-        </span>
-    </div>
-    <button class="alert-close" type="button" onclick="dismissAlert()" aria-label="Close message">&times;</button>
-</div>
-{% endif %}
-
-<div class="hero">
-    <h1>♟ Chess Learning Hub</h1>
-    <p>Master chess from beginner to advanced lessons.</p>
+<div class="lessons-hero">
+  <h1>Chess Learning Hub</h1>
+  <p>Master chess from beginner to advanced lessons.</p>
 </div>
 
 <div class="progress-box">
-    <div class="progress-header">
-        <h2>Your Learning Progress</h2>
-        <span>{{ completed_count }}/{{ total_lessons }} Completed</span>
-    </div>
+  <div class="progress-header">
+    <h2>Your Learning Progress</h2>
+    <span>{{ completed_count }}/{{ total_lessons }} Completed</span>
+  </div>
 
+  <div
+    class="progress-bar"
+    role="progressbar"
+    aria-valuenow="{% widthratio completed_count total_lessons 100 %}"
+    aria-valuemin="0"
+    aria-valuemax="100"
+    aria-label="Lesson completion progress"
+  >
     <div
-        class="progress-bar"
-        role="progressbar"
-        aria-valuenow="{% widthratio completed_count total_lessons 100 %}"
-        aria-valuemin="0"
-        aria-valuemax="100"
-        aria-label="Lesson completion progress">
-        <div class="progress-fill" id="lesson-progress-fill" style="width: {% widthratio completed_count total_lessons 100 %}%;"></div>
-    </div>
+      class="progress-fill"
+      id="lesson-progress-fill"
+      style="width: {% widthratio completed_count total_lessons 100 %}%;"
+    ></div>
+  </div>
 
-    <p class="progress-text">
-        Keep going! Complete lessons to improve your chess skills.
-    </p>
+  <p class="progress-text">
+    Keep going! Complete lessons to improve your chess skills.
+  </p>
 </div>
 
 <div class="continue-learning">
-    <h2>▶ Continue Learning</h2>
-    <p>Track your progress and continue mastering chess lessons.</p>
+  <h2>
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <polygon points="6 4 20 12 6 20 6 4" />
+    </svg>
+    Continue Learning
+  </h2>
+  <p>Track your progress and continue mastering chess lessons.</p>
 
-    <div class="learning-stats">
-        <span>{{ completed_count }} Completed</span>
-        <span>{{ total_lessons }} Total Lessons</span>
-    </div>
+  <div class="learning-stats">
+    <span>{{ completed_count }} Completed</span>
+    <span>{{ total_lessons }} Total Lessons</span>
+  </div>
 </div>
 
 {% for category, lesson_list in lessons.items %}
 
 <div class="category">
+  <div class="category-header">
+    {% if category == "Beginner" %}
+    <span class="category-badge beginner">Beginner</span>
+    {% elif category == "Intermediate" %}
+    <span class="category-badge intermediate">Intermediate</span>
+    {% else %}
+    <span class="category-badge advanced">Advanced</span>
+    {% endif %}
 
-    <div class="category-header">
+    <span class="lesson-count"> {{ lesson_list|length }} Lessons </span>
+  </div>
 
-        {% if category == "Beginner" %}
-            <span class="category-badge beginner">Beginner</span>
-        {% elif category == "Intermediate" %}
-            <span class="category-badge intermediate">Intermediate</span>
-        {% else %}
-            <span class="category-badge advanced">Advanced</span>
-        {% endif %}
+  <div class="lesson-grid">
+    {% for lesson in lesson_list %}
 
-        <span class="lesson-count">
-            {{ lesson_list|length }} Lessons
-        </span>
+    <a href="{% url 'lesson_detail' lesson|slugify %}">
+      <div class="lesson-card">
+        <div class="lesson-top">
+          <div class="lesson-icon" aria-hidden="true">♜</div>
 
-    </div>
-  
-    <div class="lesson-grid">
+          {% if lesson in completed_lessons %}
+          <span class="status completed">
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="3"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+            Completed
+          </span>
+          {% else %}
+          <span class="status pending"> Start </span>
+          {% endif %}
+        </div>
 
-        {% for lesson in lesson_list %}
+        <h3>{{ lesson }}</h3>
 
-        <a href="{% url 'lesson_detail' lesson|slugify %}">
-           <div class="lesson-card">
+        <div class="lesson-meta">
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path
+              d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"
+            />
+          </svg>
+          Chess Lesson
+        </div>
+      </div>
+    </a>
 
-                <div class="lesson-top">
-
-                    <div class="lesson-icon" aria-hidden="true">
-                        ♜
-                    </div>
-
-                    {% if lesson in completed_lessons %}
-                        <span class="status completed">
-                            ✓ Completed
-                        </span>
-                    {% else %}
-                        <span class="status pending">
-                            Start
-                        </span>
-                    {% endif %}
-
-                </div>
-
-                <h3>{{ lesson }}</h3>
-
-                <div class="lesson-meta">
-                    <span aria-hidden="true">📚</span>
-                    Chess Lesson
-                </div>
-
-            </div>
-        </a>
-
-        {% endfor %}
-
-    </div>
-
+    {% endfor %}
+  </div>
 </div>
 
-{% endfor %}
-
-<script>
-    document.addEventListener('DOMContentLoaded', function() {
-        if (localStorage.getItem('lessons_guest_alert_dismissed') === 'true') {
-            var alert = document.getElementById('guest-alert');
-            if (alert) {
-                alert.style.display = 'none';
-            }
-        }
-    });
-
-    function dismissAlert() {
-        var alert = document.getElementById('guest-alert');
-        if (alert) {
-            alert.style.transition = 'opacity 0.3s ease, transform 0.3s ease';
-            alert.style.opacity = '0';
-            alert.style.transform = 'translateY(-10px)';
-            localStorage.setItem('lessons_guest_alert_dismissed', 'true');
-            setTimeout(function() {
-                alert.style.display = 'none';
-            }, 300);
-        }
-    }
-</script>
-</body>
-</html>
+{% endfor %} {% endblock %}

--- a/game/templates/partials/back_to_top.html
+++ b/game/templates/partials/back_to_top.html
@@ -1,0 +1,23 @@
+<!-- ══════════════════════════════════════════════════════════════
+     Shared Back-to-Top Partial
+     Included via base.html
+     ══════════════════════════════════════════════════════════════ -->
+<div id="backToTopWrapper">
+  <span id="backToTopTooltip">Back to Top</span>
+  <button type="button" id="backToTopBtn" aria-label="Back to top" onclick="window.scrollTo({top:0,behavior:'smooth'})">
+    <svg class="btn-arrow" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <line x1="12" y1="19" x2="12" y2="5"></line>
+      <polyline points="5 12 12 5 19 12"></polyline>
+    </svg>
+  </button>
+</div>
+
+<script>
+  (function () {
+    const backToTopWrapper = document.getElementById('backToTopWrapper');
+    if (!backToTopWrapper) return;
+    window.addEventListener('scroll', () => {
+      backToTopWrapper.classList.toggle('visible', window.scrollY > 300);
+    }, { passive: true });
+  })();
+</script>

--- a/game/templates/partials/cursor_widget.html
+++ b/game/templates/partials/cursor_widget.html
@@ -1,0 +1,141 @@
+<!-- ══════════════════════════════════════════════════════════════
+     Shared Cursor Widget Partial
+     Pairs with the "Cursor: ..." dropdown in partials/navbar.html.
+     Include once per page, after navbar.html:
+       {% include "partials/cursor_widget.html" %}
+     ══════════════════════════════════════════════════════════════ -->
+<div class="cursor"></div>
+
+<script>
+  /* Animated Cursor System
+     - Core Architecture: JS-driven translate3d() (anchored 0,0) handles mouse tracking.
+       Pseudo-elements (::before/::after) host all animations to prevent transform
+       conflicts with the JS-set position. GPU-accelerated; display: none by default.
+       Z-index < 9999 ensures dropdown/click-through interactivity.
+     - Variant Implementation: Default / Glow / Trail / Sparkle / Orbit / Chess (pawn glyph). */
+  if (window.__checkoraCursorInited) {
+    // Already initialized on this page; do nothing.
+  } else {
+    window.__checkoraCursorInited = true;
+
+    const cursor = document.querySelector('.cursor');
+    const cursorDropdown = document.querySelector('.cursor-dropdown');
+    const cursorTrigger = document.getElementById('cursorTypeTrigger');
+    const cursorTypeLabel = document.getElementById('cursorTypeLabel');
+    const cursorOptions = document.querySelectorAll('.cursor-type-option');
+    const CURSOR_STORAGE_KEY = 'checkora:cursor-type';
+    const VALID_CURSOR_TYPES = ['default', 'glow', 'trail', 'sparkle', 'orbit', 'chess'];
+
+    const prefersReducedMotion = window.matchMedia &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const isTouchDevice = window.matchMedia &&
+      window.matchMedia('(pointer: coarse)').matches;
+
+    let activeCursor = 'default';
+    let mouseX = 0;
+    let mouseY = 0;
+    let rafRunning = false;
+
+    const CURSOR_OFFSETS = {
+      default: 8,
+      glow: 9,
+      trail: 6,
+      sparkle: 8,
+      orbit: 20,
+      chess: 12
+    };
+    let cursorOffset = CURSOR_OFFSETS.default;
+    function updateCursorPosition() {
+      cursor.style.transform =
+        'translate3d(' + (mouseX - cursorOffset) + 'px, ' + (mouseY - cursorOffset) + 'px, 0)';
+      rafRunning = false;
+    }
+
+    document.addEventListener('mousemove', e => {
+      mouseX = e.clientX;
+      mouseY = e.clientY;
+      if (!rafRunning && activeCursor !== 'default') {
+        rafRunning = true;
+        requestAnimationFrame(updateCursorPosition);
+      }
+    }, { passive: true });
+
+    function safeGetStoredType() {
+      try {
+        const v = window.localStorage.getItem(CURSOR_STORAGE_KEY);
+        return VALID_CURSOR_TYPES.indexOf(v) >= 0 ? v : 'default';
+      } catch (e) { return 'default'; }
+    }
+    function safeSetStoredType(type) {
+      try { window.localStorage.setItem(CURSOR_STORAGE_KEY, type); } catch (e) { /* ignore */ }
+    }
+
+    function updateCursorType(type, persist) {
+      if (VALID_CURSOR_TYPES.indexOf(type) < 0) type = 'default';
+      if ((isTouchDevice || prefersReducedMotion) && type !== 'default') type = 'default';
+
+      activeCursor = type;
+      cursor.className = 'cursor';
+
+      if (type !== 'default') {
+        cursor.classList.add(type);
+        cursor.style.opacity = '0.98';
+        cursor.style.display = type === 'chess' ? 'flex' : 'block';
+      } else {
+        cursor.style.opacity = '0';
+        cursor.style.display = 'none';
+      }
+
+      cursorTypeLabel.textContent =
+        type.charAt(0).toUpperCase() + type.slice(1);
+      document.body.classList.toggle('hide-native-cursor', type !== 'default');
+      cursorOptions.forEach(option => {
+        option.classList.toggle('selected', option.dataset.cursor === type);
+      });
+
+      if (type !== 'default' && !rafRunning) {
+        rafRunning = true;
+        requestAnimationFrame(updateCursorPosition);
+      }
+
+      if (persist) safeSetStoredType(type);
+    }
+
+    if (!isTouchDevice) {
+      const initialType = prefersReducedMotion ? 'default' : safeGetStoredType();
+      updateCursorType(initialType, false);
+    }
+
+    function closeCursorDropdown() {
+      cursorDropdown.classList.remove('active');
+      cursorTrigger.setAttribute('aria-expanded', 'false');
+    }
+    cursorTrigger.addEventListener('click', e => {
+      e.stopPropagation();
+      cursorDropdown.classList.toggle('active');
+      const expanded = cursorDropdown.classList.contains('active');
+      cursorTrigger.setAttribute('aria-expanded', expanded);
+    });
+
+    cursorOptions.forEach(option => {
+      option.addEventListener('click', () => {
+        updateCursorType(option.dataset.cursor, true);
+        closeCursorDropdown();
+      });
+    });
+
+    document.addEventListener('click', e => {
+      if (!cursorDropdown.contains(e.target)) {
+        closeCursorDropdown();
+      }
+    });
+
+    document.addEventListener('keydown', e => {
+      if (e.key === 'Escape') {
+        closeCursorDropdown();
+      }
+    });
+
+    window.addEventListener('scroll', closeCursorDropdown, { passive: true });
+  }
+</script>

--- a/game/templates/partials/footer.html
+++ b/game/templates/partials/footer.html
@@ -1,0 +1,400 @@
+{% load static %}
+<!-- ══════════════════════════════════════════════════════════════
+     Shared Footer Partial (footer nav + legal modals + their JS)
+     Included via base.html
+     Requires: theme.css + landing.css loaded in the page <head>.
+     ══════════════════════════════════════════════════════════════ -->
+<footer class="footer">
+  <div class="footer-container">
+    <div class="footer-col brand-column">
+      <a href="{% url 'landing' %}" class="logo-link">
+        <img
+          src="{% static 'game/checkora_icon_only.png' %}"
+          alt="Checkora Logo"
+          class="logo-img"
+        />
+        <span class="logo-text">CHECK<span class="logo-accent">ORA</span></span>
+      </a>
+      <p class="brand-desc">
+        Experience high-performance chess with Checkora's hybrid C++ engine.
+        Challenge the AI, track your stats, and master the board.
+      </p>
+    </div>
+
+    <div class="footer-col">
+      <h4>Platform</h4>
+      <ul class="footer-nav-list">
+        <li><a href="{% url 'index' %}" class="footer-link">Play Game</a></li>
+        <li><a href="{% url 'leaderboard' %}" class="footer-link">Leaderboard</a></li>
+        <li><a href="{% url 'achievements' %}" class="footer-link">Achievements</a></li>
+        <li><a href="{% url 'stats' %}" class="footer-link">Statistics</a></li>
+        <li><a href="{% url 'rules' %}" class="footer-link">Rulebook</a></li>
+        <li><a href="{% url 'lessons' %}" class="footer-link">Lessons</a></li>
+        <li><a href="{% url 'puzzles' %}" class="footer-link">Puzzles</a></li>
+      </ul>
+    </div>
+
+    <div class="footer-col">
+      <h4>Community</h4>
+      <ul class="footer-nav-list">
+        <li>
+          <a href="https://github.com/Checkora" target="_blank" rel="noopener noreferrer" class="footer-link">
+            GitHub Organization
+          </a>
+        </li>
+        <li>
+          <a href="https://discord.gg/WfrpMuNZn" target="_blank" rel="noopener noreferrer" class="footer-link">
+            Discord Community
+          </a>
+        </li>
+        <li class="maintainer-item">
+          <span class="footer-meta-text">
+            Maintainers:
+            <a href="https://github.com/triemerge" target="_blank" rel="noopener noreferrer">@triemerge</a> &amp;
+            <a href="https://github.com/EDWARD-012" target="_blank" rel="noopener noreferrer">@EDWARD-012</a>
+          </span>
+        </li>
+      </ul>
+    </div>
+
+    <div class="footer-col">
+      <h4>Legal</h4>
+      <ul class="footer-nav-list">
+        <li><a href="#" class="footer-link" data-modal-trigger="privacyModal">Privacy Policy</a></li>
+        <li><a href="#" class="footer-link" onclick="openTermsModal(); return false;">Terms &amp; Conditions</a></li>
+        <li><a href="#" class="footer-link" onclick="openDisclaimerModal(); return false;">Disclaimer</a></li>
+        <li><a href="#" class="footer-link" onclick="openContactModal(); return false;">Contact Us</a></li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="footer-bottom">
+    <span class="footer-copy">
+      &copy; {% now "Y" %} Checkora Hybrid Engine. All rights reserved.
+    </span>
+    <div class="footer-socials">
+      <a href="https://github.com/Checkora" target="_blank" rel="noopener noreferrer" aria-label="Checkora GitHub organization">
+        <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" fill="currentColor"/>
+        </svg>
+      </a>
+      <a href="https://discord.gg/WfrpMuNZn" target="_blank" rel="noopener noreferrer" aria-label="Checkora Discord community">
+        <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M19.27 5.33C17.94 4.71 16.5 4.26 15 4a.09.09 0 0 0-.07.03c-.18.33-.39.76-.53 1.09a16.09 16.09 0 0 0-4.8 0c-.14-.34-.35-.76-.54-1.09c-.01-.02-.04-.03-.07-.03c-1.5.26-2.93.71-4.27 1.33c-.01 0-.02.01-.03.02c-2.72 4.07-3.47 8.03-3.1 11.95c0 .02.02.04.03.05c1.8 1.32 3.53 2.12 5.24 2.65c.03.01.06 0 .07-.02c.4-.55.76-1.13 1.07-1.74c.02-.04 0-.08-.04-.09c-.57-.22-1.11-.48-1.64-.78c-.04-.02-.04-.08-.01-.11c.11-.08.22-.17.33-.25c.02-.02.05-.02.07-.01c3.44 1.57 7.15 1.57 10.55 0c.02-.01.05-.01.07.01c.11.09.22.17.33.26c.04.03.04.09-.01.11c-.52.31-1.07.56-1.64.78c-.04.01-.05.06-.04.09c.32.61.68 1.19 1.07 1.74c.03.01.06 0 .09.01c1.72-.53 3.45-1.33 5.25-2.65c.02-.01.03-.03.03-.05.44-4.53-.73-8.46-3.1-11.95c-.01-.01-.02-.02-.04-.02zM8.52 14.91c-1.03 0-1.89-.95-1.89-2.12s.84-2.12 1.89-2.12c1.06 0 1.9.96 1.89 2.12c0 1.17-.84 2.12-1.89 2.12zm6.97 0c-1.03 0-1.89-.95-1.89-2.12s.84-2.12 1.89-2.12c1.06 0 1.9.96 1.89 2.12c0 1.17-.83 2.12-1.89 2.12z" fill="currentColor"/>
+        </svg>
+      </a>
+    </div>
+  </div>
+</footer>
+
+<!-- ── Legal Modals (Privacy / Terms / Contact / Disclaimer) ── -->
+<div id="privacyModal" role="dialog" aria-modal="true" aria-labelledby="privacyModalTitle" class="legal-modal">
+  <div tabindex="-1" class="legal-modal-inner">
+    <div class="legal-modal-header">
+      <h1 id="privacyModalTitle" class="legal-modal-title">Privacy Policy</h1>
+      <button type="button" aria-label="Close privacy policy" onclick="closePrivacyModal()" class="legal-modal-close">✕</button>
+    </div>
+    <div class="modal-scroll-content legal-modal-body">
+      <div class="legal-modal-sections">
+        <div class="legal-modal-section">
+          <span class="legal-modal-badge">1</span>
+          <div>
+            <h2>Information We Collect</h2>
+            <p>Checkora only collects basic information necessary to manage user authentication and orchestrate your chess matches:</p>
+            <ul>
+              <li><strong>Account Data:</strong> Username, email address, and encrypted password profiles when you register.</li>
+              <li><strong>Gameplay Metrics:</strong> Move history, win/loss stats, match durations, and time preferences for leaderboard rankings.</li>
+              <li><strong>Technical Logs:</strong> Minimal session tokens to keep you securely logged in across page reloads.</li>
+            </ul>
+          </div>
+        </div>
+        <div class="legal-modal-section">
+          <span class="legal-modal-badge">2</span>
+          <div>
+            <h2>How Your Data is Used</h2>
+            <p>Your data remains dedicated exclusively to powering your active application experiences:</p>
+            <ul>
+              <li>Maintain your personalized player profile dashboard and performance metrics.</li>
+              <li>Calculate real-time material scores and process live move-validation checks.</li>
+              <li>Optimize the sync pipeline between backend systems and computation services.</li>
+            </ul>
+          </div>
+        </div>
+        <div class="legal-modal-section">
+          <span class="legal-modal-badge">3</span>
+          <div>
+            <h2>Cookies and Session Storage</h2>
+            <p>We use essential cookies and local storage tokens to manage authentication states and secure form submissions against CSRF. No tracking cookies or behavioral profile monitors are embedded inside the platform.</p>
+          </div>
+        </div>
+        <div class="legal-modal-section">
+          <span class="legal-modal-badge">4</span>
+          <div>
+            <h2>Data Retention &amp; Security</h2>
+            <p>We retain your profile credentials and match logs for as long as your account remains active. Passwords are securely stored using Django authentication hashing mechanisms.</p>
+          </div>
+        </div>
+        <div class="legal-modal-section">
+          <span class="legal-modal-badge">5</span>
+          <div>
+            <h2>Open Source Transparency &amp; User Rights</h2>
+            <p>In alignment with our open-source framework and GSSoC community policies, users maintain full authority over their data and may request account deletion or data removal at any time.</p>
+          </div>
+        </div>
+        <div class="legal-modal-section">
+          <span class="legal-modal-badge">6</span>
+          <div>
+            <h2>Contact &amp; Community Channels</h2>
+            <p>If you have questions or feedback regarding this Privacy Policy, please open an issue on our GitHub repository or contact the project maintainers directly.</p>
+          </div>
+        </div>
+        <p class="legal-modal-updated">Last updated: May 2026</p>
+      </div>
+    </div>
+    <div class="legal-modal-footer">
+      <button type="button" aria-label="Close privacy policy" onclick="closePrivacyModal()" class="legal-modal-agree">I Agree</button>
+    </div>
+  </div>
+</div>
+
+<div id="termsModal" role="dialog" aria-modal="true" aria-labelledby="termsModalTitle" class="legal-modal">
+  <div tabindex="-1" class="legal-modal-inner">
+    <div class="legal-modal-header">
+      <h1 id="termsModalTitle" class="legal-modal-title">Terms and Conditions</h1>
+      <button type="button" aria-label="Close terms and conditions" onclick="closeTermsModal()" class="legal-modal-close">✕</button>
+    </div>
+    <div class="modal-scroll-content legal-modal-body">
+      <div class="legal-modal-sections">
+        <div class="legal-modal-section">
+          <span class="legal-modal-badge">1</span>
+          <div>
+            <h2>Acceptance of Terms</h2>
+            <p>By accessing, registering for, or interacting with the Checkora Chess Platform, you agree to comply with and be bound by these Terms and Conditions. If you do not accept these parameters, you are advised to discontinue platform interaction.</p>
+          </div>
+        </div>
+        <div class="legal-modal-section">
+          <span class="legal-modal-badge">2</span>
+          <div>
+            <h2>Fair Play and Anti-Cheat Policy</h2>
+            <p>Checkora runs a native high-performance C++ minimax engine designed to provide competitive gameplay. To safeguard integrity:</p>
+            <ul>
+              <li>Use of third-party engine assistance, browser modifications, or state-manipulation scripts is strictly prohibited.</li>
+              <li>Intentionally stalling game clocks or throwing matches to manipulate metrics violates our guidelines.</li>
+            </ul>
+          </div>
+        </div>
+        <div class="legal-modal-section">
+          <span class="legal-modal-badge">3</span>
+          <div>
+            <h2>Account Management and Security</h2>
+            <p>When creating profile credentials and completing OTP verification, you are fully accountable for preserving credential confidentiality. Checkora reserves authority to clean up idle ghost accounts that remain abandoned to free system namespaces.</p>
+          </div>
+        </div>
+        <div class="legal-modal-section">
+          <span class="legal-modal-badge">4</span>
+          <div>
+            <h2>Open Source and Modifications</h2>
+            <p>Checkora operates openly under the MIT License. While customization of backend logic modules is encouraged for developer variants, users are requested to interact fairly and maintain the software's style parameters.</p>
+          </div>
+        </div>
+        <div class="legal-modal-section">
+          <span class="legal-modal-badge">5</span>
+          <div>
+            <h2>Disclaimer of Liability</h2>
+            <p>The platform services and integrated AI engines are offered on an "as-is" operational basis. The maintenance team assumes no liability for match state disruptions, profile cache rollbacks during server updates, or local dependency failures in client-side setups.</p>
+          </div>
+        </div>
+        <p class="legal-modal-updated">Last updated: May 2026</p>
+      </div>
+    </div>
+    <div class="legal-modal-footer">
+      <button type="button" onclick="closeTermsModal()" class="legal-modal-agree">I Agree</button>
+    </div>
+  </div>
+</div>
+
+<div id="contactModal" role="dialog" aria-modal="true" aria-labelledby="contactModalTitle" class="legal-modal">
+  <div tabindex="-1" class="legal-modal-inner">
+    <div class="legal-modal-header">
+      <h1 id="contactModalTitle" class="legal-modal-title">Contact Us</h1>
+      <button type="button" aria-label="Close contact form" onclick="closeContactModal()" class="legal-modal-close">✕</button>
+    </div>
+    <div class="modal-scroll-content legal-modal-body">
+      <p class="contact-modal-intro">Have questions about the C++ platform integration or found a glitch? Reach out to the maintainers.</p>
+      <div class="contact-modal-grid">
+        <div class="contact-modal-info">
+          <div>
+            <h3>Community Support</h3>
+            <p>For instant technical coordination, join our active development spaces on the <a href="https://discord.gg/WfrpMuNZn" target="_blank" rel="noopener noreferrer">Discord Server</a>.</p>
+          </div>
+          <div>
+            <h3>Open Source &amp; Bugs</h3>
+            <p>Found a bug? Open a thread on our <a href="https://github.com/Checkora" target="_blank" rel="noopener noreferrer">GitHub Issue Tracker</a>.</p>
+          </div>
+          <div>
+            <h3>Maintainer Reach</h3>
+            <p>Email: <a href="mailto:support@checkora.example.com">support@checkora.example.com</a></p>
+          </div>
+        </div>
+
+        <form id="contactForm" class="contact-modal-form" onsubmit="handleContactSubmit(event)">
+          {% csrf_token %}
+          <div class="contact-modal-field">
+            <label for="contact-name">Name</label>
+            <input type="text" id="contact-name" name="name" placeholder="Your name" required />
+          </div>
+          <div class="contact-modal-field">
+            <label for="contact-email">Email Address</label>
+            <input type="email" id="contact-email" name="email" placeholder="username@example.com" required />
+          </div>
+          <div class="contact-modal-field">
+            <label for="contact-message">Message</label>
+            <textarea id="contact-message" name="message" placeholder="Type your query regarding engine or interface states..." required rows="5"></textarea>
+          </div>
+          <button type="submit" class="contact-modal-submit">Send Message</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="disclaimerModal" role="dialog" aria-modal="true" aria-labelledby="disclaimerModalTitle" class="legal-modal">
+  <div tabindex="-1" class="legal-modal-inner">
+    <div class="legal-modal-header">
+      <h1 id="disclaimerModalTitle" class="legal-modal-title">Disclaimer</h1>
+      <button type="button" aria-label="Close disclaimer" onclick="closeDisclaimerModal()" class="legal-modal-close">✕</button>
+    </div>
+    <div class="modal-scroll-content legal-modal-body">
+      <div class="legal-modal-sections">
+        <div class="legal-modal-section">
+          <span class="legal-modal-badge">1</span>
+          <div>
+            <h2>General Information</h2>
+            <p>The information, services, and structural match simulation environments provided on the Checkora chess platform are intended solely for general informational, educational, and recreational entertainment purposes.</p>
+            <p>All modules are interactive and provided on an "as-is" and "as-available" execution model without absolute performance assertions of any kind.</p>
+          </div>
+        </div>
+        <div class="legal-modal-section">
+          <span class="legal-modal-badge">2</span>
+          <div>
+            <h2>Limitation of Liability</h2>
+            <p>To the fullest extent permitted by applicable law, Checkora, its core architects, and open-source contribution members shall assume no accountability for any direct, indirect, accidental, or consequential operational data disruptions.</p>
+            <ul>
+              <li>Server connection synchronization issues.</li>
+              <li>Temporary match-state profile resets.</li>
+              <li>Algorithmic parsing variances.</li>
+              <li>System downtime occurrences.</li>
+            </ul>
+          </div>
+        </div>
+        <div class="legal-modal-section">
+          <span class="legal-modal-badge">3</span>
+          <div>
+            <h2>Accuracy of Information</h2>
+            <p>While our platform utilizes a custom C++ Minimax engine alongside Python web orchestration, we make no absolute guarantees regarding analytical precision.</p>
+            <ul>
+              <li>Position evaluations are algorithmic estimates.</li>
+              <li>Material calculations may vary.</li>
+              <li>Strategic suggestions are not official chess arbitration metrics.</li>
+            </ul>
+          </div>
+        </div>
+        <div class="legal-modal-section">
+          <span class="legal-modal-badge">4</span>
+          <div>
+            <h2>External Links</h2>
+            <p>Checkora may reference external resources and community platforms.</p>
+            <ul>
+              <li>GitHub repositories.</li>
+              <li>Discord community servers.</li>
+              <li>Official chess federation resources.</li>
+            </ul>
+            <p>We do not control or guarantee the content, policies, or privacy practices of third-party services.</p>
+          </div>
+        </div>
+        <div class="legal-modal-section">
+          <span class="legal-modal-badge">5</span>
+          <div>
+            <h2>User Responsibility Statement</h2>
+            <p>By using Checkora, you acknowledge responsibility for maintaining fair and secure usage of the platform.</p>
+            <ul>
+              <li>Maintain secure account credentials.</li>
+              <li>Follow fair-play policies.</li>
+              <li>Ensure client-side system reliability.</li>
+              <li>Accept timer synchronization limitations inherent to online systems.</li>
+            </ul>
+          </div>
+        </div>
+        <p class="legal-modal-updated">Last updated: June 2026</p>
+      </div>
+    </div>
+    <div class="legal-modal-footer">
+      <button type="button" onclick="closeDisclaimerModal()" class="legal-modal-agree">I Understand</button>
+    </div>
+  </div>
+</div>
+
+<script>
+(function () {
+  function wireModal(modalId, openFnName, closeFnName) {
+    const modal = document.getElementById(modalId);
+    if (!modal) return;
+    const modalInner = modal.querySelector('[tabindex="-1"]');
+    let lastFocused;
+
+    window[openFnName] = function (e) {
+      lastFocused = e ? e.target : document.activeElement;
+      modal.style.display = 'flex';
+      if (modalInner) modalInner.focus();
+    };
+
+    window[closeFnName] = function () {
+      modal.style.display = 'none';
+      if (lastFocused) lastFocused.focus();
+    };
+
+    modal.addEventListener('click', function (e) {
+      if (e.target === modal) window[closeFnName]();
+    });
+
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && modal.style.display === 'flex') window[closeFnName]();
+    });
+
+    modal.addEventListener('keydown', function (e) {
+      if (e.key !== 'Tab') return;
+      const focusable = modal.querySelectorAll('button, input, textarea, [href], [tabindex]:not([tabindex="-1"])');
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault(); last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault(); first.focus();
+      }
+    });
+  }
+
+  wireModal('privacyModal', 'openPrivacyModal', 'closePrivacyModal');
+  wireModal('termsModal', 'openTermsModal', 'closeTermsModal');
+  wireModal('disclaimerModal', 'openDisclaimerModal', 'closeDisclaimerModal');
+  wireModal('contactModal', 'openContactModal', 'closeContactModal');
+
+  document.addEventListener('DOMContentLoaded', function () {
+    const trigger = document.querySelector('[data-modal-trigger="privacyModal"]');
+    if (trigger) {
+      trigger.addEventListener('click', function (e) {
+        e.preventDefault();
+        window.openPrivacyModal(e);
+      });
+    }
+  });
+
+  window.handleContactSubmit = function (e) {
+    e.preventDefault();
+    alert('Message logged locally inside development environment container loop.');
+    if (window.closeContactModal) window.closeContactModal();
+    const form = document.getElementById('contactForm');
+    if (form) form.reset();
+  };
+})();
+</script>

--- a/game/templates/partials/guest_alert.html
+++ b/game/templates/partials/guest_alert.html
@@ -1,0 +1,45 @@
+<!-- ══════════════════════════════════════════════════════════════
+     Shared Guest Alert Banner Partial
+     Shown to signed-out users on lesson pages so progress isn't lost.
+     Included where needed on lesson pages
+     Requires the .alert-banner rules in lessons-shared.css.
+     ══════════════════════════════════════════════════════════════ -->
+{% if not user.is_authenticated %}
+<div class="alert-banner" id="guest-alert">
+  <div class="alert-content">
+    <span class="alert-icon" aria-hidden="true">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M9 18h6"/>
+        <path d="M10 22h4"/>
+        <path d="M12 2a7 7 0 0 0-4 12.7V17a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1v-2.3A7 7 0 0 0 12 2z"/>
+      </svg>
+    </span>
+    <span class="alert-text">
+      <a href="{% url 'login' %}" class="alert-link">Sign in</a> or <a href="{% url 'register' %}" class="alert-link">create a free account</a> to save your lesson progress.
+    </span>
+  </div>
+  <button class="alert-close" type="button" onclick="dismissAlert()" aria-label="Close message">&times;</button>
+</div>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    if (localStorage.getItem('lessons_guest_alert_dismissed') === 'true') {
+      var alertEl = document.getElementById('guest-alert');
+      if (alertEl) alertEl.style.display = 'none';
+    }
+  });
+
+  function dismissAlert() {
+    var alertEl = document.getElementById('guest-alert');
+    if (alertEl) {
+      alertEl.style.transition = 'opacity 0.3s ease, transform 0.3s ease';
+      alertEl.style.opacity = '0';
+      alertEl.style.transform = 'translateY(-10px)';
+      localStorage.setItem('lessons_guest_alert_dismissed', 'true');
+      setTimeout(function () {
+        alertEl.style.display = 'none';
+      }, 300);
+    }
+  }
+</script>
+{% endif %}

--- a/game/templates/partials/navbar.html
+++ b/game/templates/partials/navbar.html
@@ -1,0 +1,91 @@
+{% load static %}
+<!-- ══════════════════════════════════════════════════════════════
+     Shared Navbar Partial
+     Included via base.html
+     Requires: theme.css + landing.css loaded in the page <head>,
+     and game/js/dropdown.js + game/js/theme.js loaded before </body>.
+     ══════════════════════════════════════════════════════════════ -->
+<nav class="navbar">
+  <div class="nav-left">
+    <a href="{% url 'landing' %}" class="logo-link">
+      <img
+        src="{% static 'game/checkora_icon_only.png' %}"
+        alt="Checkora Logo"
+        class="logo-img"
+      />
+      <span class="logo-text"
+        >CHECK<span class="logo-accent">ORA</span></span
+      >
+    </a>
+    <div class="nav-links">
+      <a href="{% url 'landing' %}#about">About Us</a>
+      <a href="{% url 'landing' %}#features">Features</a>
+      <a href="{% url 'landing' %}#faq">FAQ</a>
+      <a href="{% url 'forum' %}">Forum</a>
+    </div>
+  </div>
+  <div class="nav-right">
+    <button type="button" id="themeToggle" class="theme-toggle" aria-label="Toggle light/dark theme">
+      <svg class="theme-icon-dark" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+      </svg>
+    </button>
+    <div class="cursor-dropdown custom-dropdown">
+      <button type="button" id="cursorTypeTrigger" class="cursor-btn" aria-haspopup="true" aria-expanded="false">
+        Cursor: <span id="cursorTypeLabel">Default</span>
+        <svg viewBox="0 0 24 24" class="cursor-dropdown-arrow" aria-hidden="true"><path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+      </button>
+      <div class="dropdown-content" role="menu" aria-label="Cursor type selector">
+        <button type="button" class="dropdown-item cursor-type-option selected" data-cursor="default">Default</button>
+        <button type="button" class="dropdown-item cursor-type-option" data-cursor="glow">Glow</button>
+        <button type="button" class="dropdown-item cursor-type-option" data-cursor="trail">Trail</button>
+        <button type="button" class="dropdown-item cursor-type-option" data-cursor="sparkle">Sparkle</button>
+        <button type="button" class="dropdown-item cursor-type-option" data-cursor="orbit">Orbit</button>
+        <button type="button" class="dropdown-item cursor-type-option" data-cursor="chess">Chess</button>
+      </div>
+    </div>
+    {% if user.is_authenticated %}
+    <div class="profile-dropdown">
+      <button type="button" class="profile-btn" style="display:flex;align-items:center;gap:4px;">
+        {% if user.profile.avatar %}
+          <img src="{{ user.profile.avatar }}" class="nav-avatar" alt="">
+        {% else %}
+          <span class="nav-avatar-icon" aria-hidden="true">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+          </span>
+        {% endif %}
+        {{ user.username }}
+        <svg class="profile-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 9l6 6 6-6"></path></svg>
+      </button>
+      <div class="dropdown-content">
+        <a href="{% url 'profile' %}">Profile</a>
+        <a href="/play/">Dashboard</a>
+        <a href="{% url 'opening_trainer' %}">Opening Trainer</a>
+        <a href="/stats/">Stats</a>
+        <a href="{% url 'puzzles' %}">Puzzles</a>
+        <a href="{% url 'leaderboard' %}">Leaderboard</a>
+        <a href="{% url 'achievements' %}">Achievements</a>
+        <a href="{% url 'upload_avatar' %}">Profile Picture</a>
+        <a href="{% url 'delete_account' %}" class="delete-option">Delete Account</a>
+        <form method="post" action="{% url 'logout' %}" style="margin:0;">
+          {% csrf_token %}
+          <button type="submit" class="logout-option">Logout</button>
+        </form>
+      </div>
+    </div>
+    {% else %}
+    <a href="{% url 'login' %}" class="btn-signin">Sign In</a>
+    <a href="{% url 'register' %}" class="btn-register">Register</a>
+    {% endif %}
+  </div>
+</nav>
+
+<script>
+  document.addEventListener('click', function (e) {
+    document.querySelectorAll('.profile-dropdown.active').forEach(function (menu) {
+      if (!menu.contains(e.target)) {
+        menu.classList.remove('active');
+      }
+    });
+  });
+</script>

--- a/game/templates/partials/stortcuts_modal.html
+++ b/game/templates/partials/stortcuts_modal.html
@@ -1,0 +1,159 @@
+{% load static %}
+<!-- ══════════════════════════════════════════════════════════════
+     Shared Keyboard Shortcuts Modal Partial
+     Included via base.html
+     Site-wide: Shift+/ opens it from any page; g+h/g+p/g+l/g+s navigate
+     regardless of which page you're currently on.
+     ══════════════════════════════════════════════════════════════ -->
+<div
+  id="shortcutsModal"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="shortcutsTitle"
+  style="
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.85);
+    z-index: 99999;
+    align-items: center;
+    justify-content: center;
+  "
+>
+  <div
+    style="
+      background: #131522;
+      color: white;
+      padding: 24px;
+      border-radius: 16px;
+      width: 90%;
+      max-width: 600px;
+      border: 1px solid rgba(240, 192, 64, 0.3);
+    "
+  >
+    <div
+      style="
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 20px;
+      "
+    >
+      <h2 id="shortcutsTitle" style="color: var(--accent-gold)">
+        Keyboard Shortcuts
+      </h2>
+      <button
+        type="button"
+        aria-label="Close keyboard shortcuts dialog"
+        title="Close"
+        onclick="closeShortcutsModal()"
+        style="
+          background: none;
+          border: none;
+          color: white;
+          font-size: 22px;
+          cursor: pointer;
+        "
+      >
+        ✕
+      </button>
+    </div>
+
+    <table style="width: 100%">
+      <tr>
+        <td><strong>Shift + /</strong></td>
+        <td>Open shortcuts help</td>
+      </tr>
+      <tr>
+        <td><strong>Esc</strong></td>
+        <td>Close modal</td>
+      </tr>
+      <tr>
+        <td><strong>g + h</strong></td>
+        <td>Go to Home</td>
+      </tr>
+      <tr>
+        <td><strong>g + p</strong></td>
+        <td>Play Game</td>
+      </tr>
+      <tr>
+        <td><strong>g + l</strong></td>
+        <td>Leaderboard</td>
+      </tr>
+      <tr>
+        <td><strong>g + s</strong></td>
+        <td>Lessons</td>
+      </tr>
+    </table>
+  </div>
+</div>
+
+<script>
+  (function () {
+    let gPressed = false;
+    const modal = document.getElementById("shortcutsModal");
+    if (!modal) return;
+
+    window.openShortcutsModal = function () {
+      modal.style.display = "flex";
+    };
+
+    window.closeShortcutsModal = function () {
+      modal.style.display = "none";
+    };
+
+    document.addEventListener("keydown", function (e) {
+      const tag = document.activeElement.tagName;
+      if (
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        tag === "SELECT" ||
+        document.activeElement.isContentEditable
+      ) {
+        return;
+      }
+
+      if (e.shiftKey && e.key === "?") {
+        e.preventDefault();
+        openShortcutsModal();
+        return;
+      }
+
+      if (e.key === "Escape") {
+        closeShortcutsModal();
+        return;
+      }
+
+      if (e.key.toLowerCase() === "g") {
+        gPressed = true;
+        setTimeout(() => {
+          gPressed = false;
+        }, 1000);
+        return;
+      }
+
+      if (modal.style.display === "flex") return;
+      if (!gPressed) return;
+
+      switch (e.key.toLowerCase()) {
+        case "h":
+          window.location.href = "{% url 'landing' %}";
+          break;
+        case "p":
+          window.location.href = "{% url 'index' %}";
+          break;
+        case "l":
+          window.location.href = "{% url 'leaderboard' %}";
+          break;
+        case "s":
+          window.location.href = "{% url 'lessons' %}";
+          break;
+      }
+      gPressed = false;
+    });
+
+    modal.addEventListener("click", function (e) {
+      if (e.target === modal) closeShortcutsModal();
+    });
+  })();
+</script>


### PR DESCRIPTION
## Description
Unifies all lesson-related pages (`lessons.html`, `lessons_roadmap.html`, `lesson_detail.html`) with the landing page under a shared `base.html` Django template, navbar, and footer. Previously these pages had no navbar/footer, no theme toggle, hand-rolled "Back" links, duplicated back-to-top widgets, hardcoded hex colors, missing Google Fonts, and inconsistent emoji-based icons.

**Structural changes:**
- Extracted `templates/partials/navbar.html`, `footer.html`, `back_to_top.html`, `cursor_widget.html`, `guest_alert.html`
- Introduced `templates/base.html` - all pages now extend it via `{% block content %}`
- Migrated `landing.html`, `lessons.html`, `lessons_roadmap.html`, `lesson_detail.html` to extend `base.html`
- Consolidated duplicated/drifted CSS variables from `landing.css` into `theme.css` as the single source of truth
- Added `lessons-shared.css` for styles shared across lesson pages
- Fixed `.back-btn` positioning bug (added `.back-btn-inline` modifier for pages without a `position: relative` hero container)
- Migrated `lesson.css` hardcoded hex values to `theme.css` variables; removed now-redundant `[data-theme="light"]` override block
- Ensured Google Fonts (Cinzel/Inter/Rajdhani) load consistently across all pages, not just landing

**Visual changes:**
- Replaced decorative emoji icons with inline SVGs matching the existing `.bento-icon-small` style across navbar, footer, and all four templates
- Added `aria-hidden="true"` on purely decorative icons and meaningful `aria-label`s on state-conveying icons (locked/completed/current lesson nodes)
- Kept chess piece glyphs (♛♚♞♝♜♔♕) as-is — structural, not decorative

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue
Fixes #2258

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots 
<img width="1883" height="613" alt="image" src="https://github.com/user-attachments/assets/356b1b7e-6344-4436-b039-bfcbdf96e46e" />
<img width="1900" height="757" alt="image" src="https://github.com/user-attachments/assets/22474859-c776-4de3-94f4-840dea649d4e" />
<img width="1917" height="952" alt="image" src="https://github.com/user-attachments/assets/f18f0f34-7653-452a-8398-e41c1774cad1" />


## Additional Notes
Verified manually across all four pages: navbar (cursor picker, theme toggle, profile dropdown), footer (legal/contact modals), back-to-top button, and theme toggle persistence when navigating between landing and lesson pages. Font loading confirmed consistent (Cinzel/Inter/Rajdhani) on all pages. Grepped all four templates + landing.html for remaining raw hex outside `lesson.css`'s intentional exceptions (quiz correct/incorrect colors, complete-btn always-dark text, confetti colors, focus-ring color).