### PR TITLE
Add background blur for resign confirmation modal

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -704,6 +704,11 @@ body {
     grid-column: 2;
     grid-row: 1;
 }
+/* Blur board and surrounding game UI while confirmation dialog is open */
+.board-container:has(#board.confirm-open) {
+    filter: blur(5px);
+    transition: filter 200ms ease;
+}
 
 .board-outer {
     display: flex;
@@ -3715,6 +3720,9 @@ body.blindfold-mode .capture-ring {
         animation: none !important;
         transform: none !important;
     }
+    .board-container:has(#board.confirm-open) {
+    transition: none;
+}
 }
 
 


### PR DESCRIPTION
## Description

This PR adds a subtle background blur effect to the game interface when the Resign confirmation modal is displayed. The blur helps direct the user's focus to the confirmation dialog while keeping the modal sharp and fully interactive. The blur is removed immediately when the dialog is closed or the action is confirmed, providing a smoother and more modern user experience.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #2451

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

### Before
- The confirmation modal appears with only a dark overlay while the game board and surrounding interface remain clearly visible.

### After
- The game board and surrounding interface are subtly blurred when the confirmation modal is open.
- The confirmation dialog remains sharp and fully interactive.
- The blur is removed immediately after the modal is closed or the action is confirmed.

<img width="1288" height="817" alt="Screenshot 2026-08-08 at 2 36 03 AM" src="https://github.com/user-attachments/assets/3391610e-8c9e-410d-8bba-8ee3ab71180d" />


## Additional Notes

- Implemented using the existing `confirm-open` state.
- Applied the blur effect through CSS without introducing additional JavaScript logic.
- Added support for `prefers-reduced-motion` by disabling the blur transition for users who prefer reduced motion.