### PR TITLE
feat: add random chess quote block between hero and capabilities section

### DIFF
--- a/game/static/game/css/landing.css
+++ b/game/static/game/css/landing.css
@@ -1906,6 +1906,90 @@ body.hide-native-cursor * {
 }
 
 /* ==========================================================================
+   Chess Quote Section
+   ========================================================================== */
+.quote-section {
+    width: 100%;
+    padding: 2.5rem 1.5rem 3rem;
+    position: relative;
+    z-index: 10;
+}
+
+.quote-container {
+    max-width: 760px;
+    margin: 0 auto;
+    text-align: center;
+    padding: 2rem 2.5rem;
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 20px;
+    backdrop-filter: blur(10px);
+}
+
+.quote-mark {
+    display: block;
+    font-family: 'Cinzel', serif;
+    font-size: 3rem;
+    line-height: 1;
+    color: var(--accent-gold);
+    opacity: 0.7;
+    margin-bottom: 0.25rem;
+}
+
+.quote-text {
+    margin: 0;
+    font-family: 'Cinzel', serif;
+    font-size: 1.4rem;
+    line-height: 1.5;
+    font-style: italic;
+    color: var(--text-title);
+}
+
+.quote-author {
+    display: block;
+    margin-top: 1rem;
+    font-family: 'Rajdhani', sans-serif;
+    font-style: normal;
+    font-size: 1rem;
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    color: var(--text-secondary);
+}
+
+.quote-author::before {
+    content: "\2014\00A0";
+    color: var(--accent-gold);
+}
+
+@media (max-width: 900px) {
+    .quote-container {
+        padding: 1.75rem 1.75rem;
+    }
+    .quote-text {
+        font-size: 1.2rem;
+    }
+}
+
+@media (max-width: 480px) {
+    .quote-section {
+        padding: 2rem 1rem 2.5rem;
+    }
+    .quote-container {
+        padding: 1.5rem 1.25rem;
+        border-radius: 14px;
+    }
+    .quote-mark {
+        font-size: 2.25rem;
+    }
+    .quote-text {
+        font-size: 1.05rem;
+    }
+    .quote-author {
+        font-size: 0.9rem;
+    }
+}
+
+/* ==========================================================================
    Platform Growth Statistics Section
    ========================================================================== */
 .platform-stats-section {

--- a/game/static/game/js/landing.js
+++ b/game/static/game/js/landing.js
@@ -32,3 +32,16 @@ document.addEventListener("DOMContentLoaded", () => {
         if (window.innerWidth > 768) closeMenu();
     });
 });
+
+// ── Chess Quote (Hero → Platform Capabilities) ──
+document.addEventListener("DOMContentLoaded", () => {
+    const quoteTextEl = document.getElementById("chessQuoteText");
+    const quoteAuthorEl = document.getElementById("chessQuoteAuthor");
+
+    if (!quoteTextEl || !quoteAuthorEl) return;
+
+    const CHESS_QUOTE = { text: "Every chess master was once a beginner.", author: "Irving Chernev" };
+
+    quoteTextEl.textContent = CHESS_QUOTE.text;
+    quoteAuthorEl.textContent = CHESS_QUOTE.author;
+});

--- a/game/static/game/js/landing.js
+++ b/game/static/game/js/landing.js
@@ -33,15 +33,30 @@ document.addEventListener("DOMContentLoaded", () => {
     });
 });
 
-// ── Chess Quote (Hero → Platform Capabilities) ──
+// ── Random Chess Quote (Hero → Platform Capabilities) ──
 document.addEventListener("DOMContentLoaded", () => {
     const quoteTextEl = document.getElementById("chessQuoteText");
     const quoteAuthorEl = document.getElementById("chessQuoteAuthor");
 
     if (!quoteTextEl || !quoteAuthorEl) return;
 
-    const CHESS_QUOTE = { text: "Every chess master was once a beginner.", author: "Irving Chernev" };
+    const quotes = [
+        { text: "Every chess master was once a beginner.", author: "Irving Chernev" },
+        { text: "Chess is the gymnasium of the mind.", author: "Blaise Pascal" },
+        { text: "Chess is life in miniature.", author: "Garry Kasparov" },
+        { text: "When you see a good move, look for a better one.", author: "Emanuel Lasker" },
+        { text: "Tactics flow from a superior position.", author: "Bobby Fischer" },
+        { text: "The blunders are all there on the board, waiting to be made.", author: "Savielly Tartakower" },
+        { text: "A good player is always lucky.", author: "Jose Raul Capablanca" },
+        { text: "In life, as in chess, forethought wins.", author: "Charles Buxton" },
+        { text: "Chess is beautiful enough to waste your life for.", author: "Hans Ree" },
+        { text: "You may learn much more from a game you lose than from a game you win.", author: "Jose Raul Capablanca" },
+        { text: "Chess, like love, like music, has the power to make people happy.", author: "Siegbert Tarrasch" },
+        { text: "Even a poor plan is better than no plan at all.", author: "Mikhail Chigorin" }
+    ];
 
-    quoteTextEl.textContent = CHESS_QUOTE.text;
-    quoteAuthorEl.textContent = CHESS_QUOTE.author;
+    const randomQuote = quotes[Math.floor(Math.random() * quotes.length)];
+
+    quoteTextEl.textContent = randomQuote.text;
+    quoteAuthorEl.textContent = randomQuote.author;
 });

--- a/game/templates/game/landing.html
+++ b/game/templates/game/landing.html
@@ -214,6 +214,15 @@
       </script>
     </main>
 
+    <!-- ── Chess Quote Section ── -->
+    <section class="quote-section" id="chess-quote-section" aria-label="Chess quote">
+      <div class="quote-container">
+        <span class="quote-mark" aria-hidden="true">&ldquo;</span>
+        <blockquote class="quote-text" id="chessQuoteText"></blockquote>
+        <cite class="quote-author" id="chessQuoteAuthor"></cite>
+      </div>
+    </section>
+
     <!-- ── Platform Growth Statistics Section ── -->
     <section class="platform-stats-section">
       <div class="stats-container">


### PR DESCRIPTION
## Description
Adds a random chess-related quote (with attribution) between the Hero 
section and Platform Capabilities section on the home page. A new quote 
is randomly selected on every page load/refresh.

fixes #2390 

## Changes
- **landing.html**: Added a quote block placed between the Hero and 
  Platform Capabilities sections.
- **landing.js**: Added an array of chess quotes with authors and logic 
  to randomly select and render one quote on each page load.
- **landing.css**: Added styling for the quote block, matching the 
  existing home page visual theme, responsive on desktop and mobile.

## Behavior
- A different quote (with attribution) appears on every refresh
- No backend or database changes
- No impact on existing home page layout or functionality

## Testing
- Verified a new quote appears on repeated page refreshes
- Verified attribution displays correctly for each quote
- Verified layout and styling on both desktop and mobile viewport sizes