### PR TITLE
fix: improve engine subprocess diagnostics (#2615)

### DIFF
--- a/game/engine.py
+++ b/game/engine.py
@@ -18,6 +18,7 @@ is chosen at random to add variety.
 
 import os
 import contextlib
+import logging
 import random
 import subprocess
 import json
@@ -26,6 +27,9 @@ import time
 import threading
 import uuid
 from datetime import date
+
+
+logger = logging.getLogger(__name__)
 
 
 class ChessGame:
@@ -616,17 +620,40 @@ DP cache is intentionally excluded to save cookie space."""
                 timeout_secs = getattr(
                     self, "_analysis_timeout", self.ANALYSIS_TIMEOUT_SECONDS
                 )
-                stdout, _ = proc.communicate(input=command, timeout=timeout_secs)
+                stdout, stderr = proc.communicate(
+                    input=command, timeout=timeout_secs
+                )
+                if stderr:
+                    logger.warning(
+                        "Chess engine wrote to stderr while handling %s: %s",
+                        command.split(maxsplit=1)[0] if command else "<empty>",
+                        stderr.strip(),
+                    )
                 return stdout.strip()
-            except subprocess.TimeoutExpired:
+            except subprocess.TimeoutExpired as exc:
                 if proc:
                     try:
                         proc.kill()
-                        proc.communicate()
+                        _, stderr = proc.communicate()
+                        stderr = stderr or getattr(exc, "stderr", None)
+                        if stderr:
+                            logger.warning(
+                                "Chess engine timed out while handling %s. "
+                                "stderr: %s",
+                                command.split(maxsplit=1)[0]
+                                if command else "<empty>",
+                                stderr.strip()
+                                if isinstance(stderr, str) else stderr,
+                            )
                     except Exception:
                         pass
                 return None
-            except OSError:
+            except OSError as exc:
+                logger.warning(
+                    "Failed to start chess engine while handling %s: %s",
+                    command.split(maxsplit=1)[0] if command else "<empty>",
+                    exc,
+                )
                 return None
 
         try:

--- a/game/test_persistent_engine.py
+++ b/game/test_persistent_engine.py
@@ -1,6 +1,7 @@
 import os
 import time
 import tempfile
+import subprocess
 from unittest import mock
 from django.test import TestCase
 from game.engine import ChessGame
@@ -225,3 +226,81 @@ class PersistentEngineTest(TestCase):
                 self.assertFalse(os.path.exists(lock_path),
                                  "Stale lock file should be deleted")
                 self.assertEqual(mock_client.call_count, 2)
+
+    def test_stateless_engine_logs_stderr_without_changing_response(self):
+        """Engine stderr is logged while stdout behavior is preserved."""
+        game = ChessGame()
+        game._analysis_timeout = 1
+
+        engine_proc = mock.MagicMock()
+        engine_proc.communicate.return_value = (
+            "STATUS OK\n",
+            "diagnostic details\n",
+        )
+
+        with (
+            mock.patch.object(game, '_resolve_engine_path',
+                              return_value='engine-binary'),
+            mock.patch('game.engine.os.path.exists', return_value=False),
+            mock.patch('game.engine.os.open', side_effect=OSError),
+            mock.patch('game.engine.time.sleep', return_value=None),
+            mock.patch('game.engine.subprocess.Popen',
+                       return_value=engine_proc),
+            self.assertLogs('game.engine', level='WARNING') as logs,
+        ):
+            resp = game._call_engine("STATUS")
+
+        self.assertEqual(resp, "STATUS OK")
+        self.assertTrue(
+            any("diagnostic details" in message for message in logs.output)
+        )
+
+    def test_stateless_engine_timeout_kills_process_and_logs_stderr(self):
+        """Timeout handling kills the process and logs drained stderr."""
+        game = ChessGame()
+        game._analysis_timeout = 1
+
+        engine_proc = mock.MagicMock()
+        engine_proc.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd='engine-binary', timeout=1),
+            ("", "timeout diagnostics\n"),
+        ]
+
+        with (
+            mock.patch.object(game, '_resolve_engine_path',
+                              return_value='engine-binary'),
+            mock.patch('game.engine.os.path.exists', return_value=False),
+            mock.patch('game.engine.os.open', side_effect=OSError),
+            mock.patch('game.engine.time.sleep', return_value=None),
+            mock.patch('game.engine.subprocess.Popen',
+                       return_value=engine_proc),
+            self.assertLogs('game.engine', level='WARNING') as logs,
+        ):
+            resp = game._call_engine("STATUS")
+
+        self.assertIsNone(resp)
+        engine_proc.kill.assert_called_once()
+        self.assertTrue(
+            any("timeout diagnostics" in message for message in logs.output)
+        )
+
+    def test_stateless_engine_start_failure_is_logged(self):
+        """Engine start failures are logged without surfacing raw errors."""
+        game = ChessGame()
+
+        with (
+            mock.patch.object(game, '_resolve_engine_path',
+                              return_value='engine-binary'),
+            mock.patch('game.engine.os.path.exists', return_value=False),
+            mock.patch('game.engine.os.open', side_effect=OSError),
+            mock.patch('game.engine.time.sleep', return_value=None),
+            mock.patch('game.engine.subprocess.Popen',
+                       side_effect=OSError("missing binary")),
+            self.assertLogs('game.engine', level='WARNING') as logs,
+        ):
+            resp = game._call_engine("STATUS")
+
+        self.assertIsNone(resp)
+        self.assertTrue(
+            any("missing binary" in message for message in logs.output)
+        )


### PR DESCRIPTION
## Description

Fixes #2615

This PR improves engine subprocess diagnostics by capturing stderr from stateless engine calls, logging useful diagnostic output safely, and preserving the existing stdout/fallback behavior.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes

- Added a `game.engine` logger.
- Captured engine stderr from `proc.communicate()`.
- Logged stderr when the engine writes diagnostic output.
- Logged stderr after timeout cleanup when available.
- Logged engine start failures without exposing raw errors to users.
- Added tests for stderr logging, timeout cleanup, and start failure logging.

## Related Issue

Fixes #2615

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally

## Validation

- flake8 passed
- Django system check passed
- Persistent engine tests passed: 10/10
- Related backend tests passed: 18/18
- Jest frontend tests passed: 65/65
- Full Django test suite passed: 350 tests, 1 skipped
- collectstatic passed
- C++ engine compile passed

## Additional Notes

This is a scoped backend reliability improvement. It does not change the engine protocol, chess rules, frontend UI, or gameplay behavior.

`npm run build` was not applicable because the repository does not define a build script.