### PR TITLE
Fix Community Forum light/dark theme consistency

### DIFF
--- a/game/static/game/css/forum.css
+++ b/game/static/game/css/forum.css
@@ -989,8 +989,8 @@ html {
     flex-wrap: wrap;
     gap: 0.75rem;
     width: fit-content;
-    background: rgba(255,255,255,0.03);
-    border: 1px solid rgba(255,255,255,0.08);
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
     border-radius: 8px;
     padding: 0.75rem 1rem;
 }
@@ -1002,9 +1002,9 @@ html {
 }
 
 .forum-sort-form select {
-    background: #1a1d30;
-    color: #ffffff;
-    border: 1px solid rgba(240, 192, 64, 0.25);
+    background: var(--card-bg);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
     border-radius: 5px;
     padding: 0.45rem 2rem 0.45rem 0.85rem;
     font-family: inherit;
@@ -1026,14 +1026,17 @@ html {
 }
 
 .forum-search-input {
-    background: #1a1d30;
-    color: #ffffff;
-    border: 1px solid rgba(240, 192, 64, 0.25);
+    background: var(--card-bg);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
     border-radius: 5px;
     padding: 0.45rem 0.85rem;
     font-family: inherit;
     font-size: 0.82rem;
     min-width: 200px;
+}
+.forum-search-input::placeholder {
+    color: var(--text-secondary);
 }
 
 .forum-search-input:focus {

--- a/game/static/game/css/forum.css
+++ b/game/static/game/css/forum.css
@@ -18,7 +18,7 @@
 .forum-title {
     font-size: clamp(2rem, 4vw, 2.8rem);
     font-weight: 700;
-    color: #ffffff;
+    color: var(--text-title);
     margin-bottom: 0.75rem;
 }
 
@@ -71,7 +71,7 @@
 .forum-card-title {
     font-size: 1.1rem;
     font-weight: 600;
-    color: #ffffff;
+    color: var(--text-title);
     margin-bottom: 0.35rem;
 }
 
@@ -133,8 +133,8 @@
     padding: 0 2rem;
     min-height: 80px;
 
-    background: rgba(10,10,20,0.95);
-    border-bottom: 1px solid rgba(255,255,255,0.08);
+    background: var(--nav-bg);
+    border-bottom: 1px solid var(--border-color);
 
     box-sizing: border-box;
 }
@@ -250,8 +250,8 @@
 }
 
 .forum-discussion-card {
-    background: rgba(255,255,255,0.03);
-    border: 1px solid rgba(255,255,255,0.08);
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
     border-radius: 12px;
     padding: 1.25rem 1.5rem;
     margin-bottom: 1.75rem;
@@ -267,7 +267,7 @@
 }
 
 .forum-meta-label {
-    color: #8f96b0;
+    color: var(--text-secondary);
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.5px;
@@ -279,11 +279,11 @@
 }
 
 .forum-date {
-    color: #c2c7da;
+    color: var(--text-secondary);;
 }
 
 .forum-detail-content {
-    color: #d7dcec;
+    color: var(--text-primary);
     font-size: 1rem;
     line-height: 1.7;
 }
@@ -291,13 +291,13 @@
 .forum-replies-title {
     font-size: 1.3rem;
     font-weight: 700;
-    color: #ffffff;
+    color: var(--text-title);
     margin-bottom: 1.25rem;
 }
 
 .forum-reply-card {
-    background: rgba(255,255,255,0.025);
-    border: 1px solid rgba(255,255,255,0.08);
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
     border-radius: 12px;
     padding: 1rem 1.25rem;
     margin-bottom: 0.9rem;
@@ -338,7 +338,7 @@
 }
 
 .forum-form-group label {
-    color: #ffffff;
+    color: var(--text-title);
     font-weight: 600;
     font-size: 0.9rem;
 }
@@ -346,11 +346,11 @@
 .forum-new-form input[type="text"],
 .forum-new-form textarea,
 .forum-new-form select {
-    background: #1a1d30;
-    border: 1px solid #2b2f4a;
+    background: var(--input-bg);
+    border: 1px solid var(--input-border);
+    color: var(--input-text);
     border-radius: 8px;
     padding: 0.85rem 1rem;
-    color: #ffffff;
     font-family: inherit;
     font-size: 1rem;
     resize: vertical;
@@ -388,7 +388,7 @@
     bottom: 0;
     left: 0;
     right: 0;
-    background: #131522;
+    background: var(--nav-bg);
     border-top: 1px solid rgba(240, 192, 64, 0.2);
     padding: 1rem 1.5rem;
     display: flex;
@@ -402,11 +402,11 @@
     flex: 1;
     max-width: 1100px;
     margin: 0 auto;
-    background: #1a1d30;
-    border: 1px solid #2b2f4a;
+    background: var(--input-bg);
+    border: 1px solid var(--input-border);
+    color: var(--input-text);
     border-radius: 8px;
     padding: 0.75rem 1rem;
-    color: #ffffff;
     font-family: inherit;
     font-size: 1rem;
     resize: none;
@@ -431,7 +431,7 @@
     bottom: 0;
     left: 0;
     right: 0;
-    background: #131522;
+    background: var(--nav-bg);
     border-top: 1px solid rgba(240, 192, 64, 0.2);
     text-align: center;
     color: var(--text-secondary);

--- a/game/templates/game/forum_list.html
+++ b/game/templates/game/forum_list.html
@@ -11,6 +11,7 @@
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{% static 'game/css/landing.css' %}">
     <link rel="stylesheet" href="{% static 'game/css/board.css' %}">
+    <link rel="stylesheet" href="{% static 'game/css/theme.css' %}">
     <link rel="stylesheet" href="{% static 'game/css/forum.css' %}">
 </head>
 <body>
@@ -28,6 +29,12 @@
         </div>
 
         <div class="nav-right">
+            <button
+                type="button"
+                id="themeToggle"
+                class="theme-toggle"
+                title="Toggle light / dark theme">
+            </button>
             {% if user.is_authenticated %}
             <div class="profile-dropdown">
                 <button type="button" class="profile-btn">
@@ -206,5 +213,6 @@
     });
     </script>
     <script src="{% static 'game/js/dropdown.js' %}"></script>
+    <script src="{% static 'game/js/theme.js' %}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Description

This PR fixes the Community Forum's inconsistent light/dark theme behavior by integrating the global theme system and updating forum-specific styling.

### Changes Made
- Added the global `theme.css` to the Community Forum templates.
- Added the shared theme toggle button to the forum navbar for consistent theme switching.
- Ensured the Community Forum uses the existing global theme system.
- Updated forum-specific styles to use the project's theme variables instead of hard-coded colors where applicable.
- Improved visual consistency between light and dark modes across forum components.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #2559

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] I have tested the changes locally
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

## Screenshots (if applicable)

### Before
- Theme toggle was not available on the Community Forum page.
- Several forum components retained dark styling when switching themes.

### After
- Theme toggle is available on the Community Forum page.
- Forum components now follow the selected light/dark theme consistently.


https://github.com/user-attachments/assets/da4537fc-ce66-4ae0-acc2-c4d5c0017a79



## Additional Notes

This implementation reuses the existing global theme infrastructure (`theme.css` and `theme.js`) to keep the Community Forum consistent with the rest of the application while avoiding duplicate theme logic.