### PR TITLE
fix: cursor dropdown reset/unresponsive bug on auth pages

### DIFF
--- a/game/templates/game/login.html
+++ b/game/templates/game/login.html
@@ -11,9 +11,11 @@
     <link rel="stylesheet" href="{% static 'game/css/auth.css' %}?v=15">
     <link rel="icon" type="image/jpeg" href="{% static 'game/favicon.jpeg' %}">
     <link rel="stylesheet" href="{% static 'game/css/toast.css' %}">
+    <link rel="stylesheet" href="{% static 'game/css/cursor.css' %}">
 </head>
 <body class="login-page new-cyber-design">
     <!-- Animated background grid effect -->
+    <div class="cursor"></div>
     <div class="bg-grid-overlay"></div>
 
     {% include 'game/includes/navbar.html' %}
@@ -86,6 +88,7 @@
     <script src="{% static 'game/js/auth.js' %}?v=15"></script>
     <script src="{% static 'game/js/toast.js' %}"></script>
     <script src="{% static 'game/js/theme.js' %}?v=1"></script>
+    <script src="{% static 'game/js/cursor.js' %}"></script>
 
 </body>
 </html>

--- a/game/templates/game/register.html
+++ b/game/templates/game/register.html
@@ -14,8 +14,10 @@
       href="{% static 'game/favicon.jpeg' %}"
     />
       <link rel="stylesheet" href="{% static 'game/css/toast.css' %}">
+      <link rel="stylesheet" href="{% static 'game/css/cursor.css' %}">
 </head>
 <body>
+    <div class="cursor"></div>
     {% include 'game/includes/navbar.html' %}
 
     <main class="auth-layout">
@@ -115,5 +117,6 @@
         }
     </script>
     <script src="{% static 'game/js/theme.js' %}?v=1"></script>
+    <script src="{% static 'game/js/cursor.js' %}"></script>
 </body>
 </html>

--- a/game/templates/game/verify_otp.html
+++ b/game/templates/game/verify_otp.html
@@ -60,8 +60,10 @@
             text-decoration: underline;
         }
     </style>
+    <link rel="stylesheet" href="{% static 'game/css/cursor.css' %}">
 </head>
 <body>
+    <div class="cursor"></div>
     {% include 'game/includes/navbar.html' %}
 
     <div class="header header--with-navbar">
@@ -119,6 +121,7 @@
     updateTimer();
 </script>
 <script src="{% static 'game/js/theme.js' %}?v=1"></script>
+<script src="{% static 'game/js/cursor.js' %}"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Description

Fixes the cursor dropdown so it works correctly on the Sign In, Register, 
and Verify OTP pages. Auth pages included the shared navbar with the 
cursor dropdown, but were missing `cursor.css`, `cursor.js`, and the 
required `.cursor` div — without that div, `cursor.js` hits its early-return 
guard and exits, leaving the dropdown non-functional. This was the shared 
root cause behind two bugs: the selected cursor style resetting to "Default" 
when navigating away from the landing page, and the dropdown being completely 
unresponsive on the auth pages themselves.
Added the same three pieces that `landing.html` and `board.html` already have 
to `login.html`, `register.html`, and `verify_otp.html`:
- `cursor.css` link in `<head>`
- `<div class="cursor"></div>` as the first element in `<body>`
- `cursor.js` script at the end of `<body>`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue

Fixes #2613 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)
<img width="1852" height="795" alt="image" src="https://github.com/user-attachments/assets/54213d5d-9949-4f6d-9487-ddc94ceb0f3c" />



## Additional Notes

This is a minimal, additive fix — no existing logic was changed, only the 
missing includes/markup were added to bring these three pages in line with 
`landing.html` and `board.html`.
