### PR TITLE
feat: add Open Graph and Twitter Card meta tags to board page

### DIFF
--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -8,6 +8,15 @@
     <title>Play Chess | Checkora AI</title>
     <meta name="description" content="Challenge the Checkora AI engine. Play a professional game of chess with advanced AI analysis and move history.">
     <meta name="keywords" content="Play Chess, Checkora, AI Chess, Chess Analysis, Chess Game Online">
+    <meta property="og:title" content="Play Chess | Checkora AI">
+    <meta property="og:description" content="Challenge the Checkora AI engine. Play a professional game of chess with advanced AI analysis and move history.">
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="{% static 'game/checkora_icon_only.png' %}">
+    <meta property="og:site_name" content="Checkora">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Play Chess | Checkora AI">
+    <meta name="twitter:description" content="Challenge the Checkora AI engine with advanced minimax search.">
+    <meta name="twitter:image" content="{% static 'game/checkora_icon_only.png' %}">
     <link rel="icon" type="image/jpeg" href="{% static 'game/favicon.jpeg' %}">
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Outfit:wght@400;500;600;700&family=JetBrains+Mono:wght@400;700&display=swap" rel="stylesheet">
 


### PR DESCRIPTION
Adds og:title, og:description, og:type, og:image, og:site_name, and twitter:* meta tags to board.html for better social media link previews.