### PR TITLE
feat: add auto-save draft functionality for forms

### DIFF
--- a/game/templates/game/forum_new.html
+++ b/game/templates/game/forum_new.html
@@ -1,6 +1,7 @@
 {% load static %}
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -8,18 +9,18 @@
     <link rel="icon" type="image/jpeg" href="{% static 'game/favicon.jpeg' %}">
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght=400;700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght=400;500;600;700&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap"
+        rel="stylesheet">
     <link rel="stylesheet" href="{% static 'game/css/landing.css' %}">
     <link rel="stylesheet" href="{% static 'game/css/board.css' %}">
     <link rel="stylesheet" href="{% static 'game/css/forum.css' %}">
 </head>
+
 <body>
     <nav class="forum-navbar">
         <div class="nav-left">
             <a href="{% url 'landing' %}" class="logo-link">
-                <img src="{% static 'game/checkora_icon_only.png' %}"
-                    alt="Checkora Logo"
-                    class="logo-img">
+                <img src="{% static 'game/checkora_icon_only.png' %}" alt="Checkora Logo" class="logo-img">
 
                 <span class="logo-text">
                     CHECK<span class="logo-accent">ORA</span>
@@ -62,33 +63,126 @@
         <div class="forum-new-card">
             <h1 class="forum-detail-title">Start a New Discussion</h1>
 
-            <form method="post" class="forum-new-form">
+            <form method="post" class="forum-new-form" id="new-discussion-form">
                 {% csrf_token %}
                 <div class="forum-form-group">
                     <label for="{{ form.title.id_for_label }}">Title</label>
                     {{ form.title }}
                     {% if form.title.errors %}
-                        <p class="forum-error">{{ form.title.errors|first }}</p>
+                    <p class="forum-error">{{ form.title.errors|first }}</p>
                     {% endif %}
                 </div>
                 <div class="forum-form-group">
                     <label for="{{ form.category.id_for_label }}">Category</label>
                     {{ form.category }}
                     {% if form.category.errors %}
-                        <p class="forum-error">{{ form.category.errors|first }}</p>
+                    <p class="forum-error">{{ form.category.errors|first }}</p>
                     {% endif %}
                 </div>
                 <div class="forum-form-group">
                     <label for="{{ form.content.id_for_label }}">Content</label>
                     {{ form.content }}
                     {% if form.content.errors %}
-                        <p class="forum-error">{{ form.content.errors|first }}</p>
+                    <p class="forum-error">{{ form.content.errors|first }}</p>
                     {% endif %}
                 </div>
-                <button type="submit" class="forum-btn-submit">Create Discussion</button>
+                <div class="forum-draft-actions">
+                    <button type="button" id="discard-draft" class="forum-btn-secondary" style="display: none;">
+                        Discard Draft
+                    </button>
+
+                    <button type="submit" class="forum-btn-submit">
+                        Create Discussion
+                    </button>
+                </div>
+
+                <p id="draft-status" class="forum-draft-status" aria-live="polite"></p>
             </form>
         </div>
     </div>
+    <script>
+        document.addEventListener("DOMContentLoaded", function () {
+            const form = document.getElementById("new-discussion-form");
+
+            if (!form) return;
+
+            const title = document.getElementById("{{ form.title.id_for_label }}");
+            const category = document.getElementById("{{ form.category.id_for_label }}");
+            const content = document.getElementById("{{ form.content.id_for_label }}");
+
+            const discardButton = document.getElementById("discard-draft");
+            const draftStatus = document.getElementById("draft-status");
+
+            const DRAFT_KEY = "checkora_new_discussion_draft";
+
+            function saveDraft() {
+                const draft = {
+                    title: title ? title.value : "",
+                    category: category ? category.value : "",
+                    content: content ? content.value : ""
+                };
+
+                const hasContent = Object.values(draft).some(value => value.trim() !== "");
+
+                if (!hasContent) {
+                    return;
+                }
+
+                localStorage.setItem(DRAFT_KEY, JSON.stringify(draft));
+
+                draftStatus.textContent = "Draft saved.";
+                discardButton.style.display = "inline-block";
+            }
+
+            function restoreDraft() {
+                const savedDraft = localStorage.getItem(DRAFT_KEY);
+
+                if (!savedDraft) return;
+
+                try {
+                    const draft = JSON.parse(savedDraft);
+
+                    if (title) title.value = draft.title || "";
+                    if (category) category.value = draft.category || "";
+                    if (content) content.value = draft.content || "";
+
+                    draftStatus.textContent = "Draft restored successfully.";
+                    discardButton.style.display = "inline-block";
+                } catch (error) {
+                    localStorage.removeItem(DRAFT_KEY);
+                }
+            }
+
+            function discardDraft() {
+                localStorage.removeItem(DRAFT_KEY);
+
+                if (title) title.value = "";
+                if (category) category.value = "";
+                if (content) content.value = "";
+
+                draftStatus.textContent = "Draft discarded.";
+                discardButton.style.display = "none";
+            }
+
+            let saveTimeout;
+
+            form.addEventListener("input", function () {
+                clearTimeout(saveTimeout);
+
+                saveTimeout = setTimeout(saveDraft, 1000);
+            });
+
+            discardButton.addEventListener("click", discardDraft);
+
+            form.addEventListener("submit", function () {
+                localStorage.removeItem(DRAFT_KEY);
+            });
+
+            restoreDraft();
+        });
+    </script>
+
     <script src="{% static 'game/js/dropdown.js' %}"></script>
 </body>
+
 </html>


### PR DESCRIPTION
## What does this PR do?

Fixes #2328

This PR implements an Auto-Save Draft feature for the new forum discussion form.

Users can now continue writing their discussion without losing their entered data if they accidentally refresh or leave the page.

### Changes Made

- Automatically saves form data to browser `localStorage` while the user is typing.
- Restores a previously saved draft when the form is reopened.
- Displays a "Draft restored successfully" status message when a draft is restored.
- Provides a "Discard Draft" option so users can manually remove a saved draft.
- Clears the saved draft automatically after successful form submission.
- Uses a unique draft key for the new discussion form.
- Keeps the implementation entirely client-side without requiring backend or database changes.

## How Has This Been Tested?

- [x] Tested the implementation through code inspection.
- [x] Verified `localStorage` draft save and restore logic.
- [x] Verified draft discard and successful-submission cleanup logic.
- [x] Ran `git diff --check` successfully.
- [ ] Tested locally with Django server

### Testing Note

Local Django server testing could not be completed because the current Python environment does not satisfy the project's Django 6 requirement. This is an environment limitation and is unrelated to the changes in this PR.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring / optimization

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected misspellings