### PR TITLE
fix: preserve puzzle mode clock and streak UI state

### DIFF
--- a/board.test.js
+++ b/board.test.js
@@ -305,6 +305,38 @@ describe("validateMoveWithStockfish", () => {
   });
 });
 
+describe("startNewGame puzzle UI state", () => {
+  beforeEach(() => {
+    document.getElementById("whiteClock").style.display = "none";
+    document.getElementById("blackClock").style.display = "none";
+    document.getElementById("streak-counter").style.display = "block";
+  });
+
+  test("preserves puzzle clock and streak visibility in puzzle mode", async () => {
+    await startNewGame(
+      "ai",
+      "white",
+      "medium",
+      "6k1/5ppp/8/8/8/8/5PPP/6KQ w - - 0 1",
+      null,
+      null,
+      true
+    );
+
+    expect(document.getElementById("whiteClock").style.display).toBe("none");
+    expect(document.getElementById("blackClock").style.display).toBe("none");
+    expect(document.getElementById("streak-counter").style.display).toBe("block");
+  });
+
+  test("resets clocks and streak visibility for normal games", async () => {
+    await startNewGame("pvp", "white", "medium", "startpos", 10);
+
+    expect(document.getElementById("whiteClock").style.display).toBe("");
+    expect(document.getElementById("blackClock").style.display).toBe("");
+    expect(document.getElementById("streak-counter").style.display).toBe("none");
+  });
+});
+
 describe("Coordinates visibility toggle", () => {
   test("toggles .hide-coordinates class on #board when checkbox changes state", () => {
     const checkbox = document.getElementById("showCoordinatesCheckbox");

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -3224,15 +3224,17 @@
             }
         }
         replayMode = false;
-        // Show clocks for normal games
-        document.getElementById("whiteClock").style.display = "";
-        document.getElementById("blackClock").style.display = "";
+        if (!isPuzzle) {
+            // Show clocks for normal games and hide puzzle-only streak UI.
+            document.getElementById("whiteClock").style.display = "";
+            document.getElementById("blackClock").style.display = "";
 
-        const streakCounter =
-            document.getElementById("streak-counter");
+            const streakCounter =
+                document.getElementById("streak-counter");
 
-        if (streakCounter) {
-            streakCounter.style.display = "none";
+            if (streakCounter) {
+                streakCounter.style.display = "none";
+            }
         }
 
         replayMode = false;


### PR DESCRIPTION
## Description

This PR fixes the puzzle mode UI reset bug where `startNewGame()` shows the normal game clocks and hides the puzzle streak counter even when it is called with `isPuzzle = true`.

The normal-game clock/streak reset now only runs for non-puzzle games, so Daily Puzzle and Puzzle Browser flows can preserve their intended UI state.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #2170

## Changes Made

- Guarded the normal-game clock/streak reset inside `startNewGame()` with `if (!isPuzzle)`.
- Added regression tests to verify:
  - puzzle mode keeps clocks hidden and streak visible
  - normal games still show clocks and hide streak UI

## Validation

- [x] `node --check game/static/game/js/board.js`
- [x] `node --check board.test.js`
- [ ] `npm test -- --runInBand board.test.js`

Note: Jest could not be run locally because `npm`/installed `node_modules` were unavailable in my environment.

## GSSoC Labels Requested

This is a bug fix with test coverage. Suggested labels:
- `gssoc:approved`
- `type:bug`
- `type:testing`
- `level:beginner` or `level:intermediate`