### PR TITLE
fix: keep custom cursor visible over navbar

### DIFF
--- a/game/static/game/css/landing.css
+++ b/game/static/game/css/landing.css
@@ -414,8 +414,7 @@ body {
 .cursor {
     position: fixed;
     pointer-events: none;
-
-    z-index: 9990;
+    z-index: 100000;
     width: 18px;
     height: 18px;
     border-radius: 50%;

--- a/game/static/game/css/theme.css
+++ b/game/static/game/css/theme.css
@@ -427,7 +427,7 @@
     border-radius: 14px;
     border: 1px solid rgba(255, 255, 255, 0.08);
     box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
-    /* z-index 10000 keeps dropdown above the custom cursor (z-index: 9990) */
+/* The custom cursor sits above the navbar and dropdowns */
     z-index: 10000;
     transition: opacity 0.2s ease, visibility 0.2s ease, transform 0.2s ease;
     transform: translateY(10px);


### PR DESCRIPTION
## Description
This PR resolves the issue where the custom mouse pointer gets hidden when hovering over the header on the `/home/` landing page.
- Increased the `z-index` of the `.cursor` class in `landing.css` to `100000` so it renders above the navbar and dropdowns.
- Retained `pointer-events: none` on the cursor to ensure navbar links remain clickable.
- Updated the stale `z-index` comment in `theme.css`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #2555

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally


## Additional Notes
I'm a GSSOC Contributor. 
Windows 10
Browser: Chrome
