### PR TITLE
fix: resolve invisible hover text on auth pages in light mode (#2569)

### DIFF
--- a/game/static/game/css/auth.css
+++ b/game/static/game/css/auth.css
@@ -985,8 +985,8 @@ body.new-cyber-design .checkbox-checkmark {
     top: 50%; left: 0;
     transform: translateY(-50%);
     height: 18px; width: 18px;
-    background: #090c16;
-    border: 1px solid rgba(255, 255, 255, 0.15);
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
     border-radius: 4px;
     transition: all 0.2s ease;
 }
@@ -1017,7 +1017,7 @@ body.new-cyber-design .custom-checkbox-container input:checked ~ .checkbox-check
 }
 
 body.new-cyber-design .custom-checkbox-container:hover {
-    color: #ffffff;
+    color: var(--accent-gold);
 }
 
 body.new-cyber-design .modern-remember {
@@ -1069,8 +1069,8 @@ body.new-cyber-design .footer-link-highlight {
 }
 
 body.new-cyber-design .footer-link-highlight:hover {
-    color: #ffffff !important;
-    text-shadow: 0 0 8px rgba(0, 200, 255, 0.6);
+    color: var(--accent-gold) !important;
+    text-shadow: 0 0 8px rgba(240, 192, 64, 0.4); /* Optional: changed shadow to match gold */
 }
 
 body.new-cyber-design .footer-dot {


### PR DESCRIPTION
## Description
This PR fixes accessibility and theme contrast issues on the Sign In / Auth pages when viewing in Light Mode.
Previously, hover states and component backgrounds were using hardcoded dark/white colors, causing text to vanish on hover and elements to blend into the light background.

## Changes Made
- **Hover Visibility:** Updated `custom-checkbox-container:hover` and `.footer-link-highlight:hover` in `auth.css` to use `var(--accent-gold)` instead of `#ffffff`, ensuring text stays visible against light backgrounds.
- **Checkbox Styling:** Updated `.checkbox-checkmark` background and border in `auth.css` to use theme-aware variables (`var(--card-bg)` and `var(--border-color)`).
- **Checkmark Contrast:** Adjusted the checkmark icon border color to `var(--bg-primary)` to maintain high contrast against active states in both themes.
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #2569 

## Checklist
- [x] My code follows the project's style guidelines.
- [x] I have performed a self-review of my code.
- [x] Hover text remains clearly visible in both Light Mode and Dark Mode.
- [x] The checkbox and checkmark maintain appropriate contrast across themes.
- [x] Changes generate no new warnings or regressions.

## Screenshots (if applicable)

https://github.com/user-attachments/assets/7a7e17da-edae-452f-a669-920293adbd06



## Additional Notes
I'm a gssoc contributor.