### PR TITLE
feat(css): add prefers-reduced-motion support for landing page animations

### DIFF
--- a/game/static/game/css/landing.css
+++ b/game/static/game/css/landing.css
@@ -3587,3 +3587,13 @@ body.hide-native-cursor * {
     opacity:1;
     pointer-events:auto;
 }
+
+/* Reduced motion: disable animations for users who prefer it */
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+}


### PR DESCRIPTION
Adds @media (prefers-reduced-motion: reduce) to landing.css. Disables all animations, transitions, and scroll effects for users who have enabled reduced motion in their OS accessibility settings.