### PR TITLE
fix(game): clean up temporary ChessGame engine in analysis mode

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -643,50 +643,53 @@ def ai_move(request):
 
             # Create a temporary copy
             temp_game = ChessGame()
-            temp_game.board = temp_game._parse_board64(game.serialize_board())
-            temp_game.castling_rights = dict(game.castling_rights)
-            temp_game.current_turn = game.current_turn
-            temp_game.en_passant_target = game.en_passant_target
-            
-            # Synchronize history and clocks to prevent state desync
-            temp_game.move_history = list(game.move_history)
-            temp_game.halfmove_clock = game.halfmove_clock
-            temp_game.repetition_history = list(game.repetition_history)
-            temp_game.repetition_counts = dict(game.repetition_counts)
-            temp_game.captured = {k: list(v) for k, v in game.captured.items()} if hasattr(game, 'captured') and isinstance(game.captured, dict) else {'white': [], 'black': []}
-            
-            # Apply the suggested move, handling promotions
-            temp_game.make_move(best['from_row'], best['from_col'], best['to_row'], best['to_col'], promotion_piece=best.get('promotion_piece'))
-            
-            # Request opponent's responses
-            opp_resp = temp_game.get_ai_move(depth=depth)
-            
-            predicted_responses = []
-            if opp_resp:
-                predicted_responses.append({
-                    'notation': temp_game._notation(
-                        opp_resp['from_row'], opp_resp['from_col'], 
-                        opp_resp['to_row'], opp_resp['to_col'], 
-                        temp_game.board[opp_resp['from_row']][opp_resp['from_col']], 
-                        temp_game.board[opp_resp['to_row']][opp_resp['to_col']], 
-                        temp_game.serialize_board(), temp_game.serialize_castling_rights(), temp_game._serialize_ep()
-                    ),
-                    'eval': opp_resp.get('eval')
-                })
-                # Cap the alts before running the notation loop
-                for alt in opp_resp.get('alts', [])[:2]:
+            try:
+                temp_game.board = temp_game._parse_board64(game.serialize_board())
+                temp_game.castling_rights = dict(game.castling_rights)
+                temp_game.current_turn = game.current_turn
+                temp_game.en_passant_target = game.en_passant_target
+
+                # Synchronize history and clocks to prevent state desync
+                temp_game.move_history = list(game.move_history)
+                temp_game.halfmove_clock = game.halfmove_clock
+                temp_game.repetition_history = list(game.repetition_history)
+                temp_game.repetition_counts = dict(game.repetition_counts)
+                temp_game.captured = {k: list(v) for k, v in game.captured.items()} if hasattr(game, 'captured') and isinstance(game.captured, dict) else {'white': [], 'black': []}
+
+                # Apply the suggested move, handling promotions
+                temp_game.make_move(best['from_row'], best['from_col'], best['to_row'], best['to_col'], promotion_piece=best.get('promotion_piece'))
+
+                # Request opponent's responses
+                opp_resp = temp_game.get_ai_move(depth=depth)
+
+                predicted_responses = []
+                if opp_resp:
                     predicted_responses.append({
                         'notation': temp_game._notation(
-                            alt['from_row'], alt['from_col'], 
-                            alt['to_row'], alt['to_col'], 
-                            temp_game.board[alt['from_row']][alt['from_col']], 
-                            temp_game.board[alt['to_row']][alt['to_col']], 
+                            opp_resp['from_row'], opp_resp['from_col'],
+                            opp_resp['to_row'], opp_resp['to_col'],
+                            temp_game.board[opp_resp['from_row']][opp_resp['from_col']],
+                            temp_game.board[opp_resp['to_row']][opp_resp['to_col']],
                             temp_game.serialize_board(), temp_game.serialize_castling_rights(), temp_game._serialize_ep()
                         ),
-                        'eval': alt.get('eval')
+                        'eval': opp_resp.get('eval')
                     })
-            
-            best['predicted_responses'] = predicted_responses
+                    # Cap the alts before running the notation loop
+                    for alt in opp_resp.get('alts', [])[:2]:
+                        predicted_responses.append({
+                            'notation': temp_game._notation(
+                                alt['from_row'], alt['from_col'],
+                                alt['to_row'], alt['to_col'],
+                                temp_game.board[alt['from_row']][alt['from_col']],
+                                temp_game.board[alt['to_row']][alt['to_col']],
+                                temp_game.serialize_board(), temp_game.serialize_castling_rights(), temp_game._serialize_ep()
+                            ),
+                            'eval': alt.get('eval')
+                        })
+
+                best['predicted_responses'] = predicted_responses
+            finally:
+                temp_game.cleanup_engine()
         except Exception:
             logger.exception("Failed to predict opponent responses")
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1830,9 +1830,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4360,9 +4360,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Description

This PR fixes a resource leak in Analysis Mode by ensuring the temporary `ChessGame` instance created for opponent prediction always releases its engine resources.

### Changes

* Wrapped the temporary `ChessGame` usage in a `try/finally` block.
* Added `temp_game.cleanup_engine()` in the `finally` block to guarantee cleanup, even if an exception occurs.
* No changes to existing game logic or analysis behavior.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

## Related Issue

Fixes #2437

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [ ] I have commented my code where necessary
* [ ] I have updated the documentation if needed
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix/feature works
* [x] New and existing tests pass locally

## Screenshots (if applicable)

N/A

## Additional Notes

This change is intentionally minimal and only ensures temporary engine processes are cleaned up immediately after analysis mode predictions.
