### PR TITLE
feat: show elapsed pause duration timer inside pause overlay

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -2683,6 +2683,69 @@ body {
     color: #ddd;
 }
 
+/* ================= PAUSE OVERLAY (Issue #12: Pause Duration Timer) ================= */
+.pause-overlay {
+    display: none;
+    position: absolute;
+    inset: 0;
+    z-index: 45; /* below start countdown (50), above blurred board squares */
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    pointer-events: none;
+}
+
+.pause-overlay.active {
+    display: flex;
+}
+
+.pause-overlay-icon {
+    font-size: clamp(1.6rem, 4vw, 2.2rem);
+    color: var(--accent-gold, #f0c040);
+    line-height: 1;
+}
+
+.pause-overlay-title {
+    font-family: Cinzel, serif;
+    font-size: clamp(1rem, 3vw, 1.4rem);
+    font-weight: 700;
+    letter-spacing: 1px;
+    color: var(--accent-gold, #f0c040);
+    text-shadow: 0 0 20px rgba(240, 192, 64, 0.4);
+}
+
+.pause-timer-badge {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    background: rgba(8, 8, 16, 0.85);
+    border: 1px solid var(--card-border, #252545);
+    border-radius: 10px;
+    padding: 8px 20px;
+}
+
+.pause-timer-label {
+    font-size: 0.65rem;
+    letter-spacing: 1.5px;
+    color: var(--text-secondary, #8a8aaa);
+}
+
+.pause-timer-value {
+    font-family: 'Courier New', monospace;
+    font-size: clamp(1.1rem, 3.4vw, 1.6rem);
+    font-weight: 700;
+    color: var(--accent-gold, #f0c040);
+    font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 600px) {
+    .pause-timer-badge {
+        padding: 6px 14px;
+    }
+}
+
 
 /* ================= INPUT ERROR STATE ================= */
 .input-error {

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -375,6 +375,7 @@
     let countdownInterval = null;
     let pauseTimerInterval = null; // Issue #12: drives the "Paused for: MM:SS" overlay counter
     let pauseElapsedSeconds = 0;
+    let pauseStartedAt = null; // Date.now() anchor for this client's pause — see PR discussion on cross-client sync
     let pendingPromo = null;
     let blindfoldMode = false;
     let illegalMoveCount = 0;
@@ -3919,19 +3920,26 @@ function updateStepperUI() {
 
             function startPauseTimer() {
                 if (pauseTimerInterval) return; // already running — avoid double intervals
+                pauseStartedAt = Date.now();
                 pauseElapsedSeconds = 0;
                 if (pauseTimerEl) pauseTimerEl.textContent = formatPauseDuration(0);
+                announceMove('Game paused.');
                 pauseTimerInterval = setInterval(() => {
-                    pauseElapsedSeconds++;
+                    // Derive from the anchor rather than incrementing, so a
+                    // throttled/backgrounded tab self-corrects instead of drifting.
+                    pauseElapsedSeconds = Math.floor((Date.now() - pauseStartedAt) / 1000);
                     if (pauseTimerEl) pauseTimerEl.textContent = formatPauseDuration(pauseElapsedSeconds);
                 }, 1000);
             }
 
             function stopPauseTimer() {
+                const wasRunning = !!pauseTimerInterval;
                 clearInterval(pauseTimerInterval);
                 pauseTimerInterval = null;
+                pauseStartedAt = null;
                 pauseElapsedSeconds = 0;
                 if (pauseTimerEl) pauseTimerEl.textContent = formatPauseDuration(0);
+                if (wasRunning) announceMove('Game resumed.');
             }
 
             function updatePauseUI() {

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -373,6 +373,8 @@
     let paused = false;
     let timerInterval = null;
     let countdownInterval = null;
+    let pauseTimerInterval = null; // Issue #12: drives the "Paused for: MM:SS" overlay counter
+    let pauseElapsedSeconds = 0;
     let pendingPromo = null;
     let blindfoldMode = false;
     let illegalMoveCount = 0;
@@ -993,6 +995,8 @@
     const wCapEl = document.getElementById('whiteCaptured');
     const bCapEl = document.getElementById('blackCaptured');
     const pauseBtn = document.getElementById('pauseBtn');
+    const pauseOverlayEl = document.getElementById('pauseOverlay');
+    const pauseTimerEl = document.getElementById('pause-timer');
     const flipBtn = document.getElementById('flipBtn');
     const promoOverlay = document.getElementById('promoOverlay');
     const promoChoices = document.getElementById('promoChoices');
@@ -3084,6 +3088,11 @@ function updateStepperUI() {
             paused = true;
             clearInterval(timerInterval);
 
+            // Issue #12: hide the pause overlay and reset its timer — the
+            // game is over now, so "paused" no longer means an active pause.
+            stopPauseTimer();
+            if (pauseOverlayEl) pauseOverlayEl.classList.remove('active');
+
         if (blindfoldMode) {
             blindfoldMode = false;
             document.body.classList.remove('blindfold-mode');
@@ -3896,11 +3905,50 @@ function updateStepperUI() {
         updateThinkingDots();
     }
 
+            /* ==========================================================
+            PAUSE DURATION TIMER (Issue #12)
+            Live counter shown inside the pause overlay: "Paused for: MM:SS".
+            Starts at 00:00 when paused, counts up every second, and is
+            stopped/reset whenever the game is resumed or ends.
+            ========================================================== */
+            function formatPauseDuration(totalSeconds) {
+                const mins = Math.floor(totalSeconds / 60);
+                const secs = totalSeconds % 60;
+                return `${String(mins).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+            }
+
+            function startPauseTimer() {
+                if (pauseTimerInterval) return; // already running — avoid double intervals
+                pauseElapsedSeconds = 0;
+                if (pauseTimerEl) pauseTimerEl.textContent = formatPauseDuration(0);
+                pauseTimerInterval = setInterval(() => {
+                    pauseElapsedSeconds++;
+                    if (pauseTimerEl) pauseTimerEl.textContent = formatPauseDuration(pauseElapsedSeconds);
+                }, 1000);
+            }
+
+            function stopPauseTimer() {
+                clearInterval(pauseTimerInterval);
+                pauseTimerInterval = null;
+                pauseElapsedSeconds = 0;
+                if (pauseTimerEl) pauseTimerEl.textContent = formatPauseDuration(0);
+            }
+
             function updatePauseUI() {
     pauseBtn.innerHTML =
     `${paused ? 'Resume' : 'Pause'}<span class="btn-shortcut">P</span>`;
     pauseBtn.classList.toggle('paused', paused);
     boardEl.classList.toggle('paused', paused);
+
+    // Issue #12: show/hide the pause overlay and drive its live timer.
+    // gameOver guards against the overlay reappearing right as a game ends
+    // while paused (e.g. a draw is accepted during a pause).
+    if (pauseOverlayEl) pauseOverlayEl.classList.toggle('active', paused && !gameOver);
+    if (paused && !gameOver) {
+        startPauseTimer();
+    } else {
+        stopPauseTimer();
+    }
 
     // Mobile FAB icon toggle
     const pauseFabIcon = document.getElementById('pauseFabIcon');

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -413,8 +413,8 @@
                                 <div class="countdown-number" id="countdownNumber">3</div>
                             </div>
                             <!-- Pause Overlay (Issue #12: Pause Duration Timer) -->
-                            <div class="pause-overlay" id="pauseOverlay" aria-live="polite" aria-atomic="true">
-                                <div class="pause-overlay-icon">⏸</div>
+                            <div class="pause-overlay" id="pauseOverlay">
+                                <div class="pause-overlay-icon" aria-hidden="true">⏸</div>
                                 <div class="pause-overlay-title">GAME PAUSED</div>
                                 <div class="pause-timer-badge">
                                     <span class="pause-timer-label">PAUSED FOR</span>

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -412,6 +412,15 @@
                             <div class="countdown-overlay" id="countdownOverlay" aria-live="assertive" aria-atomic="true">
                                 <div class="countdown-number" id="countdownNumber">3</div>
                             </div>
+                            <!-- Pause Overlay (Issue #12: Pause Duration Timer) -->
+                            <div class="pause-overlay" id="pauseOverlay" aria-live="polite" aria-atomic="true">
+                                <div class="pause-overlay-icon">⏸</div>
+                                <div class="pause-overlay-title">GAME PAUSED</div>
+                                <div class="pause-timer-badge">
+                                    <span class="pause-timer-label">PAUSED FOR</span>
+                                    <span class="pause-timer-value" id="pause-timer">00:00</span>
+                                </div>
+                            </div>
                             <!-- Floating Resume Button -->
                             <button type="button" id="resumeGameBtn" class="resume-game-floating-btn hidden">
                                 Resume Game


### PR DESCRIPTION
Fixes #2461

   ## What changed
   Adds a live counting timer inside the pause overlay so both players can see
   how long the game has been paused, instead of just a blurred board with no
   indication of elapsed time.

   ### Changes
   - **board.html**: Added `#pauseOverlay` (icon, "GAME PAUSED" title, and a
     `#pause-timer` span) as a sibling to the existing `#countdownOverlay`
     inside `.board-grid-wrap`.
   - **board.css**: Styled the new overlay to match the existing pause/countdown
     overlay design language (dark badge, gold accent color, monospace digits).
   - **board.js**:
     - Added `formatPauseDuration()`, `startPauseTimer()`, `stopPauseTimer()`.
     - Hooked these into the existing `updatePauseUI()` function — the single
       choke point already called by `pauseGame()`, `resumeGame()`, `loadGame()`,
       and `startNewGame()` — so no other call sites needed to change.
     - Added a reset call in `endGame()` so the timer/overlay correctly clears
       if the game ends while paused (e.g. a draw is accepted mid-pause).

   ### Behavior
   - Timer starts at `00:00` the instant Pause is triggered.
   - Counts up every second in `MM:SS` format.
   - Stops and resets to `00:00` on Resume.
   - Stops and resets if the game ends while paused.
   - Pure frontend (`setInterval`) — no backend changes required.

   ### Testing done
   - Paused/resumed repeatedly and confirmed timer resets each time.
   - Paused, then ended the game while paused, confirmed overlay/timer clear.
   - Verified on desktop and mobile viewport widths.