### PR TITLE
fix: update back to home button for light theme

### DIFF
--- a/game/static/game/css/auth.css
+++ b/game/static/game/css/auth.css
@@ -853,6 +853,19 @@ body.login-page .helptext {
     background: var(--input-bg) !important;
     border-color: var(--accent-gold) !important;
 }
+[data-theme="light"] body.new-cyber-design .auth-home-link {
+    background: var(--card-bg);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="light"] body.new-cyber-design .auth-home-link:hover {
+    background: rgba(240, 192, 64, 0.12);
+    border-color: var(--accent-gold);
+    color: var(--text-primary);
+    box-shadow: 0 14px 28px rgba(0, 0, 0, 0.12);
+}
 
 body.new-cyber-design .auth-home-link {
     background: rgba(13, 17, 33, 0.9);


### PR DESCRIPTION
## Description

This PR fixes the issue where the **"Back to Home"** button on the Login page continued to use dark-theme styling even when the application was switched to the Light Theme.

### Changes made:
- Added a Light Theme override for `.auth-home-link` in `auth.css`.
- Updated the button to use the existing Light Theme variables for background, border, text, and hover states.
- Preserved the existing dark styling when Dark Theme is active.
- Ensured the button updates automatically with the selected application theme without requiring a page refresh.

This keeps the Login page visually consistent with the active application theme while maintaining the existing layout and functionality.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #2472

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

Attached screenshots demonstrating that the **"Back to Home"** button now correctly follows the selected Light Theme while preserving the existing Dark Theme styling.


https://github.com/user-attachments/assets/6b1f0dd9-d013-4aa6-9777-a4d59d39f9fc



## Additional Notes

This is a CSS-only change that reuses the project's existing Light Theme variables and cascade, ensuring the **"Back to Home"** button stays synchronized with the selected application theme without modifying templates or JavaScript.