### PR TITLE
feat: Add interactive evaluation bar to game analysis view

### DIFF
--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -391,6 +391,7 @@
     let stockfishWorker = null;
     let stockfishEvalSeq = 0;
     let stockfishActiveReject = null;
+    let currentAnalysisData = null;
 
     let hintLevel = 0;
 
@@ -679,16 +680,20 @@
             const sideToMove = fen ? fen.split(' ')[1] : 'w';
             if (type === 'mate') {
                 let isWhiteMate = false;
-                if (sideToMove === 'w') {
+                if (evalResult.absolute) {
                     isWhiteMate = value > 0;
                 } else {
-                    isWhiteMate = value < 0;
+                    if (sideToMove === 'w') {
+                        isWhiteMate = value > 0;
+                    } else {
+                        isWhiteMate = value < 0;
+                    }
                 }
-                displayLabel = `M${Math.abs(value)}`;
+                displayLabel = evalResult.absolute ? 'M' : `M${Math.abs(value)}`;
                 percentage = isWhiteMate ? 100 : 0;
             } else {
                 let cp = value;
-                if (sideToMove === 'b') {
+                if (!evalResult.absolute && sideToMove === 'b') {
                     cp = -cp;
                 }
                 const rawScore = cp / 100;
@@ -2855,7 +2860,31 @@ function updateStepperUI() {
     viewingPastState = (stepperIndex < gameFens.length - 1);
 
     updateEvalBarVisibility();
-    if (fen && (gameMode === 'ai' || gameMode === 'analysis') && !dailyPuzzleMode) {
+    
+    if (gameMode === 'analysis' && currentAnalysisData) {
+        let scoreVal = null;
+        let isMate = false;
+        
+        if (stepperIndex < currentAnalysisData.move_analysis_details.length) {
+            scoreVal = currentAnalysisData.move_analysis_details[stepperIndex].eval;
+        } else if (stepperIndex === currentAnalysisData.move_analysis_details.length) {
+            scoreVal = currentAnalysisData.final_eval;
+        }
+        
+        if (scoreVal !== null && scoreVal !== undefined) {
+            if (Math.abs(scoreVal) > 90000) {
+                isMate = true;
+            }
+            const evalObj = {
+                type: isMate ? 'mate' : 'cp',
+                value: scoreVal,
+                absolute: true
+            };
+            updateEvalBar(evalObj, fen);
+        } else {
+            updateEvalBar(null, fen);
+        }
+    } else if (fen && (gameMode === 'ai' || gameMode === 'analysis') && !dailyPuzzleMode) {
         getStockfishEval(fen).then(result => {
             if (gameFens[stepperIndex] === fen) {
                 updateEvalBar(result, fen);
@@ -3044,6 +3073,7 @@ function updateStepperUI() {
     async function endGame(reason, loserColor, drawReason = null) {
         if (gameOver) return;
         gameOver = true;
+        currentAnalysisData = null;
         
         let title = '', message = '';
         let isCelebration = false;
@@ -3447,6 +3477,8 @@ function updateStepperUI() {
         }).then(analysisData => {
             if (!analysisData) return;
             if (currentAnalysisSeq !== analysisRequestSeq) return;
+            
+            currentAnalysisData = analysisData;
 
             const openingNameEl = document.getElementById('resOpeningName');
             if (openingNameEl) {
@@ -3510,7 +3542,24 @@ function updateStepperUI() {
                     const tdClass = document.createElement('td');
                     tdClass.style.padding = '5px';
                     tdClass.style.color = detail.class === 'Best' ? '#4caf50' : '#f44336';
-                    tdClass.textContent = detail.class;
+                    
+                    let nextEval = null;
+                    if (index + 1 < analysisData.move_analysis_details.length) {
+                        nextEval = analysisData.move_analysis_details[index + 1].eval;
+                    } else {
+                        nextEval = analysisData.final_eval;
+                    }
+
+                    let evalText = '';
+                    if (nextEval !== undefined && nextEval !== null) {
+                        if (Math.abs(nextEval) > 90000) {
+                            evalText = ' (M)';
+                        } else {
+                            const score = nextEval / 100;
+                            evalText = ` (${score >= 0 ? '+' : ''}${score.toFixed(1)})`;
+                        }
+                    }
+                    tdClass.textContent = detail.class + evalText;
                     tr.appendChild(tdClass);
 
                     tbody.appendChild(tr);

--- a/game/views.py
+++ b/game/views.py
@@ -2656,7 +2656,14 @@ def analyze_game_view(request):
                 except Exception as ex:
                     logger.warning('Failed to get notation for best move: %s', ex)
 
-            move_analysis_details.append({'move_num': move_num, 'color': color, 'played': notation, 'best': best_notation, 'class': move_class})
+            move_analysis_details.append({
+                'move_num': move_num,
+                'color': color,
+                'played': notation,
+                'best': best_notation,
+                'class': move_class,
+                'eval': best_move.get('eval') if best_move else None
+            })
 
             game.make_move(actual_from[0], actual_from[1], actual_to[0], actual_to[1])
             game.last_ts = time.time()
@@ -2664,6 +2671,15 @@ def analyze_game_view(request):
         bad_moves = blunders + mistakes
         accuracy = round(((analyzed_moves_count - bad_moves) / analyzed_moves_count) * 100) if analyzed_moves_count > 0 else 100
         opening = detect_opening(moves) or 'Unknown'
+
+        # Get evaluation of the final position
+        final_eval = None
+        try:
+            final_move = game.get_ai_move(depth=2)
+            if final_move:
+                final_eval = final_move.get('eval')
+        except Exception as ex:
+            logger.warning('Failed to get final evaluation: %s', ex)
 
         response_data = {
             'result': result,
@@ -2673,7 +2689,8 @@ def analyze_game_view(request):
             'promotions': promotions, 'blunders': blunders, 'mistakes': mistakes,
             'accuracy': accuracy, 'total_moves': (len(moves) + 1) // 2, 'move_analysis_details': move_analysis_details,
             'move_analysis': [detail['class'] for detail in move_analysis_details],
-            'analysis_timeout_seconds': ANALYSIS_TIMEOUT_SECONDS
+            'analysis_timeout_seconds': ANALYSIS_TIMEOUT_SECONDS,
+            'final_eval': final_eval
         }
 
         response = JsonResponse(response_data)


### PR DESCRIPTION
# Description

Fixes #2417 

This PR implements the interactive **Evaluation Bar** for the **Game Analysis View** (Issue #2417). It integrates the engine evaluation scores calculated during post-game analysis on the backend, sends them to the frontend, displays them inside the move table, and updates the evaluation bar dynamically as players navigate through the move history.

## Proposed Changes

### 1. Backend / Engine Integration (`game/views.py`)
- Updated `analyze_game_view` to extract evaluation metrics (`best_move.get('eval')`) for each chess position before the move is played.
- Evaluates and appends the `final_eval` value of the final board state at the end of the game analysis loop.
- Added evaluation metrics to the JSON response (`move_analysis_details` and `final_eval`).

### 2. Frontend / Javascript UI Integration (`game/static/game/js/board.js`)
- **Cached Analysis Data**: Introduced `currentAnalysisData` to cache the backend analysis payload locally once fetched.
- **Dynamic Eval Bar Updates**: Modified `updateStepperUI()` to update the vertical evaluation progress bar directly from cached evaluations instead of launching new Stockfish background workers during static game analysis (improving performance).
- **Absolute Score Support**: Updated `updateEvalBar()` to accept an `absolute` evaluation flag. This prevents the score from being incorrectly inverted when it is Black's turn, since backend engine evaluations are absolute and White-relative.
- **Eval Column Table Enhancements**: Updated the post-game analysis table rendering to output the engine evaluation score (e.g. `+1.5`, `-0.3`, or `(M)` for checkmate) right next to the move classification label in the `Eval` column.

