### PR TITLE
Fix #2516: expose analyzed_moves_count and is_capped in analyze-game …

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -2627,7 +2627,7 @@ def analyze_game_view(request):
             'opening': opening,
             'captures': captures, 'checks': checks, 'checkmates': checkmates,
             'promotions': promotions, 'blunders': blunders, 'mistakes': mistakes,
-            'accuracy': accuracy, 'total_moves': (len(moves) + 1) // 2, 'move_analysis_details': move_analysis_details,
+            'accuracy': accuracy, 'total_moves': (len(moves) + 1) // 2, 'analyzed_moves_count': analyzed_moves_count, 'is_capped': len(moves) > 80, 'move_analysis_details': move_analysis_details,
             'move_analysis': [detail['class'] for detail in move_analysis_details],
             'analysis_timeout_seconds': ANALYSIS_TIMEOUT_SECONDS,
             'final_eval': final_eval


### PR DESCRIPTION
Fixes #2516

## Description
The per-move analysis loop in `analyze_game_view` only processes `moves[:80]`, but `total_moves` was computed from the full, uncapped `moves` list. For games longer than 80 half-moves, the reported total didn't match what was actually analyzed. This adds `analyzed_moves_count` and `is_capped` fields to the response so clients can tell how many moves were actually analyzed, while leaving `total_moves` (full game length) unchanged for backward compatibility.

## Type of Change
Bug fix (non-breaking change that fixes an issue).
