### PR TITLE
perf: add preconnect hint for chess piece image CDN

### DIFF
--- a/game/templates/game/landing.html
+++ b/game/templates/game/landing.html
@@ -32,6 +32,10 @@
       content="Checkora, Chess, AI Chess, Hybrid Chess Engine, Play Chess Online, Minimax Chess, Django Chess"
     />
 
+    <!-- Preconnect to chess piece image CDN for faster first paint -->
+    <link rel="preconnect" href="https://images.chesscomfiles.com" crossorigin />
+    <link rel="dns-prefetch" href="https://images.chesscomfiles.com" />
+
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://checkora.vercel.app/" />
     <meta property="og:title" content="Checkora | Play AI Chess Online" />


### PR DESCRIPTION
Adds link rel=preconnect and dns-prefetch for images.chesscomfiles.com to speed up chess piece image loading on the landing page.