### PR TITLE
fix: remove stray console.log causing ReferenceError in showToast (Closes #2405)

### DIFF
--- a/game/static/game/js/toast.js
+++ b/game/static/game/js/toast.js
@@ -2,10 +2,7 @@
  * Checkora Toast System
  * Replaces default alerts with modern, floating toast notifications.
  */
-console.log("showToast called", {
-    message,
-    key
-});
+
 (function() {
     'use strict';
 


### PR DESCRIPTION
## Summary

Removes a stray `console.log("showToast called", { message, key });` statement that was sitting outside the IIFE at the top of `toast.js`. The variables `message` and `key` are only defined as parameters of `window.showToast` inside the IIFE — they are not declared in the outer scope, so this statement throws a `ReferenceError` on page load, breaking the entire toast system.

## Changes

- `game/static/game/js/toast.js`: Removed lines 5–8 (the stray debug statement)

Closes #2405