### PR TITLE
feat: add pawn promotion dialog keyboard accessibility

### DIFF
--- a/board.test.js
+++ b/board.test.js
@@ -506,7 +506,21 @@ describe("Board UI Interactions", () => {
       expect(buttons[0].querySelector(".promo-text").textContent).toContain("Queen");
 
       global.fetch.mockClear();
-      const event = new KeyboardEvent('keydown', { key: 'q' });
+
+      // Dispatch an invalid key 'x' and assert overlay stays active and no fetch call is made
+      const invalidEvent = new KeyboardEvent('keydown', { key: 'x' });
+      document.dispatchEvent(invalidEvent);
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(overlay.classList.contains("active")).toBe(true);
+      expect(global.fetch.mock.calls.length).toBe(0);
+
+      // Focus an input element to verify keydown intercepts even when inputs are focused
+      const inputEl = document.getElementById("sanMoveInput");
+      inputEl.focus();
+      expect(document.activeElement).toBe(inputEl);
+
+      // Dispatch an uppercase 'Q' and assert overlay closes and correct move is submitted
+      const event = new KeyboardEvent('keydown', { key: 'Q' });
       document.dispatchEvent(event);
       await new Promise(resolve => setTimeout(resolve, 0));
 
@@ -516,6 +530,9 @@ describe("Board UI Interactions", () => {
       expect(moveCall).toBeDefined();
       const requestBody = JSON.parse(moveCall[1].body);
       expect(requestBody.promotion_piece).toBe('q');
+
+      // Blur the input element at the end of the test to clean up focus state
+      inputEl.blur();
     } finally {
       global.fetch = originalFetch;
     }

--- a/board.test.js
+++ b/board.test.js
@@ -509,8 +509,7 @@ describe("Board UI Interactions", () => {
       global.fetch.mockClear();
  
       // Dispatch an invalid key 'x' and assert overlay stays active and no fetch call is made
-      const invalidEvent = new KeyboardEvent('keydown', { key: 'x' });
-      document.dispatchEvent(invalidEvent);
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'x' }));
       await flushPromises();
       expect(overlay.classList.contains("active")).toBe(true);
       expect(global.fetch.mock.calls.length).toBe(0);
@@ -521,8 +520,7 @@ describe("Board UI Interactions", () => {
       expect(document.activeElement).toBe(inputEl);
  
       // Dispatch an uppercase 'Q' and assert overlay closes and correct move is submitted
-      const event = new KeyboardEvent('keydown', { key: 'Q' });
-      document.dispatchEvent(event);
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Q' }));
       await flushPromises();
 
       expect(overlay.classList.contains("active")).toBe(false);

--- a/board.test.js
+++ b/board.test.js
@@ -415,6 +415,111 @@ describe("Board UI Interactions", () => {
     expect(overlay.classList.contains("active")).toBe(false);
   });
 
+  it('handles hotkeys and visual labels for promotion', async () => {
+    const originalFetch = global.fetch;
+    const customBoard = [
+      [null, null, null, null, null, null, null, null],
+      [null, null, null, null, 'P', null, null, null],
+      [null, null, null, null, null, null, null, null],
+      [null, null, null, null, null, null, null, null],
+      [null, null, null, null, null, null, null, null],
+      [null, null, null, null, null, null, null, null],
+      [null, null, null, null, null, null, null, null],
+      [null, null, null, null, null, null, null, null]
+    ];
+    
+    global.fetch = jest.fn((url) => {
+      if (url.includes('/api/new-game/')) {
+        return Promise.resolve({
+          json: () => Promise.resolve({
+            valid: true,
+            board: customBoard,
+            current_turn: 'white',
+            player_color: 'white',
+            game_mode: 'pvp',
+          })
+        });
+      }
+      if (url.includes('/api/state/')) {
+        return Promise.resolve({
+          json: () => Promise.resolve({
+            valid: true,
+            board: customBoard,
+            current_turn: 'white',
+            player_color: 'white',
+            game_mode: 'pvp',
+            white_time: 300,
+            black_time: 300,
+            paused: false,
+            captured_pieces: { white: [], black: [] },
+            move_history: []
+          })
+        });
+      }
+      if (url.includes('/api/valid-moves/')) {
+        return Promise.resolve({
+          json: () => Promise.resolve({
+            valid_moves: [{ row: 0, col: 4 }]
+          })
+        });
+      }
+      if (url.includes('/api/move/')) {
+        return Promise.resolve({
+          json: () => Promise.resolve({
+            valid: true,
+            board: customBoard,
+            current_turn: 'black',
+            player_color: 'white',
+            game_mode: 'pvp',
+          })
+        });
+      }
+      return Promise.resolve({
+        json: () => Promise.resolve({ valid: true })
+      });
+    });
+
+    try {
+      // Re-initialize with custom board layout FEN
+      await startNewGame('pvp', 'white', 'medium', '8/4P3/8/8/8/8/8/8 w - - 0 1', 10);
+
+      // Trigger DOM clicks instead of calling onClick directly to avoid stale closures
+      const boardEl = document.getElementById("board");
+      const e7Square = boardEl.children[1 * 8 + 4]; // row 1, col 4
+      const e8Square = boardEl.children[0 * 8 + 4]; // row 0, col 4
+
+      // Select pawn on e7 (row 1, col 4)
+      e7Square.click();
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      // Move to e8 (row 0, col 4) (promotes)
+      e8Square.click();
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      const overlay = document.getElementById("promoOverlay");
+      expect(overlay.classList.contains("active")).toBe(true);
+
+      const promoChoices = document.getElementById("promoChoices");
+      const buttons = promoChoices.querySelectorAll(".promo-btn");
+      expect(buttons.length).toBe(4);
+      expect(buttons[0].querySelector(".promo-key").textContent).toBe("(q)");
+      expect(buttons[0].querySelector(".promo-text").textContent).toContain("Queen");
+
+      global.fetch.mockClear();
+      const event = new KeyboardEvent('keydown', { key: 'q' });
+      document.dispatchEvent(event);
+
+      expect(overlay.classList.contains("active")).toBe(false);
+
+      const moveCall = global.fetch.mock.calls.find(c => c[0].includes('/api/move/'));
+      expect(moveCall).toBeDefined();
+      const requestBody = JSON.parse(moveCall[1].body);
+      expect(requestBody.promotion_piece).toBe('q');
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
   it('onClick ignores invalid moves when game is over', async () => {
     global.fetch.mockClear();
     // Use valid bounds but empty square (or anything, just check it doesn't do a move fetch)

--- a/board.test.js
+++ b/board.test.js
@@ -76,6 +76,7 @@ document.body.innerHTML = `
   <div id="resBlunder"></div>
 `;
 
+const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0));
 
 global.fetch = jest.fn((url, options) => {
   let boardData = [
@@ -490,39 +491,39 @@ describe("Board UI Interactions", () => {
 
       // Select pawn on e7 (row 1, col 4)
       e7Square.click();
-      await new Promise(resolve => setTimeout(resolve, 0));
-
+      await flushPromises();
+ 
       // Move to e8 (row 0, col 4) (promotes)
       e8Square.click();
-      await new Promise(resolve => setTimeout(resolve, 0));
-
+      await flushPromises();
+ 
       const overlay = document.getElementById("promoOverlay");
       expect(overlay.classList.contains("active")).toBe(true);
-
+ 
       const promoChoices = document.getElementById("promoChoices");
       const buttons = promoChoices.querySelectorAll(".promo-btn");
       expect(buttons.length).toBe(4);
       expect(buttons[0].querySelector(".promo-key").textContent).toBe("(q)");
       expect(buttons[0].querySelector(".promo-text").textContent).toContain("Queen");
-
+ 
       global.fetch.mockClear();
-
+ 
       // Dispatch an invalid key 'x' and assert overlay stays active and no fetch call is made
       const invalidEvent = new KeyboardEvent('keydown', { key: 'x' });
       document.dispatchEvent(invalidEvent);
-      await new Promise(resolve => setTimeout(resolve, 0));
+      await flushPromises();
       expect(overlay.classList.contains("active")).toBe(true);
       expect(global.fetch.mock.calls.length).toBe(0);
-
+ 
       // Focus an input element to verify keydown intercepts even when inputs are focused
       const inputEl = document.getElementById("sanMoveInput");
       inputEl.focus();
       expect(document.activeElement).toBe(inputEl);
-
+ 
       // Dispatch an uppercase 'Q' and assert overlay closes and correct move is submitted
       const event = new KeyboardEvent('keydown', { key: 'Q' });
       document.dispatchEvent(event);
-      await new Promise(resolve => setTimeout(resolve, 0));
+      await flushPromises();
 
       expect(overlay.classList.contains("active")).toBe(false);
 
@@ -602,9 +603,6 @@ describe("SAN Quick Move Input", () => {
     await startNewGame('pvp', 'white', 'medium', 'startpos', 10);
   });
 
-  async function flushPromises() {
-    return new Promise(resolve => setTimeout(resolve, 0));
-  }
 
   it('valid pawn move (e4) using Enter key clears input and calls /api/move/', async () => {
     const input = document.getElementById("sanMoveInput");

--- a/board.test.js
+++ b/board.test.js
@@ -508,6 +508,7 @@ describe("Board UI Interactions", () => {
       global.fetch.mockClear();
       const event = new KeyboardEvent('keydown', { key: 'q' });
       document.dispatchEvent(event);
+      await new Promise(resolve => setTimeout(resolve, 0));
 
       expect(overlay.classList.contains("active")).toBe(false);
 

--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -2082,25 +2082,44 @@ body {
 }
 
 .promo-btn {
-    width: 64px;
-    height: 64px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 84px;
+    height: 92px;
     border: 2px solid #333;
     border-radius: 8px;
     background: #252545;
     cursor: pointer;
-    padding: 6px;
+    padding: 8px;
     transition: all 0.2s ease;
+    gap: 6px;
 }
 .promo-btn:hover {
     border-color: #f0c040;
     background: #2a2a55;
     transform: scale(1.08);
-
 }
 .promo-btn img {
-    width: 100%;
-    height: 100%;
+    width: 48px;
+    height: 48px;
     pointer-events: none;
+}
+.promo-label {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+    font-weight: 500;
+    pointer-events: none;
+}
+.promo-key {
+    color: var(--accent-gold);
+    font-weight: bold;
+}
+.promo-text {
+    color: #ffffff;
 }
 
 /* Mobile FAB controls  */

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -2079,12 +2079,30 @@
             { key: 'n', label: 'Knight' },
         ];
         promoChoices.innerHTML = '';
-        pieces.forEach(({ key }) => {
+        pieces.forEach(({ key, label }) => {
             const btn = document.createElement('button');
             btn.className = 'promo-btn';
+            btn.setAttribute('aria-label', `${label} (${key})`);
+            
             const img = document.createElement('img');
             img.src = PIECE_IMG[prefix + key];
             btn.appendChild(img);
+            
+            const labelSpan = document.createElement('span');
+            labelSpan.className = 'promo-label';
+            
+            const keySpan = document.createElement('span');
+            keySpan.className = 'promo-key';
+            keySpan.textContent = `(${key})`;
+            
+            const nameSpan = document.createElement('span');
+            nameSpan.className = 'promo-text';
+            nameSpan.textContent = ` ${label}`;
+            
+            labelSpan.appendChild(keySpan);
+            labelSpan.appendChild(nameSpan);
+            btn.appendChild(labelSpan);
+            
             btn.onclick = () => onPromoChoice(key);
             promoChoices.appendChild(btn);
         });
@@ -5262,6 +5280,17 @@ async function handleSanMove() {
 
         const tag = document.activeElement && document.activeElement.tagName;
         if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+
+        if (promoOverlay && promoOverlay.classList.contains('active')) {
+            const key = e.key.toLowerCase();
+            if (key === 'q' || key === 'r' || key === 'b' || key === 'n') {
+                e.preventDefault();
+                onPromoChoice(key);
+                return;
+            }
+            // Ignore all other game commands when promotion is pending
+            return;
+        }
 
         if (replayMode) {
             if (e.key === 'ArrowLeft') {

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -2091,9 +2091,9 @@
             btn.appendChild(img);
             
             const labelSpan = document.createElement('span');
+            const labelSpan = document.createElement('span');
             labelSpan.className = 'promo-label';
             labelSpan.setAttribute('aria-hidden', 'true');
-            
             const keySpan = document.createElement('span');
             keySpan.className = 'promo-key';
             keySpan.textContent = `(${key})`;

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -5279,9 +5279,6 @@ async function handleSanMove() {
     document.addEventListener('keydown', e => {
         if (e.repeat) return;
 
-        const tag = document.activeElement && document.activeElement.tagName;
-        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
-
         if (promoOverlay && promoOverlay.classList.contains('active')) {
             const key = e.key.toLowerCase();
             if (key === 'q' || key === 'r' || key === 'b' || key === 'n') {
@@ -5292,6 +5289,9 @@ async function handleSanMove() {
             // Ignore all other game commands when promotion is pending
             return;
         }
+
+        const tag = document.activeElement && document.activeElement.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
 
         if (replayMode) {
             if (e.key === 'ArrowLeft') {

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -2086,6 +2086,8 @@
             
             const img = document.createElement('img');
             img.src = PIECE_IMG[prefix + key];
+            img.alt = '';
+            img.setAttribute('aria-hidden', 'true');
             btn.appendChild(img);
             
             const labelSpan = document.createElement('span');

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -5290,7 +5290,7 @@ async function handleSanMove() {
             return;
         }
 
-        const tag = document.activeElement && document.activeElement.tagName;
+        const tag = document.activeElement?.tagName;
         if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
 
         if (replayMode) {

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -2090,6 +2090,7 @@
             
             const labelSpan = document.createElement('span');
             labelSpan.className = 'promo-label';
+            labelSpan.setAttribute('aria-hidden', 'true');
             
             const keySpan = document.createElement('span');
             keySpan.className = 'promo-key';

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -2091,7 +2091,6 @@
             btn.appendChild(img);
             
             const labelSpan = document.createElement('span');
-            const labelSpan = document.createElement('span');
             labelSpan.className = 'promo-label';
             labelSpan.setAttribute('aria-hidden', 'true');
             const keySpan = document.createElement('span');


### PR DESCRIPTION

Fixes #2347

## Description
When a pawn reaches the eighth rank, a promotion selection overlay appears offering Queen, Rook, Bishop, or Knight. Currently, selecting a piece requires clicking it. For power users and accessibility, this PR adds support for keyboard hotkeys (`q`, `r`, `b`, `n`) and renders visual indicators inside the dialog.

## Changes

### 1. Keyboard Accessibility & Hotkey Capture
- Added a keypress handler in the main document `keydown` event listener in `game/static/game/js/board.js` that intercepts events when the promotion modal is active (`promoOverlay.classList.contains('active')`).
- Captures case-insensitive keys `q` / `Q` (Queen), `r` / `R` (Rook), `b` / `B` (Bishop), and `n` / `N` (Knight) to automatically select and submit the selection.
- Intercepts and blocks other general board control hotkeys (like resignation, draw, board flip, etc.) to prevent accidental triggers while the promotion modal is active.

### 2. Visual Guidance & Tooltips
- Restructured `showPromoModal()` in `game/static/game/js/board.js` to dynamically generate styled shortcut labels (e.g. `(q) Queen`, `(r) Rook`) inside each button option.
- Added appropriate `aria-label` tags (`aria-label="${label} (${key})"`) for screen readers.
- Restructured `.promo-btn` in `game/static/game/css/board.css` to use a column flexbox layout with custom-sized buttons to cleanly hold both the piece graphic and text indicators.
- Styled the shortcut guide character (e.g. `(q)`) in the primary theme accent gold (`var(--accent-gold)`) to highlight the shortcut clearly and guide the user.

