### PR TITLE
feat(ui): add interactive keyboard shortcuts modal to chess board 

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -2034,6 +2034,128 @@ body {
     justify-content: flex-end;
     margin-top: 24px;
 }
+
+/* ================= KEYBOARD SHORTCUTS MODAL ================= */
+
+.shortcuts-modal {
+    position: fixed;
+    inset: 0;
+    display: none;
+    justify-content: center;
+    align-items: center;
+    background: rgba(0, 0, 0, 0.7);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    z-index: 99999;
+    padding: 24px;
+}
+
+.shortcuts-modal.active {
+    display: flex;
+    animation: shortcutsModalFadeIn 0.3s ease-out forwards;
+}
+
+@keyframes shortcutsModalFadeIn {
+    from {
+        opacity: 0;
+        transform: scale(0.95);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+.shortcuts-dialog {
+    position: relative;
+    width: min(540px, 92vw);
+    max-height: 85vh;
+    overflow-y: auto;
+    background: rgba(16, 19, 34, 0.92);
+    border: 1px solid rgba(240, 192, 64, 0.35);
+    border-radius: 16px;
+    padding: 28px 32px;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.7), 0 0 30px rgba(240, 192, 64, 0.1);
+}
+
+.shortcuts-modal-title {
+    font-family: 'Cinzel', serif;
+    font-size: 1.6rem;
+    color: #f0c040;
+    text-align: center;
+    margin-bottom: 24px;
+    padding-right: 20px;
+    letter-spacing: 0.5px;
+}
+
+.shortcuts-content {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.shortcuts-section {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.07);
+    border-radius: 10px;
+    padding: 14px 18px;
+}
+
+.shortcuts-section-title {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #f0c040;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-bottom: 12px;
+    padding-bottom: 6px;
+    border-bottom: 1px solid rgba(240, 192, 64, 0.2);
+}
+
+.shortcut-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 0;
+    gap: 16px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.shortcut-row:last-child {
+    border-bottom: none;
+}
+
+.shortcut-desc {
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.9rem;
+    color: #e2e8f0;
+}
+
+.shortcut-keys {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: #94a3b8;
+    font-size: 0.85rem;
+}
+
+kbd {
+    display: inline-block;
+    padding: 4px 8px;
+    font-family: 'JetBrains Mono', monospace, sans-serif;
+    font-size: 0.82rem;
+    font-weight: 700;
+    line-height: 1;
+    color: #f0c040;
+    background: #141728;
+    border: 1px solid rgba(240, 192, 64, 0.4);
+    border-radius: 6px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.1);
+    min-width: 24px;
+    text-align: center;
+}
+
 /* ================= PROMOTION MODAL ================= */
 
 .promo-overlay {

--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -2052,10 +2052,10 @@ body {
 
 .shortcuts-modal.active {
     display: flex;
-    animation: shortcutsModalFadeIn 0.3s ease-out forwards;
+    animation: shortcuts-modal-fade-in 0.3s ease-out forwards;
 }
 
-@keyframes shortcutsModalFadeIn {
+@keyframes shortcuts-modal-fade-in {
     from {
         opacity: 0;
         transform: scale(0.95);
@@ -2079,7 +2079,7 @@ body {
 }
 
 .shortcuts-modal-title {
-    font-family: 'Cinzel', serif;
+    font-family: Cinzel, serif;
     font-size: 1.6rem;
     color: #f0c040;
     text-align: center;
@@ -2102,7 +2102,7 @@ body {
 }
 
 .shortcuts-section-title {
-    font-family: 'Outfit', sans-serif;
+    font-family: Outfit, sans-serif;
     font-size: 0.95rem;
     font-weight: 600;
     color: #f0c040;
@@ -2127,7 +2127,7 @@ body {
 }
 
 .shortcut-desc {
-    font-family: 'Outfit', sans-serif;
+    font-family: Outfit, sans-serif;
     font-size: 0.9rem;
     color: #e2e8f0;
 }

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -5831,6 +5831,33 @@ async function handleSanMove() {
                 closeShortcutsModal();
             }
         });
+
+        // Trap keyboard focus inside shortcutsModal while active
+        shortcutsModal.addEventListener('keydown', (e) => {
+            if (e.key !== 'Tab') return;
+            const focusable = Array.from(
+                shortcutsModal.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])')
+            ).filter(el => !el.disabled && el.offsetWidth > 0 && el.offsetHeight > 0);
+
+            if (!focusable.length) {
+                e.preventDefault();
+                return;
+            }
+            const first = focusable[0];
+            const last = focusable[focusable.length - 1];
+
+            if (e.shiftKey) {
+                if (document.activeElement === first || !shortcutsModal.contains(document.activeElement)) {
+                    e.preventDefault();
+                    last.focus();
+                }
+            } else {
+                if (document.activeElement === last || !shortcutsModal.contains(document.activeElement)) {
+                    e.preventDefault();
+                    first.focus();
+                }
+            }
+        });
     }
 
     // Theme Switcher

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -5411,6 +5411,12 @@ async function handleSanMove() {
         const tag = document.activeElement?.tagName;
         if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
 
+        if (e.key === '?') {
+            e.preventDefault();
+            toggleShortcutsModal();
+            return;
+        }
+
         if (replayMode) {
             if (e.key === 'ArrowLeft') {
                 e.preventDefault();
@@ -5443,7 +5449,8 @@ async function handleSanMove() {
             drawOverlay?.classList.contains('active') ||
             gameOverOverlay?.classList.contains('active') ||
             welcomeOverlay?.classList.contains('active') ||
-            leaveConfirmOverlay?.classList.contains('active');
+            leaveConfirmOverlay?.classList.contains('active') ||
+            shortcutsModal?.classList.contains('active');
 
         // Allow Escape to close overlays or mobile panel
         if (e.key === 'Escape') {
@@ -5461,7 +5468,10 @@ async function handleSanMove() {
             return;
         }
 
-        if (key === 'f' && flipBtn) {
+        if ((key === 'm' || e.key === '/') && sanMoveInput) {
+            e.preventDefault();
+            sanMoveInput.focus();
+        } else if (key === 'f' && flipBtn) {
             e.preventDefault();
             flipBtn.click();
         } else if (key === 'r' && resignBtn) {
@@ -5490,6 +5500,10 @@ async function handleSanMove() {
 
         } else if (key === 'escape') {
             e.preventDefault();
+
+            if (shortcutsModal?.classList.contains('active')) {
+                closeShortcutsModal();
+            }
 
             if (shareModal?.style.display === 'flex') {
                 shareModal.style.display = 'none';
@@ -5767,6 +5781,56 @@ async function handleSanMove() {
                 }
             });
         }
+    }
+
+    // ========== Keyboard Shortcuts Modal Logic ==========
+    const shortcutsModal = document.getElementById('shortcutsModal');
+    const shortcutsBtn = document.getElementById('shortcutsBtn');
+    const closeShortcutsModalBtn = document.getElementById('closeShortcutsModalBtn');
+    const saveShortcutsModalBtn = document.getElementById('saveShortcutsModalBtn');
+    let shortcutsModalFocusReturn = null;
+
+    function openShortcutsModal() {
+        if (!shortcutsModal) return;
+        shortcutsModalFocusReturn = document.activeElement;
+        shortcutsModal.classList.add('active');
+        shortcutsModal.setAttribute('aria-hidden', 'false');
+        setTimeout(() => {
+            if (closeShortcutsModalBtn) {
+                closeShortcutsModalBtn.focus();
+            }
+        }, 50);
+    }
+
+    function closeShortcutsModal() {
+        if (!shortcutsModal) return;
+        shortcutsModal.classList.remove('active');
+        shortcutsModal.setAttribute('aria-hidden', 'true');
+        if (shortcutsModalFocusReturn && typeof shortcutsModalFocusReturn.focus === 'function') {
+            shortcutsModalFocusReturn.focus();
+        }
+        shortcutsModalFocusReturn = null;
+    }
+
+    function toggleShortcutsModal() {
+        if (!shortcutsModal) return;
+        if (shortcutsModal.classList.contains('active')) {
+            closeShortcutsModal();
+        } else {
+            openShortcutsModal();
+        }
+    }
+
+    if (shortcutsBtn) shortcutsBtn.onclick = toggleShortcutsModal;
+    if (closeShortcutsModalBtn) closeShortcutsModalBtn.onclick = closeShortcutsModal;
+    if (saveShortcutsModalBtn) saveShortcutsModalBtn.onclick = closeShortcutsModal;
+
+    if (shortcutsModal) {
+        shortcutsModal.addEventListener('click', (e) => {
+            if (e.target === shortcutsModal) {
+                closeShortcutsModal();
+            }
+        });
     }
 
     // Theme Switcher

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -555,6 +555,7 @@
                     <button type="button" class="btn btn-gold" id="drawBtn" title="Shortcut: D">Offer Draw<span class="btn-shortcut">D</span></button>
                     <button type="button" class="btn btn-warning" id="pauseBtn" title="Shortcut: P">Pause<span class="btn-shortcut">P</span></button>
                     <button type="button" class="btn btn-danger" id="resignBtn" title="Shortcut: R">Resign<span class="btn-shortcut">R</span></button>
+                    <button type="button" class="btn btn-gold board-controls" id="shortcutsBtn" title="Keyboard Shortcuts (?)">⌨️ Shortcuts<span class="btn-shortcut">?</span></button>
                     <button type="button" class="btn btn-gold controls-grid-full" onclick="document.getElementById('rulebookModal').style.display='flex'">📖 Rulebook</button>
                 </div>
                 <a href="/" class="btn controls-grid-full" style="background: #2a1414; color: #ff6b6b;margin-top: 1rem;margin-bottom: 1.5rem; border: 1px solid #632424; text-decoration: none; text-align: center; display: block; line-height: 2.5;">EXIT TO HOME</a>
@@ -807,6 +808,56 @@
 
             <div style="margin-top: 24px; display: flex; justify-content: flex-end;">
                 <button type="button" class="btn btn-gold" id="saveThemeSettingsBtn">Close</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- ========== KEYBOARD SHORTCUTS MODAL ========== -->
+    <div class="theme-settings-modal shortcuts-modal" id="shortcutsModal" role="dialog" aria-modal="true" aria-labelledby="shortcuts-title" aria-hidden="true">
+        <div class="promo-dialog shortcuts-dialog">
+            <button type="button" class="modal-close-btn" id="closeShortcutsModalBtn" aria-label="Close modal">&times;</button>
+            <h2 class="shortcuts-modal-title" id="shortcuts-title">⌨️ Keyboard Shortcuts</h2>
+            
+            <div class="shortcuts-content">
+                <div class="shortcuts-section">
+                    <h3 class="shortcuts-section-title">Navigation</h3>
+                    <div class="shortcut-row">
+                        <span class="shortcut-desc">Navigate Move History (Prev / Next Move)</span>
+                        <span class="shortcut-keys"><kbd>←</kbd> / <kbd>→</kbd></span>
+                    </div>
+                    <div class="shortcut-row">
+                        <span class="shortcut-desc">Jump to Game Start / Latest Move</span>
+                        <span class="shortcut-keys"><kbd>↑</kbd> / <kbd>↓</kbd></span>
+                    </div>
+                </div>
+
+                <div class="shortcuts-section">
+                    <h3 class="shortcuts-section-title">Board Controls</h3>
+                    <div class="shortcut-row">
+                        <span class="shortcut-desc">Flip Board Orientation</span>
+                        <span class="shortcut-keys"><kbd>F</kbd></span>
+                    </div>
+                    <div class="shortcut-row">
+                        <span class="shortcut-desc">Focus SAN Quick Move Input Field</span>
+                        <span class="shortcut-keys"><kbd>M</kbd> or <kbd>/</kbd></span>
+                    </div>
+                </div>
+
+                <div class="shortcuts-section">
+                    <h3 class="shortcuts-section-title">System & Help</h3>
+                    <div class="shortcut-row">
+                        <span class="shortcut-desc">Toggle Keyboard Shortcuts Guide</span>
+                        <span class="shortcut-keys"><kbd>?</kbd></span>
+                    </div>
+                    <div class="shortcut-row">
+                        <span class="shortcut-desc">Close Modal / Cancel Selection</span>
+                        <span class="shortcut-keys"><kbd>Esc</kbd></span>
+                    </div>
+                </div>
+            </div>
+
+            <div style="margin-top: 24px; display: flex; justify-content: flex-end;">
+                <button type="button" class="btn btn-gold" id="saveShortcutsModalBtn">Close</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION

## Description
Closes #2567.

This PR adds an interactive **Keyboard Shortcuts Cheat Sheet Modal** to the Checkora Chess Board interface (`/play/`). While Checkora supports various keyboard bindings (move history navigation, board flipping, SAN input shortcuts, etc.), there was no visual indicator or helper guide informing users of these keybindings.

This modal improves overall usability, power-user workflow, and keyboard accessibility across mobile, tablet, and desktop viewports.

---

## Key Changes

### 1. HTML (`game/templates/game/board.html`)
- Added a shortcut trigger button (`⌨️ Shortcuts`) inside `.controls-grid` with `id="shortcutsBtn"` and `class="board-controls"`.
- Built the modal dialog (`#shortcutsModal`) styled with Checkora design tokens and accessibility ARIA attributes (`role="dialog"`, `aria-modal="true"`, `aria-labelledby="shortcuts-title"`).
- Grouped available keybindings by category (Navigation, Board Controls, System & Help) using `<kbd>` elements.

### 2. Styling (`game/static/game/css/board.css`)
- Styled `.shortcuts-modal` overlay with modern dark glassmorphism styling (`backdrop-filter: blur(10px)`).
- Styled `<kbd>` keycap badges with JetBrains Mono font, gold accent borders (`#f0c040`), dark background, and subtle drop shadows.
- Added smooth scale-up entrance animation (`@keyframes shortcutsModalFadeIn`).

### 3. JavaScript (`game/static/game/js/board.js`)
- Added global `keydown` listener listening for `?` (`Shift + /`) to open/toggle the cheat sheet modal, ignoring trigger events when typing inside `<input>`, `<textarea>`, or `<select>`.
- Added `M` or `/` key shortcut to focus the SAN Quick Move input field (`sanMoveInput`).
- Implemented focus trapping, backdrop click dismiss, `Esc` key press dismiss, and focus return to trigger element.
- Added state check to prevent game keyboard shortcut conflicts while modal is open.

---

## Acceptance Criteria Checklist

- [x] Trigger button (`⌨️ Shortcuts`) is visible in the board action toolbar / controls.
- [x] Pressing `?` (`Shift + /`) outside text input fields opens/closes the shortcuts modal.
- [x] Pressing `Esc` or clicking the backdrop overlay closes the modal.
- [x] Layout is responsive across screen sizes (mobile/tablet/desktop) and respects theme switching.
- [x] Accessibility: Screen readers properly announce the modal dialog via standard ARIA attributes.
- [x] No regression on existing keyboard shortcut listeners in `board.js`.