### PR TITLE
feat: add theme-color meta tag for mobile browser integration

### DIFF
--- a/game/templates/game/landing.html
+++ b/game/templates/game/landing.html
@@ -31,6 +31,7 @@
       name="keywords"
       content="Checkora, Chess, AI Chess, Hybrid Chess Engine, Play Chess Online, Minimax Chess, Django Chess"
     />
+    <meta name="theme-color" content="#0a1628" />
 
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://checkora.vercel.app/" />


### PR DESCRIPTION
Adds theme-color meta tag (#0a1628) to landing page. Enables mobile browsers to color-match the address bar and status bar to the site theme.