### PR TITLE
fix:forgot password invisible on light mode and Back to Home button hidden behind nav bar

### DIFF
--- a/game/static/game/css/auth.css
+++ b/game/static/game/css/auth.css
@@ -284,7 +284,7 @@ body {
 .auth-layout {
     flex: 1;
     display: flex;
-    justify-content: center;
+    justify-content: safe center;
     align-items: center;
 
     width: 100%;
@@ -570,7 +570,7 @@ body {
     position: fixed;
     top: 20px;
     left: 20px;
-    z-index: 1000;
+    z-index: 10010;
     color: #f0c040;
     text-decoration: none;
     font-size: 1.2rem;
@@ -865,6 +865,14 @@ body.login-page .helptext {
     border-color: var(--accent-gold);
     color: var(--text-primary);
     box-shadow: 0 14px 28px rgba(0, 0, 0, 0.12);
+}
+
+[data-theme="light"] body.new-cyber-design .forgot-link {
+    color: var(--text-secondary) !important;
+}
+
+[data-theme="light"] body.new-cyber-design .forgot-link:hover {
+    color: var(--accent-gold) !important;
 }
 
 body.new-cyber-design .auth-home-link {

--- a/game/templates/game/login.html
+++ b/game/templates/game/login.html
@@ -21,70 +21,69 @@
     {% include 'game/includes/navbar.html' %}
 
     <main class="auth-layout">
-    <div class="auth-content">
-
         <a href="{% url 'landing' %}" class="auth-home-link" aria-label="Back to home">
-            <span aria-hidden="true" class="auth-home-link__arrow">&larr;</span>
+            <span aria-hidden="true" class="auth-home-link__arrow">←</span>
             <span>Back to Home</span>
         </a>
 
-        <div class="header header--with-navbar">
-            <p class="login-subtitle">Welcome back! Sign in to continue</p>
-        </div>
+        <div class="auth-content">
 
-        <div class="auth-card modern-card">
-            <!-- Top glowing neon line decoration -->
-            <div class="card-glow-line"></div>
-
-            <form method="POST">
-                {% csrf_token %}
-
-                {% include 'game/includes/messages.html' %}
-
-                {% if form.non_field_errors %}
-                    {{ form.non_field_errors }}
-                {% endif %}
-
-                {% for field in form %}
-                    <div class="form-group modern-group">
-                        <label for="{{ field.id_for_label }}">{{ field.label }}</label>
-                        <div class="input-container-glow">
-                            {{ field }}
-                        </div>
-                        {% if field.errors %}
-                            {{ field.errors }}
-                        {% endif %}
-                    </div>
-                {% endfor %}
-
-                <div class="remember-me modern-remember">
-                    <label class="custom-checkbox-container">
-                        <input type="checkbox" name="remember_me">
-                        <span class="checkbox-checkmark"></span>
-                        <span class="label-text">Remember Me</span>
-                    </label>
-                </div>
-
-                <button type="submit" class="btn btn-gold modern-btn">
-                    Sign In
-                </button>
-            </form>
-
-            <div class="auth-footer modern-footer">
-                <div class="footer-links-row">
-                    <a href="{% url 'register' %}" class="footer-link-highlight">
-                        Create Account
-                    </a>
-                    <span class="footer-dot"></span>
-                    <a href="{% url 'password_reset' %}" class="forgot-link">
-                        Forgot Password?
-                    </a>
-                </div>
+            <div class="header header--with-navbar">
+                <p class="login-subtitle">Welcome back! Sign in to continue</p>
             </div>
 
-        </div>
-    </div>
-</main>
+            <div class="auth-card modern-card">
+            <!-- Top glowing neon line decoration -->
+                <div class="card-glow-line"></div>
+
+                <form method="POST">
+                    {% csrf_token %}
+
+                    {% include 'game/includes/messages.html' %}
+
+                    {% if form.non_field_errors %}
+                        {{ form.non_field_errors }}
+                    {% endif %}
+
+                    {% for field in form %}
+                        <div class="form-group modern-group">
+                            <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+                            <div class="input-container-glow">
+                                {{ field }}
+                            </div>
+                            {% if field.errors %}
+                                {{ field.errors }}
+                            {% endif %}
+                        </div>
+                    {% endfor %}
+
+                    <div class="remember-me modern-remember">
+                        <label class="custom-checkbox-container">
+                            <input type="checkbox" name="remember_me">
+                            <span class="checkbox-checkmark"></span>
+                            <span class="label-text">Remember Me</span>
+                        </label>
+                    </div>
+
+                    <button type="submit" class="btn btn-gold modern-btn">
+                        Sign In
+                    </button>
+                </form>
+
+                <div class="auth-footer modern-footer">
+                    <div class="footer-links-row">
+                        <a href="{% url 'register' %}" class="footer-link-highlight">
+                            Create Account
+                        </a>
+                        <span class="footer-dot"></span>
+                        <a href="{% url 'password_reset' %}" class="forgot-link">
+                            Forgot Password?
+                        </a>
+                    </div>
+                </div>
+            </div>
+       </div>
+    </main>
     <script src="{% static 'game/js/auth.js' %}?v=15"></script>
     <script src="{% static 'game/js/toast.js' %}"></script>
     <script src="{% static 'game/js/theme.js' %}?v=1"></script>


### PR DESCRIPTION
## Description
Fixes two visibility bugs on the Sign In page (and related auth pages):

1. **Forgot Password link invisible in light mode** — the link used a very pale gold color that blended into the white card background in light mode, making it nearly impossible to read.
2. **Back to Home button hidden behind navbar** — `.auth-layout` vertically centered its content (`.auth-content`, which starts with the Back to Home pill) within the space below the sticky navbar. When that content was taller than the available space, flexbox centered it by pushing the top portion off-screen above — since the page can't scroll above position 0, the clipped top (the Back to Home pill) rendered behind the sticky navbar with only a small sliver visible.

Changes made:
- Fixed the Forgot Password link color/contrast for light mode.
- Updated `.auth-layout` to use `justify-content: safe center` instead of `justify-content: center`, so content still centers normally when it fits, but falls back to start-alignment instead of clipping when it overflows.
- In `login.html`, moved the "Back to Home" link out of `.auth-content` and placed it directly under `.auth-layout` instead, since nesting it inside `.auth-content` was contributing to the centering/clipping issue. Also cleaned up and reformatted the surrounding markup in `login.html` for consistency.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issue:

Fixes #2618 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

## Screenshots (if applicable):
<img width="1659" height="689" alt="image" src="https://github.com/user-attachments/assets/6e857fbd-aa26-4596-b703-43a1ba315aa8" />
<img width="1467" height="674" alt="image" src="https://github.com/user-attachments/assets/914d7680-b5b0-40d4-b04e-24a3e741db1c" />


## Additional Notes:
The Back to Home fix has two parts: a shared CSS change in `auth.css` (`.auth-layout`) that benefits all three auth pages (login, register, verify_otp), plus a markup restructure specific to `login.html` where the Back to Home link's placement inside `.auth-content` was part of the root cause. `register.html` and `verify_otp.html` were not restructured since they weren't exhibiting the same nesting issue — worth double-checking those two pages still render correctly since they share `.auth-layout`.