### PR TITLE
devops: add automated security checks (#2630)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  # Python dependencies (requirements.txt)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "type:security"
+    commit-message:
+      prefix: "chore(deps)"
+
+  # JavaScript dependencies (package.json / package-lock.json)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "type:security"
+    commit-message:
+      prefix: "chore(deps)"
+
+  # GitHub Actions versions used in workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "type:security"
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,13 +425,29 @@ jobs:
 
       - name: 🔒 Run pip-audit security scan
         run: |
+          set -o pipefail
+
           pip-audit \
             --requirement requirements.txt \
             --format=columns \
-            --progress-spinner=off
+            --progress-spinner=off | tee pip-audit-report.txt
+
+          echo "## 🔒 Security Scan Results (pip-audit)" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat pip-audit-report.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
         # Non-zero exit = vulnerabilities found → fails CI
         # Remove the next line if you want warnings-only mode:
         continue-on-error: false
+
+      - name: 📤 Upload pip-audit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pip-audit-report-${{ github.run_id }}
+          path: pip-audit-report.txt
+          if-no-files-found: ignore
+          retention-days: 7
 
 # ───────────────────────────────────────────────────────────────────
 # JOB 6 — SAST (Bandit)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,6 +234,21 @@ python manage.py test game.selenium_tests --verbosity=2
 ```bash
 python manage.py makemigrations --check --dry-run
 ```
+
+### Security Checks
+```bash
+# Python dependency vulnerabilities
+pip install pip-audit
+pip-audit --requirement requirements.txt
+
+# Static analysis (flags insecure code patterns)
+pip install bandit
+bandit -r . --exclude ./.github
+
+# JavaScript dependency vulnerabilities
+npm audit --audit-level=high
+```
+If any of these fail, see [SECURITY.md](SECURITY.md#resolving-ci-security-findings) for how to resolve the finding.
 <p align="right">
   <a href="#top">🔼 Back to top</a>
 </p>
@@ -295,8 +310,11 @@ Every PR and push to `main` runs the following automated checks via GitHub Actio
 | 🗄️ **Migration Check** | `python manage.py migrate --check`  | ✅ Yes                 |
 | 🔒 **Security Scan**   | `pip-audit` on `requirements.txt`   | ✅ Yes                 |
 | 🛡️ **SAST (Bandit)**  | Static security analysis            | ✅ Yes                 |
+| 🃏 **JS Tests**        | `npm audit` + Jest                  | ✅ Yes                 |
 | 🖥️ **Selenium Tests**  | End-to-end browser tests            | ✅ Yes                 |
 | 🌐 **Deploy**          | Vercel production deploy            | 🔁 Push to `main` only |
+
+Outside of PR checks, **Dependabot** opens weekly PRs to patch vulnerable Python, npm, and GitHub Actions dependencies, and **CodeQL** (GitHub's default setup) scans the repo for common vulnerability patterns. See [SECURITY.md](SECURITY.md#resolving-ci-security-findings) for how to resolve a failing security check.
 
 All checks must pass before a maintainer can merge your PR.
 <p align="right">

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,3 +19,15 @@ To privately report a security vulnerability, please send an email to **ravi5258
 
 - **Acknowledgment:** You will receive a response acknowledging receipt of your report within 48 hours.
 - **Remediation & Disclosure:** We aim to provide an expected timeline for remediation and potential coordinated public disclosure within 5 business days of acknowledgment.
+
+## Resolving CI Security Findings
+
+Our CI pipeline runs three automated checks on every PR: **pip-audit** (dependency vulnerabilities), **Bandit** (static code analysis), and **npm audit** (JavaScript dependency vulnerabilities). GitHub's **CodeQL** default setup also scans the repository automatically. If any of these fail on your PR:
+
+1. **Read the failure output.** Both `pip-audit` and Bandit publish a step summary on the Actions run page, and their full reports are uploaded as downloadable artifacts — you don't need to dig through raw logs.
+2. **Dependency vulnerabilities (pip-audit / npm audit):** Update the flagged package to the patched version named in the report, then re-run the relevant local check below before pushing again.
+3. **Static analysis findings (Bandit):** Fix the flagged code pattern directly. If you believe a finding is a false positive, explain why in your PR description rather than silencing it — a maintainer will confirm before merge.
+4. **Dependabot PRs:** Dependabot opens its own PRs to bump vulnerable dependencies automatically. Review and merge these promptly to keep `main` patched; don't close them without a reason.
+5. Still stuck? Ask in the [Discord server](https://discord.gg/WfrpMuNZn) or comment on your PR — a maintainer can help triage.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md#-local-pre-pr-checks) for the exact commands to reproduce these checks locally before pushing.


### PR DESCRIPTION
## Summary
Adds automated security checks to the CI pipeline and documents how contributors should resolve findings, per the plan in #2630.

## Related Issue
Fixes #2630

## Changes

**Task 1 — Dependabot**
- Added `.github/dependabot.yml` with weekly update schedules for `pip`, `npm`, and `github-actions` ecosystems, so vulnerable dependencies get automated patch PRs instead of drifting unnoticed.

**Task 2 — visible pip-audit reporting**
- The `security` job's `pip-audit` step now writes its output to a step summary on the Actions run page and uploads the full report as a downloadable artifact (`pip-audit-report-<run_id>`), matching how the Bandit job already reports.
- Previously a failure only showed as a bare exit code, so a contributor had to dig through raw logs to find the actual vulnerability.

**Task 3 — CodeQL**
- This is a repo setting, not code: **CodeQL default setup** needs to be enabled under Settings → Code security and analysis. Flagging here since it can't ship in this diff — a maintainer with admin access will need to toggle it.

**Phase 2 — documentation**
- `SECURITY.md`: new "Resolving CI Security Findings" section explaining how to read pip-audit/Bandit/npm-audit failures, and how to handle Dependabot PRs.
- `CONTRIBUTING.md`: added local commands to run pip-audit, Bandit, and npm audit before pushing, plus updated the CI/CD pipeline table with the JS-tests row and a note on Dependabot/CodeQL.

## Out of scope
- No changes to Bandit or npm audit configuration — both already run and report correctly; only pip-audit needed the reporting upgrade.
- CodeQL enablement itself (repo setting, see Task 3 above).
