### PR TITLE
feat(ui): add move timer countdown progress bar and low-time visual alert

### DIFF
--- a/game/static/game/css/board.css
+++ b/game/static/game/css/board.css
@@ -1828,6 +1828,62 @@ body {
 .clock.white .label { color: #ddd; }
 .clock.black .label { color: #aaa; }
 
+/* Move Timer Progress Bar */
+.clock {
+    position: relative;
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: center;
+}
+
+.clock-timer-bar-wrap {
+    width: 100%;
+    height: 4px;
+    background: rgba(255, 255, 255, 0.12);
+    border-radius: 999px;
+    overflow: hidden;
+    margin-top: 4px;
+    position: relative;
+}
+
+.clock-timer-bar-fill {
+    height: 100%;
+    width: 100%;
+    background: linear-gradient(90deg, #10b981, #22c55e);
+    border-radius: 999px;
+    transition: width 0.4s linear, background-color 0.4s ease, box-shadow 0.4s ease;
+}
+
+/* Timer Bar Warning State (<= 30s) */
+.clock-timer-bar-fill.timer-warning {
+    background: linear-gradient(90deg, #f59e0b, #eab308);
+    box-shadow: 0 0 6px rgba(245, 158, 11, 0.5);
+}
+
+/* Timer Bar Critical State (<= 10s) */
+.clock-timer-bar-fill.timer-critical {
+    background: linear-gradient(90deg, #ef4444, #dc2626);
+    box-shadow: 0 0 10px rgba(239, 68, 68, 0.8);
+    animation: timerPulse 0.8s ease-in-out infinite alternate;
+}
+
+@keyframes timerPulse {
+    0% {
+        opacity: 0.75;
+        box-shadow: 0 0 4px rgba(239, 68, 68, 0.5);
+    }
+    100% {
+        opacity: 1;
+        box-shadow: 0 0 12px rgba(239, 68, 68, 1);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .clock-timer-bar-fill.timer-critical {
+        animation: none;
+    }
+}
+
 /* Thinking dots animation */
 .thinking-dots {
     display: inline-flex;

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -368,6 +368,8 @@
 
     let whiteTime = 0;
     let blackTime = 0;
+    let maxWhiteTime = 0;
+    let maxBlackTime = 0;
     let selectedMins = 10;
     let selectedIncrement = 0;
     let paused = false;
@@ -3915,7 +3917,24 @@ function updateStepperUI() {
         const bYou = document.getElementById('blackYouTag');
         if (wYou) wYou.style.display = (gameMode === 'ai' && playerColor === 'white') ? 'inline' : 'none';
         if (bYou) bYou.style.display = (gameMode === 'ai' && playerColor === 'black') ? 'inline' : 'none';
+        
+        if (whiteTime > maxWhiteTime) maxWhiteTime = whiteTime;
+        if (blackTime > maxBlackTime) maxBlackTime = blackTime;
+
+        updateClockTimerBar('whiteTimerBarFill', whiteTime, maxWhiteTime);
+        updateClockTimerBar('blackTimerBarFill', blackTime, maxBlackTime);
+
         updateThinkingDots();
+    }
+
+    function updateClockTimerBar(barFillId, currentTime, maxTime) {
+        const barFill = document.getElementById(barFillId);
+        if (!barFill) return;
+        const total = maxTime > 0 ? maxTime : (selectedMins * 60 || 600);
+        const pct = Math.min(100, Math.max(0, (currentTime / total) * 100));
+        barFill.style.width = `${pct}%`;
+        barFill.classList.toggle('timer-warning', currentTime <= 30 && currentTime > 10);
+        barFill.classList.toggle('timer-critical', currentTime <= 10 && currentTime > 0);
     }
 
             /* ==========================================================

--- a/game/static/game/js/board.js
+++ b/game/static/game/js/board.js
@@ -1573,6 +1573,8 @@
         turn = data.current_turn;
         whiteTime = data.white_time;
         blackTime = data.black_time;
+        maxWhiteTime = Math.max(whiteTime || 0, Math.round(selectedMins * 60));
+        maxBlackTime = Math.max(blackTime || 0, Math.round(selectedMins * 60));
         paused = data.paused;
 
         gameMode = data.mode || 'pvp';
@@ -3918,8 +3920,9 @@ function updateStepperUI() {
         if (wYou) wYou.style.display = (gameMode === 'ai' && playerColor === 'white') ? 'inline' : 'none';
         if (bYou) bYou.style.display = (gameMode === 'ai' && playerColor === 'black') ? 'inline' : 'none';
         
-        if (whiteTime > maxWhiteTime) maxWhiteTime = whiteTime;
-        if (blackTime > maxBlackTime) maxBlackTime = blackTime;
+        const sessionMaxTime = Math.round(selectedMins * 60) || 600;
+        if (whiteTime > maxWhiteTime || maxWhiteTime === 0) maxWhiteTime = Math.max(whiteTime, sessionMaxTime);
+        if (blackTime > maxBlackTime || maxBlackTime === 0) maxBlackTime = Math.max(blackTime, sessionMaxTime);
 
         updateClockTimerBar('whiteTimerBarFill', whiteTime, maxWhiteTime);
         updateClockTimerBar('blackTimerBarFill', blackTime, maxBlackTime);
@@ -4215,6 +4218,8 @@ function updateStepperUI() {
 
     async function startNewGame(mode, pColor = 'white', difficulty = 'medium', fen = null, timeLimitMins = null, overrideNames = null, isPuzzle = false) {
         evaluationCache = {};
+        maxWhiteTime = 0;
+        maxBlackTime = 0;
         if (!isPuzzle) {
             dailyPuzzleMode = false;
             currentPuzzle = null;
@@ -4352,6 +4357,8 @@ function updateStepperUI() {
         gameOver = false;
         whiteAlertFired = false;
         blackAlertFired = false;
+        maxWhiteTime = Math.max(d.white_time || 0, Math.round(selectedMins * 60));
+        maxBlackTime = Math.max(d.black_time || 0, Math.round(selectedMins * 60));
         incrementGameCounter();
 
         gameStartTime = Date.now();

--- a/game/templates/game/board.html
+++ b/game/templates/game/board.html
@@ -394,6 +394,9 @@
                 </div>
                 <div id="blackClock" class="clock black">
                     <span class="time" id="blackTime">10:00</span>
+                    <div class="clock-timer-bar-wrap" aria-hidden="true">
+                        <div class="clock-timer-bar-fill" id="blackTimerBarFill" style="width: 100%;"></div>
+                    </div>
                 </div>
             </div>
 
@@ -453,6 +456,9 @@
                 </div>
                 <div id="whiteClock" class="clock white active">
                     <span class="time" id="whiteTime">10:00</span>
+                    <div class="clock-timer-bar-wrap" aria-hidden="true">
+                        <div class="clock-timer-bar-fill" id="whiteTimerBarFill" style="width: 100%;"></div>
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION

Introduced a dynamic **Move Timer Countdown Progress Bar** and **Low-Time Visual Alert Animation** for player clocks on the game board screen:

1. **Visual Countdown Progress Bar**: Added `.clock-timer-bar-wrap` and `.clock-timer-bar-fill` inside player clock containers (`#whiteClock` and `#blackClock`). The progress bar smoothly shrinks in real-time as the turn countdown progresses.
2. **Color State Transitions**:
   - **Normal (> 30s)**: Vibrant green gradient (`#10b981` to `#22c55e`).
   - **Warning (10s – 30s)**: Warm amber gradient (`#f59e0b` to `#eab308`).
   - **Critical (<= 10s)**: Glowing crimson red gradient (`#ef4444` to `#dc2626`) with a soft pulsing keyframe animation (`@keyframes timerPulse`).
3. **Accessibility**: Integrated `@media (prefers-reduced-motion: reduce)` to disable pulsing keyframe animations for users who prefer reduced motion.

---

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

---

## Related Issue

Fixes #2616 

---

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally

