### PR TITLE
fix: correct Discord invite link in CONTRIBUTING.md to match README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -337,7 +337,7 @@ Violations can be reported to the project maintainers.
 ## ❓ Questions?
 
 - Open an **issue** for project-related questions.
-- For GSSoC-specific questions, join our Discord community: [https://discord.gg/WfrpMuNZn](https://discord.gg/WfrpMuNZn)
+- For GSSoC-specific questions, join our Discord community: [https://discord.gg/DvW3xVXw8g](https://discord.gg/DvW3xVXw8g)
 <p align="right">
   <a href="#top">🔼 Back to top</a>
 </p>


### PR DESCRIPTION
Updates Discord invite link in CONTRIBUTING.md from WfrpMuNZn to DvW3xVXw8g to match the link used in README.md and pr-guardian.yml.