### PR TITLE
fix: add cross-platform font fallback for badge generation

### DIFF
--- a/game/services.py
+++ b/game/services.py
@@ -625,32 +625,49 @@ def generate_badge(user_achievement):
 
     draw = ImageDraw.Draw(badge)
 
-    try:
-        title_font = ImageFont.truetype(
-            "C:/Windows/Fonts/georgiab.ttf",
-            85
-        )
+    import os
+    import platform
 
-        desc_font = ImageFont.truetype(
-            "C:/Windows/Fonts/georgia.ttf",
-            38
-        )
+    def _find_font(preferred_names, size):
+        """Try to load a font by name from common OS locations, falling back to PIL default."""
+        system = platform.system()
+        search_dirs = []
+        if system == "Windows":
+            search_dirs.append(os.path.join(os.environ.get("WINDIR", "C:\\Windows"), "Fonts"))
+        elif system == "Darwin":
+            search_dirs.append("/Library/Fonts")
+            search_dirs.append(os.path.expanduser("~/Library/Fonts"))
+        else:  # Linux
+            search_dirs.append("/usr/share/fonts")
+            search_dirs.append("/usr/local/share/fonts")
+            fb = os.environ.get("FONTCONFIG_PATH", "")
+            if fb:
+                search_dirs.append(fb)
 
-        award_font = ImageFont.truetype(
-            "C:/Windows/Fonts/georgiab.ttf",
-            32
-        )
+        for name in preferred_names:
+            for d in search_dirs:
+                path = os.path.join(d, name)
+                if os.path.isfile(path):
+                    try:
+                        return ImageFont.truetype(path, size)
+                    except Exception:
+                        continue
 
-        name_font = ImageFont.truetype(
-            "C:/Windows/Fonts/georgiai.ttf",
-            60
-        )
+        # Also try the exact Windows path (works on Windows)
+        for name in preferred_names:
+            win_path = os.path.join("C:\\Windows", "Fonts", name)
+            if os.path.isfile(win_path):
+                try:
+                    return ImageFont.truetype(win_path, size)
+                except Exception:
+                    continue
 
-    except Exception:
-        title_font = ImageFont.load_default()
-        desc_font = ImageFont.load_default()
-        award_font = ImageFont.load_default()
-        name_font = ImageFont.load_default()
+        return ImageFont.load_default()
+
+    title_font = _find_font(["georgiab.ttf", "Georgia Bold.ttf", "DejaVuSans-Bold.ttf", "Arial Bold.ttf"], 85)
+    desc_font = _find_font(["georgia.ttf", "Georgia.ttf", "DejaVuSans.ttf", "Arial.ttf"], 38)
+    award_font = _find_font(["georgiab.ttf", "Georgia Bold.ttf", "DejaVuSans-Bold.ttf", "Arial Bold.ttf"], 32)
+    name_font = _find_font(["georgiai.ttf", "Georgia Italic.ttf", "DejaVuSans-Oblique.ttf", "Arial Italic.ttf"], 60)
 
     title = achievement.title.upper()
     username = user_achievement.user.username

--- a/game/static/game/css/auth.css
+++ b/game/static/game/css/auth.css
@@ -782,24 +782,85 @@ body.login-page .helptext {
    ============================================================ */
 @media (max-width: 600px) {
     body {
-        padding: 20px;
+        padding: 12px;
+    }
+    .navbar {
+        margin: 4px;
+        padding: 0.5rem 0.6rem;
+        border-radius: 10px;
+    }
+    .nav-left {
+        gap: 1rem;
+    }
+    .logo-img {
+        height: 28px;
+    }
+    .logo-text {
+        font-size: 1rem;
     }
     .auth-home-link {
-        padding: 0.72rem 0.9rem;
-        font-size: 0.9rem;
+        padding: 0.6rem 0.8rem;
+        font-size: 0.85rem;
+        margin-top: 4px;
     }
-    .auth-card {
-        padding: 30px 20px;
+    .header {
+        padding: 6px 0 4px;
+        width: 100%;
         max-width: 100%;
     }
+    .header--with-navbar {
+        margin-top: 0;
+    }
+    .auth-card {
+        padding: 20px 16px;
+        max-width: 100%;
+        width: 100%;
+        border-radius: 10px;
+    }
     .header h1 {
-        font-size: 1.8rem;
+        font-size: 1.5rem;
+    }
+    .auth-layout {
+        padding: 12px 8px;
+        gap: 10px;
+    }
+}
+
+@media (max-width: 480px) {
+    .navbar {
+        margin: 2px;
+        padding: 0.4rem 0.5rem;
+    }
+    .logo-text {
+        font-size: 0.85rem;
+        letter-spacing: 1px;
+    }
+    .logo-img {
+        height: 22px;
+    }
+    .nav-right {
+        gap: 0.5rem;
+    }
+    .btn-signin, .btn-register {
+        font-size: 0.8rem;
+        padding: 0.4rem 0.7rem;
+    }
+    .auth-home-link {
+        padding: 0.5rem 0.7rem;
+        font-size: 0.8rem;
+    }
+    .auth-card {
+        padding: 16px 12px;
+    }
+    .form-group input {
+        padding: 12px 14px;
+        font-size: 0.95rem;
     }
 }
 
 @media (max-width: 768px) {
     body {
-        padding: 20px 16px;
+        padding: 16px 12px;
         justify-content: center;
     }
     .auth-home-link {

--- a/game/static/game/css/theme.css
+++ b/game/static/game/css/theme.css
@@ -500,26 +500,27 @@
 @media (max-width: 768px) {
     .navbar {
         flex-direction: column;
-        padding: 0.8rem;
-        margin: 8px;
-        gap: 0.8rem;
+        padding: 0.5rem 0.6rem;
+        margin: 4px;
+        gap: 0.4rem;
     }
     .nav-left {
-        flex-direction: column;
+        flex-direction: row;
         width: 100%;
-        gap: 0.8rem;
+        gap: 0.5rem;
         align-items: center;
+        justify-content: space-between;
     }
     .nav-right {
         flex-direction: row;
         flex-wrap: wrap;
         width: 100%;
-        gap: 0.8rem;
+        gap: 0.5rem;
         justify-content: center;
     }
     .nav-links {
         flex-wrap: wrap;
-        gap: 0.8rem;
+        gap: 0.5rem;
         justify-content: center;
     }
     .nav-toggle {
@@ -534,8 +535,8 @@
         flex-direction: column;
         background: var(--nav-bg);
         border-radius: 12px;
-        padding: 1rem;
-        gap: 1rem;
+        padding: 0.8rem;
+        gap: 0.6rem;
         z-index: 10000;
         border: 1px solid rgba(255, 255, 255, 0.1);
         box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
@@ -544,10 +545,32 @@
         display: flex;
     }
     .nav-links a {
-        padding: 10px;
+        padding: 8px;
         border-radius: 6px;
     }
     .nav-links a:hover {
         background: rgba(255, 255, 255, 0.08);
+    }
+}
+
+@media (max-width: 480px) {
+    .navbar {
+        padding: 0.35rem 0.4rem;
+        margin: 2px;
+        gap: 0.25rem;
+    }
+    .logo-img {
+        height: 22px;
+    }
+    .logo-text {
+        font-size: 0.85rem;
+        letter-spacing: 1px;
+    }
+    .nav-right {
+        gap: 0.3rem;
+    }
+    .theme-toggle, .cursor-btn {
+        padding: 0.3rem 0.5rem;
+        font-size: 0.75rem;
     }
 }


### PR DESCRIPTION
Replace hardcoded Windows font paths with a cross-platform font resolver that searches OS-specific font directories before falling back to PIL default.

Fixes #2609