### PR TITLE
feat: implement configurable AI difficulty levels and bot personalities

### DIFF
--- a/game/engine.py
+++ b/game/engine.py
@@ -27,6 +27,7 @@ import threading
 import uuid
 from datetime import date
 
+
 class ChessGame:
     """Manage a single chess game: state, validation,
       and engine communication."""
@@ -71,8 +72,9 @@ class ChessGame:
     #  Construction / serialization
     # ------------------------------------------------------------------
 
-    def __init__(self, time_limit=600, increment=0, game_id=None,
-                 authkey=None):
+    def __init__(self, time_limit=600, increment=0, difficulty='medium',
+                 game_id=None, authkey=None):
+        self.difficulty = difficulty
         self.game_id = game_id or str(uuid.uuid4())
         self.authkey = authkey or os.urandom(16)
         self.board = [row[:] for row in self.INITIAL_BOARD]
@@ -196,6 +198,7 @@ DP cache is intentionally excluded to save cookie space."""
             'last_ts': self.last_ts,
             'paused': self.paused,
             'mode': self.mode,
+            'difficulty': self.difficulty,
             'castling_rights': self.castling_rights,
             'en_passant_target': self.en_passant_target,
             'player_color': self.player_color,
@@ -269,6 +272,7 @@ DP cache is intentionally excluded to save cookie space."""
         game.increment = data.get('increment', 0)
         game.last_ts = data['last_ts']
         game.mode = data.get('mode', 'pvp')
+        game.difficulty = data.get('difficulty', 'medium')
         game.player_color = data.get('player_color', 'white')
         game.castling_rights = data.get(
             'castling_rights',
@@ -293,7 +297,9 @@ DP cache is intentionally excluded to save cookie space."""
         return game
 
     @classmethod
-    def from_fen(cls, fen: str, time_limit=600, increment=0):
+    def from_fen(
+        cls, fen: str, time_limit=600, increment=0, difficulty='medium'
+    ):
         """Create a new game state from a FEN string (board, side, castling)."""
         if not isinstance(fen, str):
             raise ValueError("FEN must be a string.")
@@ -320,7 +326,9 @@ DP cache is intentionally excluded to save cookie space."""
             raise ValueError(
                 "FEN must include exactly one white and one black king.")
 
-        game = cls(time_limit=time_limit, increment=increment)
+        game = cls(
+            time_limit=time_limit, increment=increment, difficulty=difficulty
+        )
         game.board = board
         game.current_turn = 'white' if active_color == 'w' else 'black'
         game.castling_rights = castling_rights
@@ -642,24 +650,10 @@ DP cache is intentionally excluded to save cookie space."""
                    for piece in row if piece is not None)
 
     def _get_ai_search_depth(self):
-        """Return appropriate search depth based on which
-        engine is available and game phase."""
-        engine_path = self._resolve_engine_path()
-        if not engine_path:
-            return self.AI_SEARCH_DEPTH_PYTHON
-        # C++ binary is much faster than Python, use deeper search
-        if engine_path.endswith('.py'):
-            return self.AI_SEARCH_DEPTH_PYTHON
-
-        piece_count = self._count_active_pieces()
-
-        # Adaptive Search Depth for C++ engine in endgame
-        if piece_count <= 6:
-            return self.AI_SEARCH_DEPTH_CPP + 2
-        elif piece_count <= 12:
-            return self.AI_SEARCH_DEPTH_CPP + 1
-
-        return self.AI_SEARCH_DEPTH_CPP
+        """Return appropriate search depth based on difficulty."""
+        if self.difficulty in self.DIFFICULTY_SETTINGS:
+            return self.DIFFICULTY_SETTINGS[self.difficulty]['max_depth']
+        return self.DIFFICULTY_SETTINGS['medium']['max_depth']
 
     def serialize_castling_rights(self):
         """Serialize castling rights to a string for the C++ engine."""

--- a/game/test_new.py
+++ b/game/test_new.py
@@ -143,6 +143,68 @@ class NewGameEdgeCaseTest(TestCase):
         for row in board:
             self.assertEqual(len(row), 8)
 
+    def test_new_game_ai_difficulty_and_bot_names(self):
+        """Test that starting an AI game correctly assigns bot names based on difficulty."""
+        response = self.client.post(
+            '/api/new-game/',
+            data=json.dumps({
+                'mode': 'ai', 'difficulty': 'easy', 'player_color': 'white'
+            }),
+            content_type='application/json',
+        )
+        data = response.json()
+        self.assertEqual(data['black_name'], '♟️ Novice Pawn')
+        self.assertEqual(data['difficulty'], 'easy')
+
+        response = self.client.post(
+            '/api/new-game/',
+            data=json.dumps({
+                'mode': 'ai', 'difficulty': 'medium', 'player_color': 'white'
+            }),
+            content_type='application/json',
+        )
+        data = response.json()
+        self.assertEqual(data['black_name'], '♗ Tactical Bishop')
+
+        response = self.client.post(
+            '/api/new-game/',
+            data=json.dumps({
+                'mode': 'ai', 'difficulty': 'hard', 'player_color': 'white'
+            }),
+            content_type='application/json',
+        )
+        data = response.json()
+        self.assertEqual(data['black_name'], '♜ Grandmaster Rook')
+
+    def test_new_game_ai_invalid_difficulty_fallback(self):
+        """Test that invalid difficulty falls back to medium personality."""
+        response = self.client.post(
+            '/api/new-game/',
+            data=json.dumps({
+                'mode': 'ai',
+                'difficulty': 'invalid_level',
+                'player_color': 'white'
+            }),
+            content_type='application/json',
+        )
+        data = response.json()
+        self.assertEqual(data['black_name'], '♗ Tactical Bishop')
+
+    def test_ai_search_depth_mapping(self):
+        """Test that the engine properly maps difficulty to search depth."""
+
+        game = ChessGame(difficulty='easy')
+        self.assertEqual(game._get_ai_search_depth(), 2)
+
+        game = ChessGame(difficulty='medium')
+        self.assertEqual(game._get_ai_search_depth(), 4)
+
+        game = ChessGame(difficulty='hard')
+        self.assertEqual(game._get_ai_search_depth(), 6)
+
+        game = ChessGame(difficulty='invalid_level')
+        self.assertEqual(game._get_ai_search_depth(), 4)
+
 
 class PuzzleStatsTest(TestCase):
     """Test the /api/puzzle-stats/ endpoint."""

--- a/game/views.py
+++ b/game/views.py
@@ -275,6 +275,8 @@ def new_game(request):
 
     mode = data.get('mode', 'pvp')
     difficulty = data.get('difficulty', 'medium')
+    if not isinstance(difficulty, str) or difficulty not in ('easy', 'medium', 'hard'):
+        difficulty = 'medium'
     fen = data.get('fen')
     time_limit_raw = data.get('time_limit', 600)
     increment_raw = data.get('increment', 0)
@@ -323,6 +325,18 @@ def new_game(request):
     request.session['difficulty'] = difficulty
     request.session['player_color'] = player_color
 
+    if mode == 'ai':
+        bot_names = {
+            'easy': '♟️ Novice Pawn',
+            'medium': '♗ Tactical Bishop',
+            'hard': '♜ Grandmaster Rook'
+        }
+        bot_name = bot_names.get(difficulty, '♗ Tactical Bishop')
+        if player_color == 'white':
+            request.session['black_name'] = bot_name
+        else:
+            request.session['white_name'] = bot_name
+
     raw_opening = data.get('opening', '') if mode == 'ai' else ''
     opening = raw_opening if raw_opening in VALID_OPENINGS else ''
     request.session['opening'] = opening
@@ -330,14 +344,14 @@ def new_game(request):
     fen = fen.strip() if isinstance(fen, str) else None
     if fen:
         try:
-            game = ChessGame.from_fen(fen, time_limit=time_limit, increment=increment)
+            game = ChessGame.from_fen(fen, time_limit=time_limit, increment=increment, difficulty=difficulty)
         except ValueError as exc:
             return JsonResponse(
                 {'valid': False, 'message': f'Invalid FEN: {exc}'},
                 status=400,
             )
     else:
-        game = ChessGame(time_limit=time_limit, increment=increment)
+        game = ChessGame(time_limit=time_limit, increment=increment, difficulty=difficulty)
     game.mode = mode
     game.player_color = player_color
     game.paused = False
@@ -593,12 +607,6 @@ def ai_move(request):
         return JsonResponse(
             {'valid': False, 'message': err_msg}, status=400
         )
-
-    # Depth Mapping — lower depth = faster response
-    difficulty = request.session.get('difficulty', 'medium')
-    depth_map = {'easy': 1, 'medium': 2, 'hard': 3}
-    depth = depth_map.get(difficulty, 2)
-
     opening = request.session.get('opening', '')
     book_move = None
     if opening:
@@ -623,11 +631,11 @@ def ai_move(request):
         if not any(m['row'] == best['to_row'] and m['col'] == best['to_col'] for m in valid):
             request.session['opening'] = ''
             request.session.modified = True
-            best = game.get_ai_move(depth=depth)
+            best = game.get_ai_move()
     else:
         request.session['opening'] = ''
         request.session.modified = True
-        best = game.get_ai_move(depth=depth)
+        best = game.get_ai_move()
 
     # Issue #1630: Predict opponent responses in Analysis Mode
     if best and game.mode == 'analysis':
@@ -642,7 +650,7 @@ def ai_move(request):
             )
 
             # Create a temporary copy
-            temp_game = ChessGame()
+            temp_game = ChessGame(difficulty=game.difficulty)
             try:
                 temp_game.board = temp_game._parse_board64(game.serialize_board())
                 temp_game.castling_rights = dict(game.castling_rights)
@@ -660,7 +668,7 @@ def ai_move(request):
                 temp_game.make_move(best['from_row'], best['from_col'], best['to_row'], best['to_col'], promotion_piece=best.get('promotion_piece'))
 
                 # Request opponent's responses
-                opp_resp = temp_game.get_ai_move(depth=depth)
+                opp_resp = temp_game.get_ai_move()
 
                 predicted_responses = []
                 if opp_resp:


### PR DESCRIPTION
## Description

Implements Issue #2369 by introducing configurable AI difficulty levels and bot personalities.

### Changes

* Centralized difficulty-to-depth mapping in `ChessGame`.
* Persisted the selected difficulty across game serialization/deserialization.
* Updated AI game creation to assign themed bot personalities:

  * ♟️ Novice Pawn (Easy)
  * ♗ Tactical Bishop (Medium)
  * ♜ Grandmaster Rook (Hard)
* Removed duplicated difficulty mapping logic from `views.py` and delegated AI depth selection to the engine.
* Added tests covering:

  * AI difficulty selection
  * Bot personality assignment
  * Invalid difficulty fallback
  * Difficulty-to-depth mapping

## Type of Change

* [x] New feature

## Related Issue

Fixes #2369

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] I have updated the tests
* [x] I have added tests that prove the feature works

## Notes

I verified that the existing authentication and endpoint test failures are already present on the current `main` branch and are unrelated to this feature.
