### PR TITLE
Add hover feedback to Exit to Home button on game board

### DIFF
--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -555,7 +555,18 @@
                     <button type="button" class="btn btn-danger" id="resignBtn" title="Shortcut: R">Resign<span class="btn-shortcut">R</span></button>
                     <button type="button" class="btn btn-gold controls-grid-full" onclick="document.getElementById('rulebookModal').style.display='flex'">📖 Rulebook</button>
                 </div>
-                <a href="/" class="btn controls-grid-full" style="background: #2a1414; color: #ff6b6b;margin-top: 1rem;margin-bottom: 1.5rem; border: 1px solid #632424; text-decoration: none; text-align: center; display: block; line-height: 2.5;">EXIT TO HOME</a>
+                <a href="/"
+   class="btn btn-danger controls-grid-full"
+   style="
+       margin-top: 1rem;
+       margin-bottom: 1.5rem;
+       text-decoration: none;
+       text-align: center;
+       display: block;
+       line-height: 2.5;
+   ">
+    EXIT TO HOME
+</a>
             </div>
 
             <div class="card" id="emotePanel" style="display: none;">


### PR DESCRIPTION
## Description

This PR adds hover feedback to the **Exit to Home** button on the game board by reusing the existing shared `btn-danger` styling.

### Changes Made
- Added the `btn-danger` class to the **Exit to Home** button.
- Removed duplicate inline styles (`background`, `color`, and `border`) so the button inherits the existing hover and active states.
- Preserved layout-related inline styles to avoid any visual or layout changes.
- Ensured the button remains consistent with the project's existing design system in both light and dark themes.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #2557

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] I have tested the changes locally
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

## Screenshots (if applicable)


https://github.com/user-attachments/assets/2dc65a5f-1567-4f60-82fe-fa4374da1e2a



## Additional Notes

This change reuses the project's existing shared button styling instead of introducing new custom hover styles, ensuring visual consistency and easier maintenance.