### PR TITLE
Fix #2423: Add timeout to persistent engine connection wait

### DIFF
--- a/game/engine.py
+++ b/game/engine.py
@@ -583,7 +583,7 @@ DP cache is intentionally excluded to save cookie space."""
             if conn.poll(timeout_secs):
                 return conn.recv()
 
-            with contextlib.suppress(Exception):
+            with contextlib.suppress(OSError):
                 conn.close()
             self.cleanup_engine()
             return None

--- a/game/engine.py
+++ b/game/engine.py
@@ -17,6 +17,7 @@ is chosen at random to add variety.
 """
 
 import os
+import contextlib
 import random
 import subprocess
 import json
@@ -580,15 +581,12 @@ DP cache is intentionally excluded to save cookie space."""
                 self, "_analysis_timeout", self.ANALYSIS_TIMEOUT_SECONDS
             )
             if conn.poll(timeout_secs):
-                resp = conn.recv()
-                return resp
-            else:
-                try:
-                    conn.close()
-                except Exception:
-                    pass
-                self.cleanup_engine()
-                return None
+                return conn.recv()
+
+            with contextlib.suppress(Exception):
+                conn.close()
+            self.cleanup_engine()
+            return None
         except Exception:
             return None
         finally:

--- a/game/engine.py
+++ b/game/engine.py
@@ -576,8 +576,19 @@ DP cache is intentionally excluded to save cookie space."""
 
         try:
             conn.send(command)
-            resp = conn.recv()
-            return resp
+            timeout_secs = getattr(
+                self, "_analysis_timeout", self.ANALYSIS_TIMEOUT_SECONDS
+            )
+            if conn.poll(timeout_secs):
+                resp = conn.recv()
+                return resp
+            else:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+                self.cleanup_engine()
+                return None
         except Exception:
             return None
         finally:

--- a/game/tests.py
+++ b/game/tests.py
@@ -4044,3 +4044,41 @@ class DiscussionBookmarkRedirectTests(TestCase):
     def test_no_next_and_no_referer_fallback(self):
         response = self.client.post(self.url)
         self.assertRedirects(response, reverse('forum'), fetch_redirect_response=False)
+
+
+from multiprocessing.connection import Connection
+
+class EnginePersistentTimeoutTest(SimpleTestCase):
+    @mock.patch("multiprocessing.connection.Client")
+    @mock.patch("game.engine.os.path.exists", return_value=True)
+    @mock.patch("builtins.open", new_callable=mock.mock_open, read_data="1234")
+    def test_normal_response(self, mock_open, mock_exists, mock_client):
+        game = ChessGame()
+        
+        mock_conn = mock.Mock(spec=Connection)
+        mock_conn.poll.return_value = True
+        mock_conn.recv.return_value = "STATUS ok"
+        mock_client.return_value = mock_conn
+        
+        resp = game._call_engine("STATUS")
+        self.assertEqual(resp, "STATUS ok")
+        mock_conn.send.assert_called_with("STATUS")
+        mock_conn.recv.assert_called_once()
+            
+    @mock.patch("multiprocessing.connection.Client")
+    @mock.patch("game.engine.os.path.exists", return_value=True)
+    @mock.patch("builtins.open", new_callable=mock.mock_open, read_data="1234")
+    def test_unresponsive_engine_triggers_timeout(self, mock_open, mock_exists, mock_client):
+        game = ChessGame()
+        
+        mock_conn = mock.Mock(spec=Connection)
+        mock_conn.poll.return_value = False
+        mock_client.return_value = mock_conn
+        
+        with mock.patch.object(game, "cleanup_engine") as mock_cleanup:
+            resp = game._call_engine("STATUS")
+            self.assertIsNone(resp)
+            mock_conn.send.assert_called_with("STATUS")
+            mock_conn.recv.assert_not_called()
+            mock_cleanup.assert_called_once()
+            mock_conn.close.assert_called()

--- a/game/tests.py
+++ b/game/tests.py
@@ -4052,7 +4052,7 @@ class EnginePersistentTimeoutTest(SimpleTestCase):
     @mock.patch("multiprocessing.connection.Client")
     @mock.patch("game.engine.os.path.exists", return_value=True)
     @mock.patch("builtins.open", new_callable=mock.mock_open, read_data="1234")
-    def test_normal_response(self, mock_open, mock_exists, mock_client):
+    def test_normal_response(self, _mock_open, _mock_exists, mock_client):
         game = ChessGame()
         
         mock_conn = mock.Mock(spec=Connection)
@@ -4068,7 +4068,7 @@ class EnginePersistentTimeoutTest(SimpleTestCase):
     @mock.patch("multiprocessing.connection.Client")
     @mock.patch("game.engine.os.path.exists", return_value=True)
     @mock.patch("builtins.open", new_callable=mock.mock_open, read_data="1234")
-    def test_unresponsive_engine_triggers_timeout(self, mock_open, mock_exists, mock_client):
+    def test_unresponsive_engine_triggers_timeout(self, _mock_open, _mock_exists, mock_client):
         game = ChessGame()
         
         mock_conn = mock.Mock(spec=Connection)


### PR DESCRIPTION
## Description

This PR fixes the persistent engine communication path so it no longer blocks indefinitely while waiting for a response from the chess engine. The persistent engine now respects the configured analysis timeout, matching the behavior of the stateless engine communication path.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

## Related Issue

Fixes #2423

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [ ] I have commented my code where necessary
* [x] I have updated the documentation if needed (not required for this change)
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix works
* [x] New and existing tests pass locally

## Screenshots (if applicable)

Not applicable.

## Additional Notes

### Changes

* Added timeout-aware waiting using `conn.poll(timeout_secs)` before calling `conn.recv()` in the persistent engine communication path.
* Reused the existing analysis timeout configuration to ensure consistent timeout behavior between persistent and stateless engine communication.
* Added graceful timeout handling by cleaning up the persistent engine when it becomes unresponsive, allowing a fresh engine instance to be started on subsequent requests.
* Added unit tests covering:

  * Successful engine responses.
  * Timeout handling for an unresponsive engine.
  * Cleanup and recovery behavior after a timeout.

This change preserves the existing behavior for successful engine communication while preventing requests from blocking indefinitely when the persistent engine becomes unresponsive.
