### PR TITLE
Persist detected openings across game state reloads

### DIFF
--- a/game/engine.py
+++ b/game/engine.py
@@ -105,6 +105,8 @@ class ChessGame:
         self._game_status = 'active'
         self.draw_reason = None
         self.threefold_warning = False
+        self.opening_name = None
+        self.opening_moves = None
         self.initial_fen = None
 
     def serialize_board(self):
@@ -207,6 +209,8 @@ DP cache is intentionally excluded to save cookie space."""
             'game_status': self.game_status,
             'draw_reason': self.draw_reason,
             'threefold_warning': self.threefold_warning,
+            'opening_name': getattr(self, 'opening_name', None),
+            'opening_moves': getattr(self, 'opening_moves', None),
             'initial_fullmove': getattr(self, 'initial_fullmove', 1),
             'initial_turn_was_black': getattr(
                 self, 'initial_turn_was_black', False
@@ -282,6 +286,8 @@ DP cache is intentionally excluded to save cookie space."""
         game._game_status = data.get('game_status', 'active')
         game.draw_reason = data.get('draw_reason', None)
         game.threefold_warning = data.get('threefold_warning', False)
+        game.opening_name = data.get('opening_name')
+        game.opening_moves = data.get('opening_moves')
         game.initial_fullmove = data.get('initial_fullmove', 1)
         game.initial_turn_was_black = data.get('initial_turn_was_black', False)
         game.initial_fen = data.get('initial_fen', None)

--- a/game/opening_detector.py
+++ b/game/opening_detector.py
@@ -11,26 +11,24 @@ class OpeningDetector:
             self.openings = json.load(f)
 
     def detect(self, move_history):
-        moves = []
-
-        for move in move_history:
-            moves.append(move["notation"])
-        sequence = " ".join(moves)
+        move_tokens = [move["notation"] for move in move_history]
 
         best_match = None
         best_length = 0
 
         for opening_moves, opening_name in self.openings.items():
+            opening_tokens = opening_moves.split()
 
-            if sequence.startswith(opening_moves):
+            if move_tokens[:len(opening_tokens)] != opening_tokens:
+                continue
 
-                length = len(opening_moves.split())
+            length = len(opening_tokens)
 
-                if length > best_length:
-                    best_length = length
-                    best_match = {
-                        "name": opening_name,
-                        "moves": opening_moves
-                    }
+            if length > best_length:
+                best_length = length
+                best_match = {
+                    "name": opening_name,
+                    "moves": opening_moves,
+                }
 
         return best_match

--- a/game/opening_detector.py
+++ b/game/opening_detector.py
@@ -1,0 +1,36 @@
+import json
+import os
+
+
+class OpeningDetector:
+    def __init__(self):
+        base_dir = os.path.dirname(__file__)
+        file_path = os.path.join(base_dir, "openings.json")
+
+        with open(file_path, "r", encoding="utf-8") as f:
+            self.openings = json.load(f)
+
+    def detect(self, move_history):
+        moves = []
+
+        for move in move_history:
+            moves.append(move["notation"])
+        sequence = " ".join(moves)
+
+        best_match = None
+        best_length = 0
+
+        for opening_moves, opening_name in self.openings.items():
+
+            if sequence.startswith(opening_moves):
+
+                length = len(opening_moves.split())
+
+                if length > best_length:
+                    best_length = length
+                    best_match = {
+                        "name": opening_name,
+                        "moves": opening_moves
+                    }
+
+        return best_match

--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -1252,6 +1252,21 @@ body {
 /* ============================================================
    Move History
    ============================================================ */
+.opening-display {
+    display: block;
+    padding: 8px 12px;
+    margin-bottom: 8px;
+    background: rgba(240, 192, 64, 0.08);
+    border: 1px solid rgba(240, 192, 64, 0.2);
+    border-radius: 6px;
+    color: var(--text-primary);
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-align: center;
+    min-height: 32px;
+    line-height: 1.4;
+}
+
 /* ============================================================
    Replay Controls
    ============================================================ */

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -2964,7 +2964,7 @@ function updateStepperUI() {
 
         openingDisplay.textContent = openingName
             ? `Opening: ${openingName}`
-            : "Opening: —";
+            : "Opening: Custom Position";
     }
 
     function updateMoves(history) {

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1622,6 +1622,7 @@
 
         updatePlayerNames(data);
         updateTurn();
+        updateOpeningDisplay(data.opening_name);
         updateMoves(data.move_history);
         updateCaptured(data.captured_pieces);
 
@@ -2392,6 +2393,7 @@
                 hints = [];
                 updatePlayerNames(data);
                 updateTurn();
+                updateOpeningDisplay(data.opening_name);
                 updateMoves(data.move_history);
                 updateCaptured(data.captured_pieces);
                 syncPieces();
@@ -2559,6 +2561,7 @@
                 hints = [];
                 updatePlayerNames(data);
                 updateTurn();
+                updateOpeningDisplay(data.opening_name);
                 updateMoves(data.move_history);
                 updateCaptured(data.captured_pieces);
                 syncPieces();
@@ -2953,6 +2956,15 @@ function updateStepperUI() {
 
         wCapEl.classList.toggle('active', turn === 'white');
         bCapEl.classList.toggle('active', turn === 'black');
+    }
+
+    function updateOpeningDisplay(openingName) {
+        const openingDisplay = document.getElementById("openingDisplay");
+        if (!openingDisplay) return;
+
+        openingDisplay.textContent = openingName
+            ? `Opening: ${openingName}`
+            : "Opening: —";
     }
 
     function updateMoves(history) {

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -508,7 +508,7 @@
             <div class="card move-history-card">
                 <div class="card-title">Move History</div>
                 <div id="openingDisplay" class="opening-display">
-                    Opening: —
+                    Opening: Custom Position
                 </div>
                 <div class="moves-list" id="movesList">
                     <span class="placeholder">No moves yet</span>

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -507,6 +507,9 @@
 
             <div class="card move-history-card">
                 <div class="card-title">Move History</div>
+                <div id="openingDisplay" class="opening-display">
+                    Opening: —
+                </div>
                 <div class="moves-list" id="movesList">
                     <span class="placeholder">No moves yet</span>
                 </div>

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -507,7 +507,7 @@
 
             <div class="card move-history-card">
                 <div class="card-title">Move History</div>
-                <div id="openingDisplay" class="opening-display">
+                <div id="openingDisplay" class="opening-display" aria-live="polite" aria-atomic="true">
                     Opening: Custom Position
                 </div>
                 <div class="moves-list" id="movesList">

--- a/game/views.py
+++ b/game/views.py
@@ -115,6 +115,17 @@ VALID_OPENINGS = get_valid_openings()
 
 opening_detector = OpeningDetector()
 
+
+def update_opening_metadata(game):
+    opening = opening_detector.detect(game.move_history)
+
+    if opening:
+        game.opening_name = opening["name"]
+        game.opening_moves = opening["moves"]
+    else:
+        game.opening_name = None
+        game.opening_moves = None
+
 def landing(request):
     """Render the landing page introduction to Checkora."""
     return render(request, 'game/landing.html')
@@ -201,13 +212,7 @@ def make_move(request):
     )
 
     if success:
-        opening = opening_detector.detect(game.move_history)
-        if opening:
-            game.opening_name = opening["name"]
-            game.opening_moves = opening["moves"]
-        else:
-            game.opening_name = None
-            game.opening_moves = None
+        update_opening_metadata(game)
         success_save, active_game = save_game_state_helper(request, active_game, game.to_dict(), version)
         if not success_save:
             return JsonResponse({'error': 'Conflict: Stale game state.'}, status=409)
@@ -765,14 +770,7 @@ def ai_move(request):
     )
 
     if success:
-        opening = opening_detector.detect(game.move_history)
-
-        if opening:
-            game.opening_name = opening["name"]
-            game.opening_moves = opening["moves"]
-        else:
-            game.opening_name = None
-            game.opening_moves = None
+        update_opening_metadata(game)
         try:
             final_store = engine.SessionStore(session_key=request.session.session_key)
             final_game = final_store.get('game', {})

--- a/game/views.py
+++ b/game/views.py
@@ -199,15 +199,15 @@ def make_move(request):
     success, message, captured, game_status = game.make_move(
         from_row, from_col, to_row, to_col, promotion_piece,
     )
-    opening = opening_detector.detect(game.move_history)
-    if opening:
-        game.opening_name = opening["name"]
-        game.opening_moves = opening["moves"]
-    else:
-        game.opening_name = None
-        game.opening_moves = None
 
     if success:
+        opening = opening_detector.detect(game.move_history)
+        if opening:
+            game.opening_name = opening["name"]
+            game.opening_moves = opening["moves"]
+        else:
+            game.opening_name = None
+            game.opening_moves = None
         success_save, active_game = save_game_state_helper(request, active_game, game.to_dict(), version)
         if not success_save:
             return JsonResponse({'error': 'Conflict: Stale game state.'}, status=409)
@@ -241,8 +241,8 @@ def make_move(request):
         'time_limit': getattr(game, 'time_limit', 600),
         'increment': getattr(game, 'increment', 0),
         'move_history': game.move_history,
-        'opening_name': opening["name"] if opening else None,
-        'opening_moves': opening["moves"] if opening else None,
+        'opening_name': getattr(game, 'opening_name', None),
+        'opening_moves': getattr(game, 'opening_moves', None),
         'captured_pieces': game.captured,
         'game_status': game_status,
         'draw_reason': game.draw_reason,
@@ -764,16 +764,15 @@ def ai_move(request):
         best['to_row'], best['to_col'],
     )
 
-    opening = opening_detector.detect(game.move_history)
-
-    if opening:
-        game.opening_name = opening["name"]
-        game.opening_moves = opening["moves"]
-    else:
-        game.opening_name = None
-        game.opening_moves = None
-
     if success:
+        opening = opening_detector.detect(game.move_history)
+
+        if opening:
+            game.opening_name = opening["name"]
+            game.opening_moves = opening["moves"]
+        else:
+            game.opening_name = None
+            game.opening_moves = None
         try:
             final_store = engine.SessionStore(session_key=request.session.session_key)
             final_game = final_store.get('game', {})
@@ -818,8 +817,8 @@ def ai_move(request):
         'time_limit': getattr(game, 'time_limit', 600),
         'increment': getattr(game, 'increment', 0),
         'move_history': game.move_history,
-        'opening_name': opening["name"] if opening else None,
-        'opening_moves': opening["moves"] if opening else None,
+        'opening_name': getattr(game, 'opening_name', None),
+        'opening_moves': getattr(game, 'opening_moves', None),
         'captured_pieces': game.captured,
         'ai_move': best,
         'game_status': game_status,

--- a/game/views.py
+++ b/game/views.py
@@ -11,6 +11,7 @@ import base64
 import ipaddress
 import secrets
 import secrets as secrets_module
+from .opening_detector import OpeningDetector
 from game.views_history import save_game_record
 from django.http import HttpResponseServerError
 from django.views.decorators.clickjacking import xframe_options_sameorigin
@@ -112,6 +113,7 @@ from .analysis import detect_opening
 from .analysis import build_summary
 VALID_OPENINGS = get_valid_openings()
 
+opening_detector = OpeningDetector()
 
 def landing(request):
     """Render the landing page introduction to Checkora."""
@@ -197,6 +199,13 @@ def make_move(request):
     success, message, captured, game_status = game.make_move(
         from_row, from_col, to_row, to_col, promotion_piece,
     )
+    opening = opening_detector.detect(game.move_history)
+    if opening:
+        game.opening_name = opening["name"]
+        game.opening_moves = opening["moves"]
+    else:
+        game.opening_name = None
+        game.opening_moves = None
 
     if success:
         success_save, active_game = save_game_state_helper(request, active_game, game.to_dict(), version)
@@ -232,6 +241,8 @@ def make_move(request):
         'time_limit': getattr(game, 'time_limit', 600),
         'increment': getattr(game, 'increment', 0),
         'move_history': game.move_history,
+        'opening_name': opening["name"] if opening else None,
+        'opening_moves': opening["moves"] if opening else None,
         'captured_pieces': game.captured,
         'game_status': game_status,
         'draw_reason': game.draw_reason,
@@ -411,7 +422,6 @@ def resume_game(request):
         return JsonResponse({'error': 'Conflict: Stale game state.'}, status=409)
 
     res_version = active_game.version if (active_game and request.user.is_authenticated) else 0
-
     return JsonResponse({
         'valid': True,
         'board': game.board,
@@ -503,6 +513,8 @@ def get_state(request):
         'game_status': game.game_status,
         'draw_reason': game.draw_reason,
         'threefold_warning': game.threefold_warning,
+        'opening_name': getattr(game, 'opening_name', None),
+        'opening_moves': getattr(game, 'opening_moves', None),
     }
 
     if request.user.is_authenticated:

--- a/game/views.py
+++ b/game/views.py
@@ -738,6 +738,8 @@ def ai_move(request):
             'white_time': game.white_time,
             'black_time': game.black_time,
             'move_history': game.move_history,
+            'opening_name': getattr(game, 'opening_name', None),
+            'opening_moves': getattr(game, 'opening_moves', None),
             'captured_pieces': game.captured,
             'message': '',
             'version': 0
@@ -761,6 +763,15 @@ def ai_move(request):
         best['from_row'], best['from_col'],
         best['to_row'], best['to_col'],
     )
+
+    opening = opening_detector.detect(game.move_history)
+
+    if opening:
+        game.opening_name = opening["name"]
+        game.opening_moves = opening["moves"]
+    else:
+        game.opening_name = None
+        game.opening_moves = None
 
     if success:
         try:
@@ -807,6 +818,8 @@ def ai_move(request):
         'time_limit': getattr(game, 'time_limit', 600),
         'increment': getattr(game, 'increment', 0),
         'move_history': game.move_history,
+        'opening_name': opening["name"] if opening else None,
+        'opening_moves': opening["moves"] if opening else None,
         'captured_pieces': game.captured,
         'ai_move': best,
         'game_status': game_status,

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,14 +91,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -221,13 +221,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -491,18 +491,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
-      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
+        "@babel/generator": "^7.29.8",
         "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.7",
+        "@babel/parser": "^7.29.8",
         "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -510,9 +510,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1144,22 +1144,25 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
+      "integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.3"
       },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -1309,9 +1312,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1462,9 +1465,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1479,9 +1479,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1496,9 +1493,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1513,9 +1507,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1530,9 +1521,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1547,9 +1535,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1564,9 +1549,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1581,9 +1563,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1598,9 +1577,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1615,9 +1591,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1901,9 +1874,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.3.tgz",
-      "integrity": "sha512-sbT0Ui/CZwyAyy7icT1Gw5P1LKRlFaHwaF6tDCW5YHq2X5SeeZFphBuIagopSfwSSZq3sQcbmEL072yphxm7ew==",
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+      "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1914,9 +1887,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2302,9 +2275,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.396",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz",
-      "integrity": "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==",
+      "version": "1.5.400",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.400.tgz",
+      "integrity": "sha512-96EWDNjM59SYflgeV5Ylsf4EMiq1a25YjCnJH7cxn/AF2H3pILRweaUnoLax0yKHWdpOzY6JKEu45e8irqZIHA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3494,9 +3467,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3740,9 +3713,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.51",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
-      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "version": "2.0.52",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.52.tgz",
+      "integrity": "sha512-MRlTqhAfoMx/4mhEbPo3Hi02g9LJZaJkka69V6h67Cb1gjrAG0jsTE4CZX1eptNx+VCAwJmfpnDIF4P0Nh1A7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4864,9 +4837,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   },
 
   "overrides": {
-    "brace-expansion": "5.0.8"
+    "brace-expansion": "5.0.9"
   }
 }


### PR DESCRIPTION
## Description

This PR adds opening recognition persistence and displays the detected opening in the Move History panel.

### Changes Made
- Added an `OpeningDetector` to detect the current opening from the game's move history.
- Persisted `opening_name` and `opening_moves` in the `ChessGame` state by serializing and restoring them during save/load.
- Updated the move and game state APIs to include opening information in their responses.
- Added an opening display section to the Move History panel.
- Refactored the frontend by introducing a reusable `updateOpeningDisplay()` helper for consistent UI updates.

As a result, the detected opening is now preserved across page refreshes and resumed games instead of being lost after reloading the game state.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #2428

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

## Screenshots (if applicable)

Added screenshots demonstrating the detected opening in the Move History panel and its persistence after refreshing or resuming a game.

## Additional Notes

The feature was manually verified by playing games with recognized openings. The detected opening is displayed correctly and remains available after page refreshes and when resuming an active game.