### PR TITLE
feat(testing): add minimum coverage thresholds to jest config

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,3 +1,11 @@
 module.exports = {
-  testEnvironment: "jest-environment-jsdom"
+  testEnvironment: "jest-environment-jsdom",
+  coverageThreshold: {
+    global: {
+      branches: 60,
+      functions: 60,
+      lines: 60,
+      statements: 60,
+    },
+  },
 };


### PR DESCRIPTION
Adds global coverage thresholds (60% branches, functions, lines, statements) to jest.config.cjs to enforce minimum test coverage standards.