### PR TITLE
fix: engine subprocess leak and black-first PGN generation

### DIFF
--- a/game/engine.py
+++ b/game/engine.py
@@ -590,7 +590,7 @@ DP cache is intentionally excluded to save cookie space."""
                     try:
                         proc.kill()
                         proc.communicate()
-                    except Exception:
+                   except OSError:
                         pass
                 return None
             except OSError:

--- a/game/engine.py
+++ b/game/engine.py
@@ -125,14 +125,27 @@ class ChessGame:
         
         def _fix_castling(move):
             return move.replace('0-0-0', 'O-O-O').replace('0-0', 'O-O')
-        for i in range(0, len(self.move_history), 2):
-            move_number = i // 2 + 1
-            white_move = _fix_castling(self.move_history[i]['notation'])
-            if i + 1 < len(self.move_history):
-                black_move = _fix_castling(self.move_history[i + 1]['notation'])
-                pgn_moves.append(f"{move_number}. {white_move} {black_move}")
+
+        fullmove = getattr(self, 'initial_fullmove', 1)
+        history = self.move_history
+        i = 0
+
+        # If Black moved first, write the first half-move as "N... move"
+        if getattr(self, 'initial_turn_was_black', False) and history:
+            black_move = _fix_castling(history[0]['notation'])
+            pgn_moves.append(f"{fullmove}... {black_move}")
+            fullmove += 1
+            i = 1
+
+        while i < len(history):
+            white_move = _fix_castling(history[i]['notation'])
+            if i + 1 < len(history):
+                black_move = _fix_castling(history[i + 1]['notation'])
+                pgn_moves.append(f"{fullmove}. {white_move} {black_move}")
             else:
-                pgn_moves.append(f"{move_number}. {white_move}")
+                pgn_moves.append(f"{fullmove}. {white_move}")
+            fullmove += 1
+            i += 2
         
         today = date.today().strftime('%Y.%m.%d')
         headers = [
@@ -558,6 +571,7 @@ DP cache is intentionally excluded to save cookie space."""
         if not conn:
             # Fallback to stateless spawning if the server failed to
             # start or connect
+            proc = None
             try:
                 proc = subprocess.Popen(
                     self._build_engine_command(engine_path),
@@ -571,7 +585,15 @@ DP cache is intentionally excluded to save cookie space."""
                 )
                 stdout, _ = proc.communicate(input=command, timeout=timeout_secs)
                 return stdout.strip()
-            except (subprocess.TimeoutExpired, OSError):
+            except subprocess.TimeoutExpired:
+                if proc:
+                    try:
+                        proc.kill()
+                        proc.communicate()
+                    except Exception:
+                        pass
+                return None
+            except OSError:
                 return None
 
         try:

--- a/game/engine.py
+++ b/game/engine.py
@@ -590,7 +590,7 @@ DP cache is intentionally excluded to save cookie space."""
                     try:
                         proc.kill()
                         proc.communicate()
-                   except OSError:
+                    except Exception:
                         pass
                 return None
             except OSError:


### PR DESCRIPTION
## Description

This PR addresses two critical logic/resource bugs in the `game/engine.py` chess manager:
1. **Subprocess Resource Leak on Timeout:** In the stateless fallback of `_call_engine`, a spawned subprocess could hang and raise a `TimeoutExpired` exception, leaving the child process orphaned and running in the background. We have added proper cleanup (`proc.kill()` and `proc.communicate()`) in the timeout exception handler.
2. **Malformed PGN when Black Moves First:** The PGN generator previously assumed `move_history[0]` was always White's move. If a game started from a custom FEN where Black moves first, the PGN was generated with mismatched turns (e.g. `1. e5 Nf3 2. Nc6`). We updated `generate_pgn` to check `initial_turn_was_black` and correctly output the starting move as `[fullmove]... [black_move]`, followed by aligned turns.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

closes #2393 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

## Screenshots (if applicable)

N/A (backend logic changes).

## Additional Notes

- The subprocess leak fix ensures server resources are preserved even if the chess engine hangs or times out.
- The PGN fix ensures full compatibility with standard chess PGN readers when loading custom positions via FEN.