### PR TITLE
Fix #2510: bind exception and log it in download_badge

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -4181,10 +4181,11 @@ def download_badge(request, achievement_id):
     except (
         FileNotFoundError,
         OSError,
-    ):
+    ) as e:
         logger.error(
             "Badge generation failed for achievement %s: %s",
             achievement_id,
+            e,
         )
 
         return HttpResponseServerError(


### PR DESCRIPTION
Fixes #2510

## Description
`download_badge` caught `(FileNotFoundError, OSError)` without binding the exception, then called `logger.error` with a two-placeholder format string but only supplied one argument (`achievement_id`). This binds the exception with `as e` and passes it as the second `%s` argument so the real cause is logged.

## Type of Change
Bug fix (non-breaking change that fixes an issue).
