### PR TITLE
Fix #2521: re-check is_deleted on locked reply in toggle_reply_vote

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -4626,6 +4626,11 @@ def toggle_reply_vote(request, reply_id):
 
     with transaction.atomic():
         reply = Reply.objects.select_for_update().get(pk=reply.pk)
+        if reply.is_deleted:
+            return JsonResponse(
+                {"success": False, "error": "Cannot vote on deleted replies."},
+                status=400
+            )
         vote = (
             ReplyVote.objects
             .select_for_update()


### PR DESCRIPTION
Fixes #2521

## Description
In `toggle_reply_vote`, `reply.is_deleted` was checked before the row was locked with `select_for_update()` inside the transaction, but was never re-checked afterward. A reply that gets soft-deleted between the initial check and lock acquisition could still receive a vote. This re-checks `is_deleted` on the freshly locked row before creating or updating the vote, keeping the pre-lock check as a fast path.

## Type of Change
Bug fix (non-breaking change that fixes an issue).
