### PR TITLE
ci: add npm caching and unify pip cache keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,9 +157,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: pip-lint-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
+          key: pip-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
           restore-keys: |
-            pip-lint-${{ runner.os }}-
+            pip-${{ runner.os }}-
 
       - name: 📥 Install flake8
         run: pip install flake8 flake8-django
@@ -195,6 +195,14 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
+
+      - name: 📦 Cache npm dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-
 
       - name: 📦 Install dependencies
         run: npm ci
@@ -372,9 +380,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: pip-migrate-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
+          key: pip-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
           restore-keys: |
-            pip-migrate-${{ runner.os }}-
+            pip-${{ runner.os }}-
 
       - name: 📥 Install dependencies
         run: |
@@ -416,9 +424,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: pip-audit-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
+          key: pip-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
           restore-keys: |
-            pip-audit-${{ runner.os }}-
+            pip-${{ runner.os }}-
 
       - name: 📥 Install pip-audit
         run: pip install pip-audit
@@ -461,9 +469,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: pip-sast-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
+          key: pip-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
           restore-keys: |
-            pip-sast-${{ runner.os }}-
+            pip-${{ runner.os }}-
 
       - name: Install Bandit
         run: pip install bandit


### PR DESCRIPTION
## Summary
Adds dependency caching to `ci.yml` to reduce CI execution time, per the plan in #2627.

## Related Issue
Fixes #2627

## Changes

**Phase 1 — npm caching for `js-tests`**
- Added an `actions/cache@v4` step for `~/.npm`, keyed on `hashFiles('package-lock.json')` with a `runner.os` restore-key fallback, matching the existing pip cache pattern in this file.
- `js-tests` was the only job with zero caching before this change.

**Phase 2 — unified pip cache keys**
- Replaced the fragmented per-job pip cache key prefixes (`pip-lint-`, `pip-migrate-`, `pip-audit-`, `pip-sast-`) with a single shared key: `pip-${{ runner.os }}-${{ hashFiles('requirements.txt') }}`.
- `test` and `selenium-tests` already used this shared key, so `lint`, `migrate-check`, `security`, and `sast` now reuse the same cache instead of downloading their own copies of the same dependencies.
- Cache paths (`~/.cache/pip`) and install commands are unchanged.

## Verification
- Cold run: cache steps report a miss on the first push, then save.
- Warm run: cache steps report a hit and restore on the follow-up push.
- No job failures introduced by restored caches; `npm ci` and `pip install` behave the same as before.

## Out of scope
- The `static-` cache in `selenium-tests` is untouched.
- Install commands in `lint`, `security`, and `sast` are unchanged even though they only install a single tool each — the shared pip cache still helps via reused wheels.