### PR TITLE
feat(css): add prefers-reduced-motion support for board animations

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -4113,3 +4113,19 @@ body.blindfold-mode .capture-ring {
 
 .board-container.flipped .top-player { order: 4; }
 .board-container.flipped .bottom-player { order: 2; }
+
+/* ============================================================
+   Accessibility: Reduced Motion Support
+   ============================================================ */
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+
+    .piece-animating {
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
Adds @media (prefers-reduced-motion: reduce) to disable piece animations, transitions, and scroll effects for users who prefer reduced motion. Improves accessibility compliance.