### PR TITLE
fix: keep custom cursor visible over navbar

### DIFF
--- a/game/static/game/css/landing.css
+++ b/game/static/game/css/landing.css
@@ -415,7 +415,8 @@ body {
     position: fixed;
     pointer-events: none;
 
-    z-index: 9990;
+    /* Keep the visual cursor above the sticky navbar without blocking clicks. */
+    z-index: 10003;
     width: 18px;
     height: 18px;
     border-radius: 50%;


### PR DESCRIPTION
## Summary
- raise the custom cursor layer above the sticky navbar
- preserve `pointer-events: none` so navbar interactions remain unchanged

## Validation
- verified navbar z-index `10002` and cursor z-index `10003`
- `git diff --check`
- `python3 manage.py check` (blocked by missing required `SECRET_KEY` environment variable)

Fixes #2379