### PR TITLE
Fix custom cursor disappearing over navbar

### DIFF
--- a/game/static/game/css/landing.css
+++ b/game/static/game/css/landing.css
@@ -348,9 +348,6 @@ body {
 
     z-index: 10001;
 
-    /* z-index 10000 keeps dropdown above the custom cursor (z-index: 9990) */
-    z-index: 10000;
-
     transition: opacity 0.2s ease, visibility 0.2s ease, transform 0.2s ease;
     transform: translateY(10px);
     pointer-events: none;
@@ -401,7 +398,7 @@ body {
    - Core Architecture: JS-driven translate3d() (anchored 0,0) handles mouse tracking.
      Pseudo-elements (::before/::after) host all animations to prevent transform 
      conflicts with the JS-set position. GPU-accelerated; display: none by default.
-     Z-index < 9999 ensures dropdown/click-through interactivity.
+     Z-index 10003 ensures cursor renders above navbar (z-index 10002) while pointer-events: none preserves interactivity.
 
    - Variant Implementation:
      * Default: Basic cursor; hidden on load to avoid unstyled flashes.
@@ -415,7 +412,7 @@ body {
     position: fixed;
     pointer-events: none;
 
-    z-index: 9990;
+    z-index: 10003;
     width: 18px;
     height: 18px;
     border-radius: 50%;

--- a/game/static/game/css/landing.css
+++ b/game/static/game/css/landing.css
@@ -411,7 +411,6 @@ body {
 .cursor {
     position: fixed;
     pointer-events: none;
-
     z-index: 10003;
     width: 18px;
     height: 18px;


### PR DESCRIPTION
## Description

This PR fixes an issue where custom cursors (Glow, Trail, Sparkle, Orbit, Chess, etc.) became invisible when hovering over the navigation bar.

The custom cursor's `z-index` was lower than the navbar, causing it to render behind the navbar. This change updates the cursor's stacking order so it remains visible across the entire page while preserving `pointer-events: none`, ensuring all navbar interactions continue to work normally.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #2379 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary 
- [ ] I have updated the documentation if needed 
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works 
- [x] New and existing tests pass locally

## Screenshots (if applicable)

Before:
- Custom cursors became invisible when hovering over the navigation bar.
<img width="1488" height="146" alt="Screenshot 2026-07-23 at 8 13 36 PM" src="https://github.com/user-attachments/assets/ab580a92-b133-4cdc-a34f-113b9e464583" />



After:
- Custom cursors remain visible while hovering over the navigation bar, navigation links, and dropdowns.

<img width="1496" height="117" alt="Screenshot 2026-07-23 at 8 14 57 PM" src="https://github.com/user-attachments/assets/3d306696-e97e-4473-b386-1989181fb965" />


## Additional Notes

- Verified all available custom cursor styles (Glow, Trail, Sparkle, Orbit, and Chess).
- Confirmed navbar links, dropdowns, and other interactive elements continue to function correctly because the cursor retains `pointer-events: none`.
