### PR TITLE
chore: standardize editorconfig rules (#1322)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,10 +8,16 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[*.py]
+indent_size = 4
+
 [*.js]
 indent_size = 2
 
 [*.json]
+indent_size = 2
+
+[*.{yml,yaml}]
 indent_size = 2
 
 [*.html]
@@ -21,7 +27,7 @@ indent_size = 2
 indent_size = 2
 
 [*.md]
-trim_trailing_whitespace = false
+indent_size = 2
 
 [Makefile]
 indent_style = tab


### PR DESCRIPTION
## Description

Adds/updates the root `.editorconfig` rules to keep formatting consistent across Checkora's Python backend and frontend/config files.

## Type of Change

- [x] Documentation update / project configuration
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related Issue

Fixes #1322

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally

## Validation

- Django system check passed
- flake8 passed
- Jest passed: 65 tests
- Django test suite passed: 348 tests, 1 skipped
- collectstatic passed
- C++ engine compile passed

## Additional Notes

This is a scoped configuration-only change. No source files were reformatted.