### PR TITLE
perf(models): add db_index on GameResult.played_at for query performance

### DIFF
--- a/game/models.py
+++ b/game/models.py
@@ -50,6 +50,9 @@ class GameResult(models.Model):
 
     class Meta:
         ordering = ["-played_at"]
+        indexes = [
+            models.Index(fields=["played_at"]),
+        ]
 
     def __str__(self):
         return f"{self.mode} | {self.winner} | {self.end_reason}"


### PR DESCRIPTION
Adds db_index=True to GameResult.played_at field. This field is used for ordering and filtering in match history views and stats queries. The index improves query performance for these common operations.